### PR TITLE
Localization for the "Profil:" label

### DIFF
--- a/src/components/profil/profilSelect.vue
+++ b/src/components/profil/profilSelect.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="w-64 flex items-center">
-    <label class="mr-2" for="profileDropdown">Profil: </label>
+    <label class="mr-2" for="profileDropdown">{{ $t('components.profile.label') }} </label>
     <select
       id="profileDropdown"
       class="default-inputfield"

--- a/src/locales/cn.json
+++ b/src/locales/cn.json
@@ -481,6 +481,9 @@
         "ra": "RA",
         "title": "Selected object"
       }
+    },
+    "profile": {
+      "label": "配置文件:"
     }
   }
 }

--- a/src/locales/cz.json
+++ b/src/locales/cz.json
@@ -481,6 +481,9 @@
         "ra": "RA",
         "title": "Vybraný objekt"
       }
+    },
+    "profile": {
+      "label": "Profil:"
     }
   }
 }

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -530,6 +530,9 @@
         "landscapes_visible": "Landschaften",
         "meridian_lines_visible": "Meridian"
       }
+    },
+    "profile": {
+      "label": "Profil:"
     }
   }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -511,6 +511,9 @@
         "atmosphere_visible": "Show atmosphere",
         "landscapes_visible": "Show landscapes"
       }
+    },
+    "profile": {
+      "label": "Profile:"
     }
   }
 }

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -481,6 +481,9 @@
         "ra": "REAL ACADEMIA DE BELLAS ARTES",
         "title": "Objeto seleccionado"
       }
+    },
+    "profile": {
+      "label": "Perfil:"
     }
   }
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -481,6 +481,9 @@
         "ra": "Rampe",
         "title": "Objet sélectionné"
       }
+    },
+    "profile": {
+      "label": "Profil:"
     }
   }
 }

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -481,6 +481,9 @@
         "ra": "Ra",
         "title": "Oggetto selezionato"
       }
+    },
+    "profile": {
+      "label": "Profilo:"
     }
   }
 }

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -481,6 +481,9 @@
         "ra": "Ra",
         "title": "Objeto selecionado"
       }
+    },
+    "profile": {
+      "label": "Perfil:"
     }
   }
 }


### PR DESCRIPTION
Small fix to get a feel for the development process.

Testing in the Android emulator:
- English:
![Screenshot_1743488049](https://github.com/user-attachments/assets/b606d34d-7599-4d19-858a-7a8cd5a278e3)
- German:
![Screenshot_1743488097](https://github.com/user-attachments/assets/b7fe862e-e26b-4b5b-b02d-8952c6e25bb5)

Used Gemini 2.5 to translate the label to all the languages available in the app. Cross-checked the correctness with https://translate.google.com/.