### PR TITLE
Fix geolocation on the web

### DIFF
--- a/src/utils/location.js
+++ b/src/utils/location.js
@@ -1,0 +1,94 @@
+import { ref } from 'vue';
+import { Geolocation } from '@capacitor/geolocation';
+import apiService from '@/services/apiService';
+import { useSettingsStore } from '@/store/settingsStore';
+import { apiStore } from '@/store/store';
+
+export const latitude = ref('');
+export const longitude = ref('');
+export const altitude = ref('');
+export const gpsError = ref(null);
+
+export async function getCurrentLocation() {
+  try {
+    // Check for location permission
+    if (Capacitor.getPlatform() !== 'web') {
+      const result = await Geolocation.requestPermissions({
+        permissions: ['location'],
+      });
+      if (result.location !== 'granted') {
+        gpsError.value = 'Location permission not granted';
+        return;
+      }
+    }
+    // Get current position with high accuracy
+    const pos = await Geolocation.getCurrentPosition({
+      enableHighAccuracy: true,
+      timeout: 10000,
+      maximumAge: 0,
+    });
+    console.log(pos);
+    latitude.value = pos.coords.latitude.toFixed(6);
+    longitude.value = pos.coords.longitude.toFixed(6);
+    altitude.value = pos.coords.altitude;
+    gpsError.value = null;
+  } catch (error) {
+    gpsError.value = error.message || 'Failed to get GPS location';
+  }
+}
+
+export function useLocationStore() {
+  const settingsStore = useSettingsStore();
+  const store = apiStore();
+
+  function sanitizeCoordinate(input) {
+    if (typeof input === 'string') {
+      const cleaned = input.trim().replace(',', '.');
+      const parsed = parseFloat(cleaned);
+      return isNaN(parsed) ? null : parsed;
+    } else if (typeof input === 'number') {
+      return input;
+    }
+    return null;
+  }
+
+  return {
+    async loadFromAstrometrySettings() {
+      const settings = store.profileInfo?.AstrometrySettings;
+      if (!settings) {
+        return;
+      }
+      latitude.value = settings.Latitude ?? '';
+      longitude.value = settings.Longitude ?? '';
+      altitude.value = settings.Elevation ?? '';
+    },
+
+    async saveCoordinates() {
+      try {
+        settingsStore.setCoordinates({
+          latitude: (latitude.value = sanitizeCoordinate(latitude.value)),
+          longitude: (longitude.value = sanitizeCoordinate(longitude.value)),
+          altitude: (altitude.value = sanitizeCoordinate(altitude.value)),
+        });
+
+        if (store.isBackendReachable) {
+          await apiService.profileChangeValue('AstrometrySettings-Latitude', latitude.value);
+          await apiService.profileChangeValue('AstrometrySettings-Longitude', longitude.value);
+          await apiService.profileChangeValue('AstrometrySettings-Elevation', altitude.value);
+          await apiService.profileChangeValue(
+            'TelescopeSettings-TelescopeLocationSyncDirection',
+            2
+          );
+
+          if (store.mountInfo.Connected) {
+            await apiService.mountAction('disconnect');
+            await apiService.mountAction('connect');
+          }
+          console.log('Coordinates saved');
+        }
+      } catch (error) {
+        console.error('Failed to update backend coordinates:', error);
+      }
+    },
+  };
+}

--- a/src/views/SetupPage.vue
+++ b/src/views/SetupPage.vue
@@ -175,7 +175,6 @@
               </div>
             </div>
             <button
-              v-if="['android', 'ios'].includes(Capacitor.getPlatform())"
               @click="getCurrentLocation"
               class="w-full bg-gray-600 hover:bg-gray-500 text-white py-2 px-4 rounded-md"
             >
@@ -220,7 +219,7 @@ import { useI18n } from 'vue-i18n';
 import { getAvailableLanguages } from '@/i18n';
 import { useRouter } from 'vue-router';
 import { useSettingsStore } from '@/store/settingsStore';
-import { Geolocation } from '@capacitor/geolocation';
+import { latitude, longitude, altitude, gpsError, getCurrentLocation, useLocationStore } from '@/utils/location';
 import { Capacitor } from '@capacitor/core';
 import { apiStore } from '@/store/store';
 import apiService from '@/services/apiService';
@@ -235,10 +234,7 @@ const currentStep = ref(1);
 const totalSteps = ref(5);
 const isVisible = ref(true);
 const selectedLanguage = ref(locale.value);
-const latitude = ref('');
-const longitude = ref('');
-const altitude = ref('');
-const gpsError = ref(null);
+const locationStore = useLocationStore();
 const instanceData = ref({
   name: '',
   ip: '',
@@ -266,9 +262,7 @@ async function nextStep() {
   if (currentStep.value === 5) {
     store.startFetchingInfo();
     await wait(1000);
-    latitude.value = store.profileInfo.AstrometrySettings.Latitude;
-    longitude.value = store.profileInfo.AstrometrySettings.Longitude;
-    altitude.value = store.profileInfo.AstrometrySettings.Elevation;
+    await locationStore.loadFromAstrometrySettings();
   }
 }
 
@@ -286,52 +280,11 @@ function saveLanguage() {
   nextStep();
 }
 
-async function getCurrentLocation() {
-  try {
-    // Check for location permission
-    const status = await Geolocation.checkPermissions();
-    if (status.location !== 'granted') {
-      const result = await Geolocation.requestPermissions();
-      if (result.location !== 'granted') {
-        gpsError.value = 'Location permission not granted';
-        return;
-      }
-    }
-    // Get current position with high accuracy
-    const pos = await Geolocation.getCurrentPosition({
-      enableHighAccuracy: true,
-      timeout: 10000,
-      maximumAge: 0,
-    });
-    latitude.value = pos.coords.latitude.toFixed(6);
-    longitude.value = pos.coords.longitude.toFixed(6);
-    altitude.value = pos.coords.altitude;
-    gpsError.value = null;
-  } catch (error) {
-    gpsError.value = error.message || 'Failed to get GPS location';
-  }
-}
-
 async function saveGPS() {
-  const lat = sanitizeCoordinate(latitude.value);
-  const lon = sanitizeCoordinate(longitude.value);
-  const alt = sanitizeCoordinate(altitude.value);
-
-  latitude.value = lat;
-  longitude.value = lon;
-  altitude.value = alt;
-
-  settingsStore.setCoordinates({
-    latitude: lat,
-    longitude: lon,
-    altitude: alt,
-  });
-
-  console.log('Coordinates saved', lat, lon, alt);
-
-  await saveCoordinates();
+  await locationStore.saveCoordinates();
   nextStep();
 }
+
 async function saveInstance() {
   // Validate instance connection details
   if (!instanceData.value.name.trim()) {
@@ -372,9 +325,7 @@ async function saveInstance() {
     console.log('Backend reachable');
     store.startFetchingInfo();
     await wait(1500);
-    latitude.value = store.profileInfo.AstrometrySettings.Latitude;
-    longitude.value = store.profileInfo.AstrometrySettings.Longitude;
-    altitude.value = store.profileInfo.AstrometrySettings.Elevation;
+    await locationStore.loadFromAstrometrySettings();
     nextStep();
   } catch (error) {
     console.warn('Incomplete astrometry data');
@@ -387,41 +338,6 @@ function completeSetup() {
   settingsStore.completeSetup();
   localStorage.setItem('setupCompleted', 'true');
   router.push('/');
-}
-
-async function saveCoordinates() {
-  if (store.isBackendReachable) {
-    try {
-      await apiService.profileChangeValue('AstrometrySettings-Latitude', latitude.value);
-      await apiService.profileChangeValue('AstrometrySettings-Longitude', longitude.value);
-      await apiService.profileChangeValue('AstrometrySettings-Elevation', altitude.value);
-      await apiService.profileChangeValue('TelescopeSettings-TelescopeLocationSyncDirection', 2);
-
-      if (store.mountInfo.Connected) {
-        await apiService.mountAction('disconnect');
-        await apiService.mountAction('connect');
-      }
-      settingsStore.setCoordinates({
-        latitude: latitude.value,
-        longitude: longitude.value,
-        altitude: altitude.value,
-      });
-      console.log('Coordinates saved');
-    } catch (error) {
-      console.error('Failed to update backend coordinates:', error);
-    }
-  }
-}
-
-function sanitizeCoordinate(input) {
-  if (typeof input === 'string') {
-    const cleaned = input.trim().replace(',', '.');
-    const parsed = parseFloat(cleaned);
-    return isNaN(parsed) ? null : parsed;
-  } else if (typeof input === 'number') {
-    return input;
-  }
-  return null;
 }
 </script>
 


### PR DESCRIPTION
I noticed that clicking "get geolocation" in the web app settings results in "not implemented" error, and on the setup page it's hidden altogether (presumably due to the same error in the past) and thought it might be fun to dig in.

Looks like this is because requestPermissions is not supported on the web in Capacitor, so as long as we skip it on this platform, everything else works fine.

In the process I noticed a lot of duplicated code for geolocation between setup and settings pages (which makes sense, the logic is pretty much the same) so I extracted it out into the utils.