### PR TITLE
Fix info overlay about offline catalog in slew tab

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "touch-n-stars",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "touch-n-stars",
-      "version": "3.6.0",
+      "version": "3.6.1",
       "dependencies": {
         "@capacitor-community/keep-awake": "^7.1.0",
         "@capacitor-community/media": "^8.0.1",

--- a/src/App.vue
+++ b/src/App.vue
@@ -122,7 +122,7 @@
     <!-- ManuellFilterModal Modal -->
     <ManuellFilterModal v-if="store.filterInfo.DeviceId === 'Networked Filter Wheel'" />
     <!-- Debug Console -->
-    <ConsoleViewer class="fixed top-32 right-6 z-[60]" v-if="settingsStore.showDebugConsole" />
+    <ConsoleViewer class="fixed top-32 right-6 z-60" v-if="settingsStore.showDebugConsole" />
     <!-- LocationSyncModal -->
     <LocationSyncModal />
 
@@ -153,7 +153,7 @@
     <!-- Settings Modal -->
     <div
       v-if="showSettingsModal"
-      class="fixed inset-0 z-[100] flex items-center justify-center bg-black bg-opacity-50"
+      class="fixed inset-0 z-top flex items-center justify-center bg-black bg-opacity-50"
     >
       <div
         class="bg-gray-900 rounded-lg w-full h-full sm:w-auto sm:h-auto sm:max-w-4xl sm:max-h-[90vh] overflow-y-auto mx-0 sm:mx-4 scrollbar-hide"

--- a/src/components/WeatherModal.vue
+++ b/src/components/WeatherModal.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="fixed inset-0 z-[1000] flex items-center justify-center bg-black/50 backdrop-blur-sm transition-opacity duration-300"
+    class="fixed inset-0 z-top flex items-center justify-center bg-black/50 backdrop-blur-sm transition-opacity duration-300"
     @click.self="handleOutsideClick"
   >
     <div

--- a/src/components/framing/TargetPic.vue
+++ b/src/components/framing/TargetPic.vue
@@ -16,7 +16,7 @@
   <!-- Modal -->
   <div
     v-if="showModal"
-    class="fixed inset-0 bg-gray-900 bg-opacity-50 flex items-center justify-center"
+    class="fixed inset-0 bg-gray-900 bg-opacity-50 flex items-center justify-center z-top"
     @click.self="showModal = false"
   >
     <!-- Modal Box -->

--- a/src/components/helpers/ToastModal.vue
+++ b/src/components/helpers/ToastModal.vue
@@ -3,7 +3,7 @@
   <transition name="fade">
     <div
       v-if="toastStore.newMessage && (toastStore.isConfirmation || toastStore.type === 'critical')"
-      class="fixed inset-0 bg-black bg-opacity-50 z-[9999] flex items-center justify-center"
+      class="fixed inset-0 bg-black bg-opacity-50 z-top flex items-center justify-center"
     >
       <div
         :class="[
@@ -49,7 +49,7 @@
   </transition>
 
   <!-- Non-blocking Toast Notifications -->
-  <div class="fixed top-4 right-4 z-[9999] space-y-3 max-w-sm pointer-events-none">
+  <div class="fixed top-4 right-4 z-toast space-y-3 max-w-sm pointer-events-none">
     <transition-group name="toast-slide">
       <div
         v-if="toastStore.newMessage && !toastStore.isConfirmation && toastStore.type !== 'critical'"

--- a/src/components/helpers/imageModal.vue
+++ b/src/components/helpers/imageModal.vue
@@ -22,7 +22,7 @@
       </button>
       <!-- Zoom Overlay -->
       <div
-        class="absolute top-4 left-4 shadow-lg shadow-black bg-gray-800 text-white text-sm px-3 py-1 rounded-lg z-[100] pointer-events-none"
+        class="absolute top-4 left-4 shadow-lg shadow-black bg-gray-800 text-white text-sm px-3 py-1 rounded-lg z-top pointer-events-none"
       >
         Zoom: {{ zoomLevel.toFixed(2) }}x
       </div>
@@ -30,13 +30,13 @@
       <button
         v-if="imageData"
         @click="downloadImage"
-        class="absolute top-4 right-20 rounded-lg bg-gray-800 text-white text-sm px-3 py-1 shadow-lg shadow-black hover:bg-gray-700 transition z-[100]"
+        class="absolute top-4 right-20 rounded-lg bg-gray-800 text-white text-sm px-3 py-1 shadow-lg shadow-black hover:bg-gray-700 transition z-top"
       >
         <ArrowDownTrayIcon class="h-6" />
       </button>
       <BadButton
         v-if="settingsStore.showSpecial"
-        class="absolute top-4 right-40 h-6 z-[100]"
+        class="absolute top-4 right-40 h-6 z-top"
         :index="index"
       />
 

--- a/src/components/mount/ButtonSlewCenterRotate.vue
+++ b/src/components/mount/ButtonSlewCenterRotate.vue
@@ -68,7 +68,7 @@
   </div>
 
   <!-- Settings Modal -->
-  <Modal :show="showSettingsModal" @close="showSettingsModal = false" :zIndex="'z-[60]'">
+  <Modal :show="showSettingsModal" @close="showSettingsModal = false" :zIndex="'z-60'">
     <template #header>
       <h2 class="text-xl font-bold">{{ $t('components.settings.title') }}</h2>
     </template>

--- a/src/components/status/AboutModal.vue
+++ b/src/components/status/AboutModal.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="fixed inset-0 z-[1000] flex items-center justify-center bg-black/50 backdrop-blur-sm transition-opacity duration-300"
+    class="fixed inset-0 z-top flex items-center justify-center bg-black/50 backdrop-blur-sm transition-opacity duration-300"
     @click.self="handleOutsideClick"
   >
     <div

--- a/src/components/status/LogModal.vue
+++ b/src/components/status/LogModal.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="fixed inset-0 z-[1000] flex items-center justify-center bg-black/50 backdrop-blur-sm transition-opacity duration-300"
+    class="fixed inset-0 z-top flex items-center justify-center bg-black/50 backdrop-blur-sm transition-opacity duration-300"
     @click.self="handleOutsideClick"
   >
     <div

--- a/src/views/CameraPage.vue
+++ b/src/views/CameraPage.vue
@@ -71,7 +71,7 @@
         </div>
 
         <!-- Capture Button Overlay -->
-        <div class="absolute inset-0 pointer-events-none z-[55]">
+        <div class="absolute inset-0 pointer-events-none z-60">
           <div class="pointer-events-auto">
             <CaptureButton />
           </div>

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -7,6 +7,12 @@ module.exports = {
       screens: {
         xs: '480px', // Fügt eine "xs"-Breakpoint für 480px hinzu
       },
+      zIndex: {
+        60: '60',  
+        70: '70', 
+        top: '1000', // topmost layer
+        toast: '9999', // toast notifications
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
Minor glitch in z-index on an info overlay. I've used this PR to remove all the z-[x]  and replace by semantical values defined on tailwindcss configuration.

| Before | After |
| ---- | ---- |
| <img width="959" height="616" alt="Screenshot 2025-11-09 091527" src="https://github.com/user-attachments/assets/edd83361-6423-401f-963a-d6d64d631fe5" /> | <img width="959" height="616" alt="Screenshot 2025-11-09 091559" src="https://github.com/user-attachments/assets/0ed7f56f-accf-4f83-a82d-5fc83963869c" /> |