### PR TITLE
Avoid duplicate NINA connection entries

### DIFF
--- a/src/store/settingsStore.js
+++ b/src/store/settingsStore.js
@@ -91,15 +91,24 @@ export const useSettingsStore = defineStore('settings', {
     },
 
     addInstance(instance) {
-      const newInstance = {
-        id: Date.now().toString(),
-        name: instance.name || 'Instance',
-        ip: instance.ip,
-        port: instance.port,
-      };
-      this.connection.instances.push(newInstance);
-      this.lastCreatedInstanceId = newInstance.id;
-      this.setSelectedInstanceId(newInstance.id);
+      const existingInstance = this.getInstanceByNameIpPort(
+        instance.name || 'Instance',
+        instance.ip,
+        instance.port
+      );
+      if (existingInstance) {
+        this.setSelectedInstanceId(existingInstance.id);
+      } else {
+        const newInstance = {
+          id: Date.now().toString(),
+          name: instance.name || 'Instance',
+          ip: instance.ip,
+          port: instance.port,
+        };
+        this.connection.instances.push(newInstance);
+        this.lastCreatedInstanceId = newInstance.id;
+        this.setSelectedInstanceId(newInstance.id);
+      }
     },
 
     isLastCreatedInstance(id) {
@@ -133,6 +142,12 @@ export const useSettingsStore = defineStore('settings', {
 
     getInstance(id) {
       return this.connection.instances.find((i) => i.id === id);
+    },
+
+    getInstanceByNameIpPort(name, ip, port) {
+      return this.connection.instances.find(
+        (i) => i.name === name && i.ip === ip && i.port === port
+      );
     },
 
     setSelectedInstanceId(id) {


### PR DESCRIPTION
When setting up Touch-N-Stars for the first time, I initially made several unsuccessful connection attempts to my NINA instance. All of those attempts were saved as duplicate instance entries.

This PR updates `addInstance` to check if an instance with the same input parameters already exists and skips adding new one if so.

Here is an example behavior before the change:


https://github.com/user-attachments/assets/da9cec83-7a1b-4872-9b01-c546aab0c613

and after:


https://github.com/user-attachments/assets/4a540bf2-f6f3-48fd-bca9-776197af63cd

