### PR TITLE
Feat/pins allsky frontend sync develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,11 +29,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Plate Solve: Use the NINA-style toolbar icon in the shared image viewer
+- PINS AllSky: Add AllSky auto-exposure tuning controls, timelapse overlay toggles for timestamp and exposure/gain, and show the active session label plus actual auto exposure/gain/mean values in live preview
 
 ### Fixed
 - Total Exposuer time: filter total exposure time by LIGHT image type
 - Stellarium time fix
 - PINS: Manual Rotator dialog button
+- PINS AllSky: Live preview now shows the active session label instead of only the generated session ID
 - Fix crash when NINA plugin version is not yet loaded (checkVersionNewerOrEqual)
 - Fix app not reconnecting after backend restart: removed blocking `await` on SignalR connect in polling loop, added socket-ID guard to prevent stale WebSocket events from corrupting connection state, and fixed async race condition in `disconnect()` across all SignalR services
 - Debug console: fix SignalR "WebSocket is not in the OPEN state" error caused by WebSocket proxy losing static constants (`OPEN`, `CONNECTING`, etc.)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Stellarium time fix
 - PINS: Manual Rotator dialog button
 - PINS AllSky: Live preview now shows the active session label instead of only the generated session ID
+- PINS AllSky: Show in-flight state for capture and cleanup actions, and use attachment downloads with session-based filenames for timelapse, keogram, and startrails
 - Fix crash when NINA plugin version is not yet loaded (checkVersionNewerOrEqual)
 - Fix app not reconnecting after backend restart: removed blocking `await` on SignalR connect in polling loop, added socket-ID guard to prevent stale WebSocket events from corrupting connection state, and fixed async race condition in `disconnect()` across all SignalR services
 - Debug console: fix SignalR "WebSocket is not in the OPEN state" error caused by WebSocket proxy losing static constants (`OPEN`, `CONNECTING`, etc.)

--- a/src/locales/cn.json
+++ b/src/locales/cn.json
@@ -3096,8 +3096,8 @@
           "stampTimestamp": "Stamp capture timestamp",
           "overlayExposureGain": "Overlay Exposure + Gain",
           "stampExposureGain": "Stamp exposure and gain",
-          "overlayTimestampTooltip": "Render the captured timestamp into each timelapse frame.",
-          "overlayExposureGainTooltip": "Render the actual exposure and gain used for each captured frame into the timelapse."
+          "overlayTimestampTooltip": "Render the captured timestamp into each timelapse frame. This applies on the next timelapse render or when you regenerate an existing session.",
+          "overlayExposureGainTooltip": "Render the actual exposure and gain used for each captured frame into the timelapse. This applies on the next timelapse render or when you regenerate an existing session."
         }
       },
       "recentSessions": {

--- a/src/locales/cn.json
+++ b/src/locales/cn.json
@@ -2895,7 +2895,8 @@
         "frameCount": "帧数：",
         "captureInterval": "捕捉间隔：",
         "exposure": "接触：",
-        "gain": "获得："
+        "gain": "获得：",
+        "mean": "Mean:"
       },
       "statusRows": {
         "backend": "后端",
@@ -2986,10 +2987,10 @@
           "sharpness": "清晰度",
           "manualExposure": "手动曝光",
           "shutterMicroseconds": "快门（微秒）",
-          "manualExposureHelp": "禁用时，rpicam-still 自动控制曝光。",
+          "manualExposureHelp": "When disabled, PINS AllSky uses the AllSky mean-based controller. If Target Mean is 0, rpicam-still exposure stays automatic instead.",
           "manualGain": "手动增益",
           "analogGain": "模拟增益",
-          "manualGainHelp": "禁用时，rpicam-still 自动控制增益。",
+          "manualGainHelp": "When disabled, PINS AllSky uses the AllSky mean-based controller. If Target Mean is 0, rpicam-still gain stays automatic instead.",
           "horizontalFlip": "水平翻转",
           "mirrorOnXAxis": "X 轴上的镜像",
           "verticalFlip": "垂直翻转",
@@ -3029,7 +3030,23 @@
             "cdnOff": "CDN 关闭",
             "cdnFast": "CDN 快速",
             "cdnHq": "CDN 高质量"
-          }
+          },
+          "allSkyAutoExposure": "AllSky auto exposure / gain",
+          "allSkyAutoExposureHelp": "Adapted from AllSky's mean-based controller. When manual exposure and/or manual gain are disabled, PINS AllSky measures the previous frame and calculates the next shutter and gain instead of relying on rpicam-still auto exposure alone.",
+          "autoMeanTarget": "Target Mean",
+          "autoMeanThreshold": "Mean Threshold",
+          "autoMaxExposureMicroseconds": "Auto Max Shutter (µs)",
+          "autoMaxGain": "Auto Max Gain",
+          "autoMeanP0": "Aggression P0",
+          "autoMeanP1": "Aggression P1",
+          "autoMeanP2": "Aggression P2",
+          "autoMeanTargetTooltip": "Target normalized image mean used by the AllSky auto-exposure controller. Set to 0 to fall back to rpicam-still auto exposure.",
+          "autoMeanThresholdTooltip": "Allowed normalized distance from the target mean before the next frame's exposure level is changed.",
+          "autoMaxExposureTooltip": "Maximum shutter time the AllSky auto-exposure controller may use when manual exposure is disabled.",
+          "autoMaxGainTooltip": "Maximum analog gain the AllSky auto-exposure controller may use when manual gain is disabled.",
+          "autoMeanP0Tooltip": "AllSky controller tuning constant p0. Higher values react more aggressively to brightness changes.",
+          "autoMeanP1Tooltip": "AllSky controller tuning constant p1 used for linear response to mean error.",
+          "autoMeanP2Tooltip": "AllSky controller tuning constant p2 used for stronger quadratic response to large brightness errors."
         },
         "outputs": {
           "keepSourceFrames": "保留源帧",
@@ -3074,7 +3091,13 @@
           "lineThicknessTooltip": "Keogram 工具绘制标签或标记时使用的线条粗细。",
           "extraKeogramArgumentsTooltip": "AllSky keogram 工具附加了额外的命令行参数。",
           "brightnessThresholdTooltip": "像素在对 startrails 合成做出贡献之前必须达到的最小标准化亮度。",
-          "extraStartrailsArgumentsTooltip": "AllSky startrails 工具附加了额外的命令行参数。"
+          "extraStartrailsArgumentsTooltip": "AllSky startrails 工具附加了额外的命令行参数。",
+          "overlayTimestamp": "Overlay Timestamp",
+          "stampTimestamp": "Stamp capture timestamp",
+          "overlayExposureGain": "Overlay Exposure + Gain",
+          "stampExposureGain": "Stamp exposure and gain",
+          "overlayTimestampTooltip": "Render the captured timestamp into each timelapse frame.",
+          "overlayExposureGainTooltip": "Render the actual exposure and gain used for each captured frame into the timelapse."
         }
       },
       "recentSessions": {

--- a/src/locales/cz.json
+++ b/src/locales/cz.json
@@ -2895,7 +2895,8 @@
         "frameCount": "Počet snímků:",
         "captureInterval": "Interval snímání:",
         "exposure": "Vystavení:",
-        "gain": "Získat:"
+        "gain": "Získat:",
+        "mean": "Mean:"
       },
       "statusRows": {
         "backend": "Backend",
@@ -2986,10 +2987,10 @@
           "sharpness": "Ostrost",
           "manualExposure": "Manuální expozice",
           "shutterMicroseconds": "Závěrka (µs)",
-          "manualExposureHelp": "Je-li zakázáno, rpicam-stále řídí expozici automaticky.",
+          "manualExposureHelp": "When disabled, PINS AllSky uses the AllSky mean-based controller. If Target Mean is 0, rpicam-still exposure stays automatic instead.",
           "manualGain": "Manuální zisk",
           "analogGain": "Analogový zisk",
-          "manualGainHelp": "Je-li zakázáno, rpicam-still automaticky řídí zesílení.",
+          "manualGainHelp": "When disabled, PINS AllSky uses the AllSky mean-based controller. If Target Mean is 0, rpicam-still gain stays automatic instead.",
           "horizontalFlip": "Horizontální překlopení",
           "mirrorOnXAxis": "Zrcadlo na ose X",
           "verticalFlip": "Vertikální překlopení",
@@ -3029,7 +3030,23 @@
             "cdnOff": "CDN vypnuto",
             "cdnFast": "CDN Rychlé",
             "cdnHq": "Vysoká kvalita CDN"
-          }
+          },
+          "allSkyAutoExposure": "AllSky auto exposure / gain",
+          "allSkyAutoExposureHelp": "Adapted from AllSky's mean-based controller. When manual exposure and/or manual gain are disabled, PINS AllSky measures the previous frame and calculates the next shutter and gain instead of relying on rpicam-still auto exposure alone.",
+          "autoMeanTarget": "Target Mean",
+          "autoMeanThreshold": "Mean Threshold",
+          "autoMaxExposureMicroseconds": "Auto Max Shutter (µs)",
+          "autoMaxGain": "Auto Max Gain",
+          "autoMeanP0": "Aggression P0",
+          "autoMeanP1": "Aggression P1",
+          "autoMeanP2": "Aggression P2",
+          "autoMeanTargetTooltip": "Target normalized image mean used by the AllSky auto-exposure controller. Set to 0 to fall back to rpicam-still auto exposure.",
+          "autoMeanThresholdTooltip": "Allowed normalized distance from the target mean before the next frame's exposure level is changed.",
+          "autoMaxExposureTooltip": "Maximum shutter time the AllSky auto-exposure controller may use when manual exposure is disabled.",
+          "autoMaxGainTooltip": "Maximum analog gain the AllSky auto-exposure controller may use when manual gain is disabled.",
+          "autoMeanP0Tooltip": "AllSky controller tuning constant p0. Higher values react more aggressively to brightness changes.",
+          "autoMeanP1Tooltip": "AllSky controller tuning constant p1 used for linear response to mean error.",
+          "autoMeanP2Tooltip": "AllSky controller tuning constant p2 used for stronger quadratic response to large brightness errors."
         },
         "outputs": {
           "keepSourceFrames": "Zachovejte zdrojové snímky",
@@ -3074,7 +3091,13 @@
           "lineThicknessTooltip": "Tloušťka čáry se používá, když nástroj keogram kreslí štítky nebo značky.",
           "extraKeogramArgumentsTooltip": "Další argumenty příkazového řádku připojené k nástroji keogram AllSky.",
           "brightnessThresholdTooltip": "Minimální normalizovaný jas, kterého musí pixel dosáhnout, než přispěje ke složení startrails.",
-          "extraStartrailsArgumentsTooltip": "Další argumenty příkazového řádku připojené k nástroji AllSky startrails."
+          "extraStartrailsArgumentsTooltip": "Další argumenty příkazového řádku připojené k nástroji AllSky startrails.",
+          "overlayTimestamp": "Overlay Timestamp",
+          "stampTimestamp": "Stamp capture timestamp",
+          "overlayExposureGain": "Overlay Exposure + Gain",
+          "stampExposureGain": "Stamp exposure and gain",
+          "overlayTimestampTooltip": "Render the captured timestamp into each timelapse frame.",
+          "overlayExposureGainTooltip": "Render the actual exposure and gain used for each captured frame into the timelapse."
         }
       },
       "recentSessions": {

--- a/src/locales/cz.json
+++ b/src/locales/cz.json
@@ -3096,8 +3096,8 @@
           "stampTimestamp": "Stamp capture timestamp",
           "overlayExposureGain": "Overlay Exposure + Gain",
           "stampExposureGain": "Stamp exposure and gain",
-          "overlayTimestampTooltip": "Render the captured timestamp into each timelapse frame.",
-          "overlayExposureGainTooltip": "Render the actual exposure and gain used for each captured frame into the timelapse."
+          "overlayTimestampTooltip": "Render the captured timestamp into each timelapse frame. This applies on the next timelapse render or when you regenerate an existing session.",
+          "overlayExposureGainTooltip": "Render the actual exposure and gain used for each captured frame into the timelapse. This applies on the next timelapse render or when you regenerate an existing session."
         }
       },
       "recentSessions": {

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -1914,7 +1914,12 @@
         "title": "Snapshot-URL Hilfe",
         "what": "Eine Snapshot-URL ist ein direkter Link zu einem einzelnen Bild deiner IP-Kamera. Die URL muss direkt ein JPEG- oder PNG-Bild zurückliefern — keine HTML-Seite und keinen Videostream.",
         "examplesTitle": "Beispiele",
-        "exampleLabels": ["Generische IP-Kamera", "ONVIF-Kamera", "Axis-Kamera", "Hikvision-Kamera"],
+        "exampleLabels": [
+          "Generische IP-Kamera",
+          "ONVIF-Kamera",
+          "Axis-Kamera",
+          "Hikvision-Kamera"
+        ],
         "credentialsTitle": "Passwortgeschützte Kameras",
         "credentials": "Wenn deine Kamera Benutzername und Passwort benötigt, füge die Zugangsdaten direkt in die URL ein:",
         "credentialsNote": "Der Backend-Proxy übernimmt die Authentifizierung automatisch — Zugangsdaten in der URL funktionieren sowohl mit Basic- als auch Digest-Authentifizierung (z.B. Hikvision).",
@@ -2938,7 +2943,8 @@
         "frameCount": "Frame Count:",
         "captureInterval": "Capture Interval:",
         "exposure": "Exposure:",
-        "gain": "Gain:"
+        "gain": "Gain:",
+        "mean": "Mean:"
       },
       "statusRows": {
         "backend": "Backend",
@@ -3029,10 +3035,10 @@
           "sharpness": "Sharpness",
           "manualExposure": "Manual exposure",
           "shutterMicroseconds": "Shutter (µs)",
-          "manualExposureHelp": "When disabled, rpicam-still controls exposure automatically.",
+          "manualExposureHelp": "When disabled, PINS AllSky uses the AllSky mean-based controller. If Target Mean is 0, rpicam-still exposure stays automatic instead.",
           "manualGain": "Manual gain",
           "analogGain": "Analog Gain",
-          "manualGainHelp": "When disabled, rpicam-still controls gain automatically.",
+          "manualGainHelp": "When disabled, PINS AllSky uses the AllSky mean-based controller. If Target Mean is 0, rpicam-still gain stays automatic instead.",
           "horizontalFlip": "Horizontal flip",
           "mirrorOnXAxis": "Mirror on X axis",
           "verticalFlip": "Vertical flip",
@@ -3072,7 +3078,23 @@
             "cdnOff": "CDN Off",
             "cdnFast": "CDN Fast",
             "cdnHq": "CDN High Quality"
-          }
+          },
+          "allSkyAutoExposure": "AllSky auto exposure / gain",
+          "allSkyAutoExposureHelp": "Adapted from AllSky's mean-based controller. When manual exposure and/or manual gain are disabled, PINS AllSky measures the previous frame and calculates the next shutter and gain instead of relying on rpicam-still auto exposure alone.",
+          "autoMeanTarget": "Target Mean",
+          "autoMeanThreshold": "Mean Threshold",
+          "autoMaxExposureMicroseconds": "Auto Max Shutter (µs)",
+          "autoMaxGain": "Auto Max Gain",
+          "autoMeanP0": "Aggression P0",
+          "autoMeanP1": "Aggression P1",
+          "autoMeanP2": "Aggression P2",
+          "autoMeanTargetTooltip": "Target normalized image mean used by the AllSky auto-exposure controller. Set to 0 to fall back to rpicam-still auto exposure.",
+          "autoMeanThresholdTooltip": "Allowed normalized distance from the target mean before the next frame's exposure level is changed.",
+          "autoMaxExposureTooltip": "Maximum shutter time the AllSky auto-exposure controller may use when manual exposure is disabled.",
+          "autoMaxGainTooltip": "Maximum analog gain the AllSky auto-exposure controller may use when manual gain is disabled.",
+          "autoMeanP0Tooltip": "AllSky controller tuning constant p0. Higher values react more aggressively to brightness changes.",
+          "autoMeanP1Tooltip": "AllSky controller tuning constant p1 used for linear response to mean error.",
+          "autoMeanP2Tooltip": "AllSky controller tuning constant p2 used for stronger quadratic response to large brightness errors."
         },
         "outputs": {
           "keepSourceFrames": "Keep source frames",
@@ -3117,7 +3139,13 @@
           "lineThicknessTooltip": "Line thickness used when the keogram tool draws labels or markers.",
           "extraKeogramArgumentsTooltip": "Extra command-line arguments appended to the AllSky keogram tool.",
           "brightnessThresholdTooltip": "Minimum normalized brightness a pixel must reach before it contributes to the startrails composite.",
-          "extraStartrailsArgumentsTooltip": "Extra command-line arguments appended to the AllSky startrails tool."
+          "extraStartrailsArgumentsTooltip": "Extra command-line arguments appended to the AllSky startrails tool.",
+          "overlayTimestamp": "Overlay Timestamp",
+          "stampTimestamp": "Stamp capture timestamp",
+          "overlayExposureGain": "Overlay Exposure + Gain",
+          "stampExposureGain": "Stamp exposure and gain",
+          "overlayTimestampTooltip": "Render the captured timestamp into each timelapse frame.",
+          "overlayExposureGainTooltip": "Render the actual exposure and gain used for each captured frame into the timelapse."
         }
       },
       "recentSessions": {

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -3144,8 +3144,8 @@
           "stampTimestamp": "Stamp capture timestamp",
           "overlayExposureGain": "Overlay Exposure + Gain",
           "stampExposureGain": "Stamp exposure and gain",
-          "overlayTimestampTooltip": "Render the captured timestamp into each timelapse frame.",
-          "overlayExposureGainTooltip": "Render the actual exposure and gain used for each captured frame into the timelapse."
+          "overlayTimestampTooltip": "Render the captured timestamp into each timelapse frame. This applies on the next timelapse render or when you regenerate an existing session.",
+          "overlayExposureGainTooltip": "Render the actual exposure and gain used for each captured frame into the timelapse. This applies on the next timelapse render or when you regenerate an existing session."
         }
       },
       "recentSessions": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1914,7 +1914,12 @@
         "title": "Snapshot URL Help",
         "what": "A snapshot URL is a direct link to a single image from your IP camera. The URL must return a JPEG or PNG image directly — not an HTML page or a video stream.",
         "examplesTitle": "Examples",
-        "exampleLabels": ["Generic IP camera", "ONVIF camera", "Axis camera", "Hikvision camera"],
+        "exampleLabels": [
+          "Generic IP camera",
+          "ONVIF camera",
+          "Axis camera",
+          "Hikvision camera"
+        ],
         "credentialsTitle": "Password-protected cameras",
         "credentials": "If your camera requires a username and password, include the credentials directly in the URL:",
         "credentialsNote": "The backend proxy handles authentication automatically — credentials in the URL work with both Basic and Digest authentication (e.g. Hikvision).",
@@ -2938,7 +2943,8 @@
         "frameCount": "Frame Count:",
         "captureInterval": "Capture Interval:",
         "exposure": "Exposure:",
-        "gain": "Gain:"
+        "gain": "Gain:",
+        "mean": "Mean:"
       },
       "statusRows": {
         "backend": "Backend",
@@ -3029,10 +3035,10 @@
           "sharpness": "Sharpness",
           "manualExposure": "Manual exposure",
           "shutterMicroseconds": "Shutter (µs)",
-          "manualExposureHelp": "When disabled, rpicam-still controls exposure automatically.",
+          "manualExposureHelp": "When disabled, PINS AllSky uses the AllSky mean-based controller. If Target Mean is 0, rpicam-still exposure stays automatic instead.",
           "manualGain": "Manual gain",
           "analogGain": "Analog Gain",
-          "manualGainHelp": "When disabled, rpicam-still controls gain automatically.",
+          "manualGainHelp": "When disabled, PINS AllSky uses the AllSky mean-based controller. If Target Mean is 0, rpicam-still gain stays automatic instead.",
           "horizontalFlip": "Horizontal flip",
           "mirrorOnXAxis": "Mirror on X axis",
           "verticalFlip": "Vertical flip",
@@ -3072,7 +3078,23 @@
             "cdnOff": "CDN Off",
             "cdnFast": "CDN Fast",
             "cdnHq": "CDN High Quality"
-          }
+          },
+          "allSkyAutoExposure": "AllSky auto exposure / gain",
+          "allSkyAutoExposureHelp": "Adapted from AllSky's mean-based controller. When manual exposure and/or manual gain are disabled, PINS AllSky measures the previous frame and calculates the next shutter and gain instead of relying on rpicam-still auto exposure alone.",
+          "autoMeanTarget": "Target Mean",
+          "autoMeanThreshold": "Mean Threshold",
+          "autoMaxExposureMicroseconds": "Auto Max Shutter (µs)",
+          "autoMaxGain": "Auto Max Gain",
+          "autoMeanP0": "Aggression P0",
+          "autoMeanP1": "Aggression P1",
+          "autoMeanP2": "Aggression P2",
+          "autoMeanTargetTooltip": "Target normalized image mean used by the AllSky auto-exposure controller. Set to 0 to fall back to rpicam-still auto exposure.",
+          "autoMeanThresholdTooltip": "Allowed normalized distance from the target mean before the next frame's exposure level is changed.",
+          "autoMaxExposureTooltip": "Maximum shutter time the AllSky auto-exposure controller may use when manual exposure is disabled.",
+          "autoMaxGainTooltip": "Maximum analog gain the AllSky auto-exposure controller may use when manual gain is disabled.",
+          "autoMeanP0Tooltip": "AllSky controller tuning constant p0. Higher values react more aggressively to brightness changes.",
+          "autoMeanP1Tooltip": "AllSky controller tuning constant p1 used for linear response to mean error.",
+          "autoMeanP2Tooltip": "AllSky controller tuning constant p2 used for stronger quadratic response to large brightness errors."
         },
         "outputs": {
           "keepSourceFrames": "Keep source frames",
@@ -3117,7 +3139,13 @@
           "lineThicknessTooltip": "Line thickness used when the keogram tool draws labels or markers.",
           "extraKeogramArgumentsTooltip": "Extra command-line arguments appended to the AllSky keogram tool.",
           "brightnessThresholdTooltip": "Minimum normalized brightness a pixel must reach before it contributes to the startrails composite.",
-          "extraStartrailsArgumentsTooltip": "Extra command-line arguments appended to the AllSky startrails tool."
+          "extraStartrailsArgumentsTooltip": "Extra command-line arguments appended to the AllSky startrails tool.",
+          "overlayTimestamp": "Overlay Timestamp",
+          "stampTimestamp": "Stamp capture timestamp",
+          "overlayExposureGain": "Overlay Exposure + Gain",
+          "stampExposureGain": "Stamp exposure and gain",
+          "overlayTimestampTooltip": "Render the captured timestamp into each timelapse frame.",
+          "overlayExposureGainTooltip": "Render the actual exposure and gain used for each captured frame into the timelapse."
         }
       },
       "recentSessions": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -3144,8 +3144,8 @@
           "stampTimestamp": "Stamp capture timestamp",
           "overlayExposureGain": "Overlay Exposure + Gain",
           "stampExposureGain": "Stamp exposure and gain",
-          "overlayTimestampTooltip": "Render the captured timestamp into each timelapse frame.",
-          "overlayExposureGainTooltip": "Render the actual exposure and gain used for each captured frame into the timelapse."
+          "overlayTimestampTooltip": "Render the captured timestamp into each timelapse frame. This applies on the next timelapse render or when you regenerate an existing session.",
+          "overlayExposureGainTooltip": "Render the actual exposure and gain used for each captured frame into the timelapse. This applies on the next timelapse render or when you regenerate an existing session."
         }
       },
       "recentSessions": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -3096,8 +3096,8 @@
           "stampTimestamp": "Stamp capture timestamp",
           "overlayExposureGain": "Overlay Exposure + Gain",
           "stampExposureGain": "Stamp exposure and gain",
-          "overlayTimestampTooltip": "Render the captured timestamp into each timelapse frame.",
-          "overlayExposureGainTooltip": "Render the actual exposure and gain used for each captured frame into the timelapse."
+          "overlayTimestampTooltip": "Render the captured timestamp into each timelapse frame. This applies on the next timelapse render or when you regenerate an existing session.",
+          "overlayExposureGainTooltip": "Render the actual exposure and gain used for each captured frame into the timelapse. This applies on the next timelapse render or when you regenerate an existing session."
         }
       },
       "recentSessions": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -2895,7 +2895,8 @@
         "frameCount": "Número de fotogramas:",
         "captureInterval": "Intervalo de captura:",
         "exposure": "Exposición:",
-        "gain": "Ganar:"
+        "gain": "Ganar:",
+        "mean": "Mean:"
       },
       "statusRows": {
         "backend": "backend",
@@ -2986,10 +2987,10 @@
           "sharpness": "Nitidez",
           "manualExposure": "exposición manual",
           "shutterMicroseconds": "Obturador (μs)",
-          "manualExposureHelp": "Cuando está desactivado, rpicam-still controla la exposición automáticamente.",
+          "manualExposureHelp": "When disabled, PINS AllSky uses the AllSky mean-based controller. If Target Mean is 0, rpicam-still exposure stays automatic instead.",
           "manualGain": "ganancia manual",
           "analogGain": "Ganancia analógica",
-          "manualGainHelp": "Cuando está desactivado, los controles de rpicam-still ganan automáticamente.",
+          "manualGainHelp": "When disabled, PINS AllSky uses the AllSky mean-based controller. If Target Mean is 0, rpicam-still gain stays automatic instead.",
           "horizontalFlip": "volteo horizontal",
           "mirrorOnXAxis": "Espejo en el eje X",
           "verticalFlip": "volteo vertical",
@@ -3029,7 +3030,23 @@
             "cdnOff": "CDN desactivado",
             "cdnFast": "CDN rápido",
             "cdnHq": "CDN de alta calidad"
-          }
+          },
+          "allSkyAutoExposure": "AllSky auto exposure / gain",
+          "allSkyAutoExposureHelp": "Adapted from AllSky's mean-based controller. When manual exposure and/or manual gain are disabled, PINS AllSky measures the previous frame and calculates the next shutter and gain instead of relying on rpicam-still auto exposure alone.",
+          "autoMeanTarget": "Target Mean",
+          "autoMeanThreshold": "Mean Threshold",
+          "autoMaxExposureMicroseconds": "Auto Max Shutter (µs)",
+          "autoMaxGain": "Auto Max Gain",
+          "autoMeanP0": "Aggression P0",
+          "autoMeanP1": "Aggression P1",
+          "autoMeanP2": "Aggression P2",
+          "autoMeanTargetTooltip": "Target normalized image mean used by the AllSky auto-exposure controller. Set to 0 to fall back to rpicam-still auto exposure.",
+          "autoMeanThresholdTooltip": "Allowed normalized distance from the target mean before the next frame's exposure level is changed.",
+          "autoMaxExposureTooltip": "Maximum shutter time the AllSky auto-exposure controller may use when manual exposure is disabled.",
+          "autoMaxGainTooltip": "Maximum analog gain the AllSky auto-exposure controller may use when manual gain is disabled.",
+          "autoMeanP0Tooltip": "AllSky controller tuning constant p0. Higher values react more aggressively to brightness changes.",
+          "autoMeanP1Tooltip": "AllSky controller tuning constant p1 used for linear response to mean error.",
+          "autoMeanP2Tooltip": "AllSky controller tuning constant p2 used for stronger quadratic response to large brightness errors."
         },
         "outputs": {
           "keepSourceFrames": "Mantener fotogramas de origen",
@@ -3074,7 +3091,13 @@
           "lineThicknessTooltip": "Grosor de línea utilizado cuando la herramienta Keograma dibuja etiquetas o marcadores.",
           "extraKeogramArgumentsTooltip": "Argumentos adicionales de línea de comandos agregados a la herramienta AllSky keogram.",
           "brightnessThresholdTooltip": "Brillo mínimo normalizado que debe alcanzar un píxel antes de contribuir a la composición de startrails.",
-          "extraStartrailsArgumentsTooltip": "Argumentos de línea de comando adicionales agregados a la herramienta AllSky startrails."
+          "extraStartrailsArgumentsTooltip": "Argumentos de línea de comando adicionales agregados a la herramienta AllSky startrails.",
+          "overlayTimestamp": "Overlay Timestamp",
+          "stampTimestamp": "Stamp capture timestamp",
+          "overlayExposureGain": "Overlay Exposure + Gain",
+          "stampExposureGain": "Stamp exposure and gain",
+          "overlayTimestampTooltip": "Render the captured timestamp into each timelapse frame.",
+          "overlayExposureGainTooltip": "Render the actual exposure and gain used for each captured frame into the timelapse."
         }
       },
       "recentSessions": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -3096,8 +3096,8 @@
           "stampTimestamp": "Stamp capture timestamp",
           "overlayExposureGain": "Overlay Exposure + Gain",
           "stampExposureGain": "Stamp exposure and gain",
-          "overlayTimestampTooltip": "Render the captured timestamp into each timelapse frame.",
-          "overlayExposureGainTooltip": "Render the actual exposure and gain used for each captured frame into the timelapse."
+          "overlayTimestampTooltip": "Render the captured timestamp into each timelapse frame. This applies on the next timelapse render or when you regenerate an existing session.",
+          "overlayExposureGainTooltip": "Render the actual exposure and gain used for each captured frame into the timelapse. This applies on the next timelapse render or when you regenerate an existing session."
         }
       },
       "recentSessions": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -2895,7 +2895,8 @@
         "frameCount": "Nombre d'images :",
         "captureInterval": "Intervalle de capture :",
         "exposure": "Exposition:",
-        "gain": "Gagner:"
+        "gain": "Gagner:",
+        "mean": "Mean:"
       },
       "statusRows": {
         "backend": "Back-end",
@@ -2986,10 +2987,10 @@
           "sharpness": "Acuité",
           "manualExposure": "Exposition manuelle",
           "shutterMicroseconds": "Obturateur (µs)",
-          "manualExposureHelp": "Lorsqu'il est désactivé, rpicam-still contrôle automatiquement l'exposition.",
+          "manualExposureHelp": "When disabled, PINS AllSky uses the AllSky mean-based controller. If Target Mean is 0, rpicam-still exposure stays automatic instead.",
           "manualGain": "Gain manuel",
           "analogGain": "Gain analogique",
-          "manualGainHelp": "Lorsqu'il est désactivé, rpicam-still contrôle automatiquement le gain.",
+          "manualGainHelp": "When disabled, PINS AllSky uses the AllSky mean-based controller. If Target Mean is 0, rpicam-still gain stays automatic instead.",
           "horizontalFlip": "Retournement horizontal",
           "mirrorOnXAxis": "Miroir sur l'axe X",
           "verticalFlip": "Retournement vertical",
@@ -3029,7 +3030,23 @@
             "cdnOff": "CDN désactivé",
             "cdnFast": "CDN Rapide",
             "cdnHq": "CDN de haute qualité"
-          }
+          },
+          "allSkyAutoExposure": "AllSky auto exposure / gain",
+          "allSkyAutoExposureHelp": "Adapted from AllSky's mean-based controller. When manual exposure and/or manual gain are disabled, PINS AllSky measures the previous frame and calculates the next shutter and gain instead of relying on rpicam-still auto exposure alone.",
+          "autoMeanTarget": "Target Mean",
+          "autoMeanThreshold": "Mean Threshold",
+          "autoMaxExposureMicroseconds": "Auto Max Shutter (µs)",
+          "autoMaxGain": "Auto Max Gain",
+          "autoMeanP0": "Aggression P0",
+          "autoMeanP1": "Aggression P1",
+          "autoMeanP2": "Aggression P2",
+          "autoMeanTargetTooltip": "Target normalized image mean used by the AllSky auto-exposure controller. Set to 0 to fall back to rpicam-still auto exposure.",
+          "autoMeanThresholdTooltip": "Allowed normalized distance from the target mean before the next frame's exposure level is changed.",
+          "autoMaxExposureTooltip": "Maximum shutter time the AllSky auto-exposure controller may use when manual exposure is disabled.",
+          "autoMaxGainTooltip": "Maximum analog gain the AllSky auto-exposure controller may use when manual gain is disabled.",
+          "autoMeanP0Tooltip": "AllSky controller tuning constant p0. Higher values react more aggressively to brightness changes.",
+          "autoMeanP1Tooltip": "AllSky controller tuning constant p1 used for linear response to mean error.",
+          "autoMeanP2Tooltip": "AllSky controller tuning constant p2 used for stronger quadratic response to large brightness errors."
         },
         "outputs": {
           "keepSourceFrames": "Conserver les images sources",
@@ -3074,7 +3091,13 @@
           "lineThicknessTooltip": "Épaisseur de ligne utilisée lorsque l'outil keogram dessine des étiquettes ou des marqueurs.",
           "extraKeogramArgumentsTooltip": "Arguments de ligne de commande supplémentaires ajoutés à l'outil AllSky keogram.",
           "brightnessThresholdTooltip": "Luminosité normalisée minimale qu'un pixel doit atteindre avant de contribuer au composite startrails.",
-          "extraStartrailsArgumentsTooltip": "Arguments de ligne de commande supplémentaires ajoutés à l'outil AllSky startrails."
+          "extraStartrailsArgumentsTooltip": "Arguments de ligne de commande supplémentaires ajoutés à l'outil AllSky startrails.",
+          "overlayTimestamp": "Overlay Timestamp",
+          "stampTimestamp": "Stamp capture timestamp",
+          "overlayExposureGain": "Overlay Exposure + Gain",
+          "stampExposureGain": "Stamp exposure and gain",
+          "overlayTimestampTooltip": "Render the captured timestamp into each timelapse frame.",
+          "overlayExposureGainTooltip": "Render the actual exposure and gain used for each captured frame into the timelapse."
         }
       },
       "recentSessions": {

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -3096,8 +3096,8 @@
           "stampTimestamp": "Stamp capture timestamp",
           "overlayExposureGain": "Overlay Exposure + Gain",
           "stampExposureGain": "Stamp exposure and gain",
-          "overlayTimestampTooltip": "Render the captured timestamp into each timelapse frame.",
-          "overlayExposureGainTooltip": "Render the actual exposure and gain used for each captured frame into the timelapse."
+          "overlayTimestampTooltip": "Render the captured timestamp into each timelapse frame. This applies on the next timelapse render or when you regenerate an existing session.",
+          "overlayExposureGainTooltip": "Render the actual exposure and gain used for each captured frame into the timelapse. This applies on the next timelapse render or when you regenerate an existing session."
         }
       },
       "recentSessions": {

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -2895,7 +2895,8 @@
         "frameCount": "Conteggio fotogrammi:",
         "captureInterval": "Intervallo di acquisizione:",
         "exposure": "Esposizione:",
-        "gain": "Guadagno:"
+        "gain": "Guadagno:",
+        "mean": "Mean:"
       },
       "statusRows": {
         "backend": "Backend",
@@ -2986,10 +2987,10 @@
           "sharpness": "Nitidezza",
           "manualExposure": "Esposizione manuale",
           "shutterMicroseconds": "Otturatore (μs)",
-          "manualExposureHelp": "Quando disabilitato, rpicam-still controlla automaticamente l'esposizione.",
+          "manualExposureHelp": "When disabled, PINS AllSky uses the AllSky mean-based controller. If Target Mean is 0, rpicam-still exposure stays automatic instead.",
           "manualGain": "Guadagno manuale",
           "analogGain": "Guadagno analogico",
-          "manualGainHelp": "Quando disabilitato, i controlli rpicam-still ottengono automaticamente il guadagno.",
+          "manualGainHelp": "When disabled, PINS AllSky uses the AllSky mean-based controller. If Target Mean is 0, rpicam-still gain stays automatic instead.",
           "horizontalFlip": "Ribaltamento orizzontale",
           "mirrorOnXAxis": "Specchio sull'asse X",
           "verticalFlip": "Capovolgimento verticale",
@@ -3029,7 +3030,23 @@
             "cdnOff": "CDN disattivato",
             "cdnFast": "CDN veloce",
             "cdnHq": "CDN di alta qualità"
-          }
+          },
+          "allSkyAutoExposure": "AllSky auto exposure / gain",
+          "allSkyAutoExposureHelp": "Adapted from AllSky's mean-based controller. When manual exposure and/or manual gain are disabled, PINS AllSky measures the previous frame and calculates the next shutter and gain instead of relying on rpicam-still auto exposure alone.",
+          "autoMeanTarget": "Target Mean",
+          "autoMeanThreshold": "Mean Threshold",
+          "autoMaxExposureMicroseconds": "Auto Max Shutter (µs)",
+          "autoMaxGain": "Auto Max Gain",
+          "autoMeanP0": "Aggression P0",
+          "autoMeanP1": "Aggression P1",
+          "autoMeanP2": "Aggression P2",
+          "autoMeanTargetTooltip": "Target normalized image mean used by the AllSky auto-exposure controller. Set to 0 to fall back to rpicam-still auto exposure.",
+          "autoMeanThresholdTooltip": "Allowed normalized distance from the target mean before the next frame's exposure level is changed.",
+          "autoMaxExposureTooltip": "Maximum shutter time the AllSky auto-exposure controller may use when manual exposure is disabled.",
+          "autoMaxGainTooltip": "Maximum analog gain the AllSky auto-exposure controller may use when manual gain is disabled.",
+          "autoMeanP0Tooltip": "AllSky controller tuning constant p0. Higher values react more aggressively to brightness changes.",
+          "autoMeanP1Tooltip": "AllSky controller tuning constant p1 used for linear response to mean error.",
+          "autoMeanP2Tooltip": "AllSky controller tuning constant p2 used for stronger quadratic response to large brightness errors."
         },
         "outputs": {
           "keepSourceFrames": "Mantieni i frame di origine",
@@ -3074,7 +3091,13 @@
           "lineThicknessTooltip": "Spessore della linea utilizzato quando lo strumento keogramma disegna etichette o contrassegni.",
           "extraKeogramArgumentsTooltip": "Argomenti aggiuntivi della riga di comando aggiunti allo strumento keogram di AllSky.",
           "brightnessThresholdTooltip": "Luminosità normalizzata minima che un pixel deve raggiungere prima di contribuire al composito startrails.",
-          "extraStartrailsArgumentsTooltip": "Argomenti aggiuntivi della riga di comando aggiunti allo strumento startrails di AllSky."
+          "extraStartrailsArgumentsTooltip": "Argomenti aggiuntivi della riga di comando aggiunti allo strumento startrails di AllSky.",
+          "overlayTimestamp": "Overlay Timestamp",
+          "stampTimestamp": "Stamp capture timestamp",
+          "overlayExposureGain": "Overlay Exposure + Gain",
+          "stampExposureGain": "Stamp exposure and gain",
+          "overlayTimestampTooltip": "Render the captured timestamp into each timelapse frame.",
+          "overlayExposureGainTooltip": "Render the actual exposure and gain used for each captured frame into the timelapse."
         }
       },
       "recentSessions": {

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -2942,7 +2942,8 @@
         "frameCount": "フレーム数：",
         "captureInterval": "キャプチャ間隔：",
         "exposure": "露出：",
-        "gain": "ゲイン："
+        "gain": "ゲイン：",
+        "mean": "平均："
       },
       "statusRows": {
         "backend": "バックエンド",
@@ -3033,10 +3034,10 @@
           "sharpness": "シャープネス",
           "manualExposure": "手動露出",
           "shutterMicroseconds": "シャッター（µs）",
-          "manualExposureHelp": "無効の場合、rpicam-stillが自動的に露出を制御します。",
+          "manualExposureHelp": "無効の場合、PINS AllSky は AllSky の平均値ベース制御を使用します。Target Mean が 0 のときだけ、rpicam-still の自動露出にフォールバックします。",
           "manualGain": "手動ゲイン",
           "analogGain": "アナログゲイン",
-          "manualGainHelp": "無効の場合、rpicam-stillが自動的にゲインを制御します。",
+          "manualGainHelp": "無効の場合、PINS AllSky は AllSky の平均値ベース制御を使用します。Target Mean が 0 のときだけ、rpicam-still の自動ゲインにフォールバックします。",
           "horizontalFlip": "水平反転",
           "mirrorOnXAxis": "X軸で反転",
           "verticalFlip": "垂直反転",
@@ -3076,7 +3077,23 @@
             "cdnOff": "CDN オフ",
             "cdnFast": "CDN 高速",
             "cdnHq": "CDN 高画質"
-          }
+          },
+          "allSkyAutoExposure": "AllSky 自動露出 / ゲイン",
+          "allSkyAutoExposureHelp": "AllSky の平均値ベース制御を移植したものです。手動露出または手動ゲインを無効にすると、PINS AllSky は前のフレームの平均輝度を測定して、次のシャッター時間とゲインを計算します。",
+          "autoMeanTarget": "目標平均値",
+          "autoMeanThreshold": "平均値しきい値",
+          "autoMaxExposureMicroseconds": "自動最大シャッター（µs）",
+          "autoMaxGain": "自動最大ゲイン",
+          "autoMeanP0": "補正係数 P0",
+          "autoMeanP1": "補正係数 P1",
+          "autoMeanP2": "補正係数 P2",
+          "autoMeanTargetTooltip": "AllSky 自動露出制御が目標とする正規化平均輝度です。0 にすると rpicam-still の自動露出に戻ります。",
+          "autoMeanThresholdTooltip": "平均輝度が目標値からどれだけ外れたら次フレームの露出レベルを変更するかを決める許容幅です。",
+          "autoMaxExposureTooltip": "手動露出が無効な場合に AllSky 自動露出制御が使用できる最大シャッター時間です。",
+          "autoMaxGainTooltip": "手動ゲインが無効な場合に AllSky 自動露出制御が使用できる最大アナログゲインです。",
+          "autoMeanP0Tooltip": "AllSky 制御定数 p0。値を大きくすると明るさ変化への反応が強くなります。",
+          "autoMeanP1Tooltip": "平均輝度誤差に対する線形応答に使う AllSky 制御定数 p1 です。",
+          "autoMeanP2Tooltip": "大きな輝度誤差に対する二次応答に使う AllSky 制御定数 p2 です。"
         },
         "outputs": {
           "keepSourceFrames": "ソースフレームを保持",
@@ -3121,7 +3138,13 @@
           "lineThicknessTooltip": "ケオグラムツールがラベルやマーカーを描画する際の線の太さ。",
           "extraKeogramArgumentsTooltip": "AllSkyケオグラムツールに追加されるコマンドライン引数。",
           "brightnessThresholdTooltip": "スタートレイル合成に寄与するピクセルの最小正規化輝度。",
-          "extraStartrailsArgumentsTooltip": "AllSkyスタートレイルツールに追加されるコマンドライン引数。"
+          "extraStartrailsArgumentsTooltip": "AllSkyスタートレイルツールに追加されるコマンドライン引数。",
+          "overlayTimestamp": "タイムスタンプを重ねる",
+          "stampTimestamp": "キャプチャ時刻を表示",
+          "overlayExposureGain": "露出とゲインを重ねる",
+          "stampExposureGain": "実際の露出値とゲインを表示",
+          "overlayTimestampTooltip": "各タイムラプスフレームにキャプチャ時刻を描画します。",
+          "overlayExposureGainTooltip": "各タイムラプスフレームに、そのフレームで実際に使用した露出値とゲインを描画します。"
         }
       },
       "recentSessions": {

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -2895,7 +2895,8 @@
         "frameCount": "Aantal frames:",
         "captureInterval": "Vastleginterval:",
         "exposure": "Blootstelling:",
-        "gain": "Verdienen:"
+        "gain": "Verdienen:",
+        "mean": "Mean:"
       },
       "statusRows": {
         "backend": "Achterkant",
@@ -2986,10 +2987,10 @@
           "sharpness": "Scherpte",
           "manualExposure": "Handmatige belichting",
           "shutterMicroseconds": "Sluiter (µs)",
-          "manualExposureHelp": "Indien uitgeschakeld, regelt rpicam-still de belichting automatisch.",
+          "manualExposureHelp": "When disabled, PINS AllSky uses the AllSky mean-based controller. If Target Mean is 0, rpicam-still exposure stays automatic instead.",
           "manualGain": "Handmatige winst",
           "analogGain": "Analoge winst",
-          "manualGainHelp": "Indien uitgeschakeld, worden de rpicam-still-besturingselementen automatisch versterkt.",
+          "manualGainHelp": "When disabled, PINS AllSky uses the AllSky mean-based controller. If Target Mean is 0, rpicam-still gain stays automatic instead.",
           "horizontalFlip": "Horizontale spiegeling",
           "mirrorOnXAxis": "Spiegel op X-as",
           "verticalFlip": "Verticale draai",
@@ -3029,7 +3030,23 @@
             "cdnOff": "CDN Uit",
             "cdnFast": "CDN Snel",
             "cdnHq": "CDN-hoge kwaliteit"
-          }
+          },
+          "allSkyAutoExposure": "AllSky auto exposure / gain",
+          "allSkyAutoExposureHelp": "Adapted from AllSky's mean-based controller. When manual exposure and/or manual gain are disabled, PINS AllSky measures the previous frame and calculates the next shutter and gain instead of relying on rpicam-still auto exposure alone.",
+          "autoMeanTarget": "Target Mean",
+          "autoMeanThreshold": "Mean Threshold",
+          "autoMaxExposureMicroseconds": "Auto Max Shutter (µs)",
+          "autoMaxGain": "Auto Max Gain",
+          "autoMeanP0": "Aggression P0",
+          "autoMeanP1": "Aggression P1",
+          "autoMeanP2": "Aggression P2",
+          "autoMeanTargetTooltip": "Target normalized image mean used by the AllSky auto-exposure controller. Set to 0 to fall back to rpicam-still auto exposure.",
+          "autoMeanThresholdTooltip": "Allowed normalized distance from the target mean before the next frame's exposure level is changed.",
+          "autoMaxExposureTooltip": "Maximum shutter time the AllSky auto-exposure controller may use when manual exposure is disabled.",
+          "autoMaxGainTooltip": "Maximum analog gain the AllSky auto-exposure controller may use when manual gain is disabled.",
+          "autoMeanP0Tooltip": "AllSky controller tuning constant p0. Higher values react more aggressively to brightness changes.",
+          "autoMeanP1Tooltip": "AllSky controller tuning constant p1 used for linear response to mean error.",
+          "autoMeanP2Tooltip": "AllSky controller tuning constant p2 used for stronger quadratic response to large brightness errors."
         },
         "outputs": {
           "keepSourceFrames": "Bewaar bronframes",
@@ -3074,7 +3091,13 @@
           "lineThicknessTooltip": "Lijndikte die wordt gebruikt wanneer het keogram-gereedschap labels of markeringen tekent.",
           "extraKeogramArgumentsTooltip": "Extra opdrachtregelargumenten toegevoegd aan de AllSky keogram-tool.",
           "brightnessThresholdTooltip": "Minimale genormaliseerde helderheid die een pixel moet bereiken voordat deze bijdraagt ​​aan de Startrails-composiet.",
-          "extraStartrailsArgumentsTooltip": "Extra opdrachtregelargumenten toegevoegd aan de AllSky startrails-tool."
+          "extraStartrailsArgumentsTooltip": "Extra opdrachtregelargumenten toegevoegd aan de AllSky startrails-tool.",
+          "overlayTimestamp": "Overlay Timestamp",
+          "stampTimestamp": "Stamp capture timestamp",
+          "overlayExposureGain": "Overlay Exposure + Gain",
+          "stampExposureGain": "Stamp exposure and gain",
+          "overlayTimestampTooltip": "Render the captured timestamp into each timelapse frame.",
+          "overlayExposureGainTooltip": "Render the actual exposure and gain used for each captured frame into the timelapse."
         }
       },
       "recentSessions": {

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -3096,8 +3096,8 @@
           "stampTimestamp": "Stamp capture timestamp",
           "overlayExposureGain": "Overlay Exposure + Gain",
           "stampExposureGain": "Stamp exposure and gain",
-          "overlayTimestampTooltip": "Render the captured timestamp into each timelapse frame.",
-          "overlayExposureGainTooltip": "Render the actual exposure and gain used for each captured frame into the timelapse."
+          "overlayTimestampTooltip": "Render the captured timestamp into each timelapse frame. This applies on the next timelapse render or when you regenerate an existing session.",
+          "overlayExposureGainTooltip": "Render the actual exposure and gain used for each captured frame into the timelapse. This applies on the next timelapse render or when you regenerate an existing session."
         }
       },
       "recentSessions": {

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -3096,8 +3096,8 @@
           "stampTimestamp": "Stamp capture timestamp",
           "overlayExposureGain": "Overlay Exposure + Gain",
           "stampExposureGain": "Stamp exposure and gain",
-          "overlayTimestampTooltip": "Render the captured timestamp into each timelapse frame.",
-          "overlayExposureGainTooltip": "Render the actual exposure and gain used for each captured frame into the timelapse."
+          "overlayTimestampTooltip": "Render the captured timestamp into each timelapse frame. This applies on the next timelapse render or when you regenerate an existing session.",
+          "overlayExposureGainTooltip": "Render the actual exposure and gain used for each captured frame into the timelapse. This applies on the next timelapse render or when you regenerate an existing session."
         }
       },
       "recentSessions": {

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -2895,7 +2895,8 @@
         "frameCount": "Liczba klatek:",
         "captureInterval": "Interwał przechwytywania:",
         "exposure": "Narażenie:",
-        "gain": "Osiągać:"
+        "gain": "Osiągać:",
+        "mean": "Mean:"
       },
       "statusRows": {
         "backend": "Zaplecze",
@@ -2986,10 +2987,10 @@
           "sharpness": "Ostrość",
           "manualExposure": "Ręczna ekspozycja",
           "shutterMicroseconds": "Migawka (µs)",
-          "manualExposureHelp": "Po wyłączeniu rpicam-still automatycznie kontroluje ekspozycję.",
+          "manualExposureHelp": "When disabled, PINS AllSky uses the AllSky mean-based controller. If Target Mean is 0, rpicam-still exposure stays automatic instead.",
           "manualGain": "Wzmocnienie ręczne",
           "analogGain": "Wzmocnienie analogowe",
-          "manualGainHelp": "Gdy wyłączone, sterowanie rpicam-still wzmacnia się automatycznie.",
+          "manualGainHelp": "When disabled, PINS AllSky uses the AllSky mean-based controller. If Target Mean is 0, rpicam-still gain stays automatic instead.",
           "horizontalFlip": "Odwrócenie poziome",
           "mirrorOnXAxis": "Lustro na osi X",
           "verticalFlip": "Przewrót w pionie",
@@ -3029,7 +3030,23 @@
             "cdnOff": "CDN wyłączony",
             "cdnFast": "Szybkość CDN",
             "cdnHq": "Wysoka jakość CDN"
-          }
+          },
+          "allSkyAutoExposure": "AllSky auto exposure / gain",
+          "allSkyAutoExposureHelp": "Adapted from AllSky's mean-based controller. When manual exposure and/or manual gain are disabled, PINS AllSky measures the previous frame and calculates the next shutter and gain instead of relying on rpicam-still auto exposure alone.",
+          "autoMeanTarget": "Target Mean",
+          "autoMeanThreshold": "Mean Threshold",
+          "autoMaxExposureMicroseconds": "Auto Max Shutter (µs)",
+          "autoMaxGain": "Auto Max Gain",
+          "autoMeanP0": "Aggression P0",
+          "autoMeanP1": "Aggression P1",
+          "autoMeanP2": "Aggression P2",
+          "autoMeanTargetTooltip": "Target normalized image mean used by the AllSky auto-exposure controller. Set to 0 to fall back to rpicam-still auto exposure.",
+          "autoMeanThresholdTooltip": "Allowed normalized distance from the target mean before the next frame's exposure level is changed.",
+          "autoMaxExposureTooltip": "Maximum shutter time the AllSky auto-exposure controller may use when manual exposure is disabled.",
+          "autoMaxGainTooltip": "Maximum analog gain the AllSky auto-exposure controller may use when manual gain is disabled.",
+          "autoMeanP0Tooltip": "AllSky controller tuning constant p0. Higher values react more aggressively to brightness changes.",
+          "autoMeanP1Tooltip": "AllSky controller tuning constant p1 used for linear response to mean error.",
+          "autoMeanP2Tooltip": "AllSky controller tuning constant p2 used for stronger quadratic response to large brightness errors."
         },
         "outputs": {
           "keepSourceFrames": "Zachowaj ramki źródłowe",
@@ -3074,7 +3091,13 @@
           "lineThicknessTooltip": "Grubość linii używana, gdy narzędzie keogramu rysuje etykiety lub znaczniki.",
           "extraKeogramArgumentsTooltip": "Dodatkowe argumenty wiersza poleceń dołączone do narzędzia keogramu AllSky.",
           "brightnessThresholdTooltip": "Minimalna znormalizowana jasność, jaką musi osiągnąć piksel, zanim zostanie włączony do kompozytu Startrails.",
-          "extraStartrailsArgumentsTooltip": "Dodatkowe argumenty wiersza poleceń dołączone do narzędzia AllSky startrails."
+          "extraStartrailsArgumentsTooltip": "Dodatkowe argumenty wiersza poleceń dołączone do narzędzia AllSky startrails.",
+          "overlayTimestamp": "Overlay Timestamp",
+          "stampTimestamp": "Stamp capture timestamp",
+          "overlayExposureGain": "Overlay Exposure + Gain",
+          "stampExposureGain": "Stamp exposure and gain",
+          "overlayTimestampTooltip": "Render the captured timestamp into each timelapse frame.",
+          "overlayExposureGainTooltip": "Render the actual exposure and gain used for each captured frame into the timelapse."
         }
       },
       "recentSessions": {

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -3096,8 +3096,8 @@
           "stampTimestamp": "Stamp capture timestamp",
           "overlayExposureGain": "Overlay Exposure + Gain",
           "stampExposureGain": "Stamp exposure and gain",
-          "overlayTimestampTooltip": "Render the captured timestamp into each timelapse frame.",
-          "overlayExposureGainTooltip": "Render the actual exposure and gain used for each captured frame into the timelapse."
+          "overlayTimestampTooltip": "Render the captured timestamp into each timelapse frame. This applies on the next timelapse render or when you regenerate an existing session.",
+          "overlayExposureGainTooltip": "Render the actual exposure and gain used for each captured frame into the timelapse. This applies on the next timelapse render or when you regenerate an existing session."
         }
       },
       "recentSessions": {

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -2895,7 +2895,8 @@
         "frameCount": "Contagem de quadros:",
         "captureInterval": "Intervalo de captura:",
         "exposure": "Exposição:",
-        "gain": "Ganho:"
+        "gain": "Ganho:",
+        "mean": "Mean:"
       },
       "statusRows": {
         "backend": "Back-end",
@@ -2986,10 +2987,10 @@
           "sharpness": "Nitidez",
           "manualExposure": "Exposição manual",
           "shutterMicroseconds": "Obturador (µs)",
-          "manualExposureHelp": "Quando desativado, o rpicam-still controla a exposição automaticamente.",
+          "manualExposureHelp": "When disabled, PINS AllSky uses the AllSky mean-based controller. If Target Mean is 0, rpicam-still exposure stays automatic instead.",
           "manualGain": "Ganho manual",
           "analogGain": "Ganho Analógico",
-          "manualGainHelp": "Quando desativado, os controles rpicam-still ganham automaticamente.",
+          "manualGainHelp": "When disabled, PINS AllSky uses the AllSky mean-based controller. If Target Mean is 0, rpicam-still gain stays automatic instead.",
           "horizontalFlip": "Inversão horizontal",
           "mirrorOnXAxis": "Espelho no eixo X",
           "verticalFlip": "Inversão vertical",
@@ -3029,7 +3030,23 @@
             "cdnOff": "CDN desativado",
             "cdnFast": "CDN rápido",
             "cdnHq": "CDN de alta qualidade"
-          }
+          },
+          "allSkyAutoExposure": "AllSky auto exposure / gain",
+          "allSkyAutoExposureHelp": "Adapted from AllSky's mean-based controller. When manual exposure and/or manual gain are disabled, PINS AllSky measures the previous frame and calculates the next shutter and gain instead of relying on rpicam-still auto exposure alone.",
+          "autoMeanTarget": "Target Mean",
+          "autoMeanThreshold": "Mean Threshold",
+          "autoMaxExposureMicroseconds": "Auto Max Shutter (µs)",
+          "autoMaxGain": "Auto Max Gain",
+          "autoMeanP0": "Aggression P0",
+          "autoMeanP1": "Aggression P1",
+          "autoMeanP2": "Aggression P2",
+          "autoMeanTargetTooltip": "Target normalized image mean used by the AllSky auto-exposure controller. Set to 0 to fall back to rpicam-still auto exposure.",
+          "autoMeanThresholdTooltip": "Allowed normalized distance from the target mean before the next frame's exposure level is changed.",
+          "autoMaxExposureTooltip": "Maximum shutter time the AllSky auto-exposure controller may use when manual exposure is disabled.",
+          "autoMaxGainTooltip": "Maximum analog gain the AllSky auto-exposure controller may use when manual gain is disabled.",
+          "autoMeanP0Tooltip": "AllSky controller tuning constant p0. Higher values react more aggressively to brightness changes.",
+          "autoMeanP1Tooltip": "AllSky controller tuning constant p1 used for linear response to mean error.",
+          "autoMeanP2Tooltip": "AllSky controller tuning constant p2 used for stronger quadratic response to large brightness errors."
         },
         "outputs": {
           "keepSourceFrames": "Manter quadros de origem",
@@ -3074,7 +3091,13 @@
           "lineThicknessTooltip": "Espessura da linha usada quando a ferramenta keograma desenha rótulos ou marcadores.",
           "extraKeogramArgumentsTooltip": "Argumentos extras de linha de comando anexados à ferramenta AllSky keogram.",
           "brightnessThresholdTooltip": "O brilho mínimo normalizado que um pixel deve atingir antes de contribuir para o composto startrails.",
-          "extraStartrailsArgumentsTooltip": "Argumentos extras de linha de comando anexados à ferramenta AllSky startrails."
+          "extraStartrailsArgumentsTooltip": "Argumentos extras de linha de comando anexados à ferramenta AllSky startrails.",
+          "overlayTimestamp": "Overlay Timestamp",
+          "stampTimestamp": "Stamp capture timestamp",
+          "overlayExposureGain": "Overlay Exposure + Gain",
+          "stampExposureGain": "Stamp exposure and gain",
+          "overlayTimestampTooltip": "Render the captured timestamp into each timelapse frame.",
+          "overlayExposureGainTooltip": "Render the actual exposure and gain used for each captured frame into the timelapse."
         }
       },
       "recentSessions": {

--- a/src/plugins/pins-allsky/components/PinsAllSkyCameraSettings.vue
+++ b/src/plugins/pins-allsky/components/PinsAllSkyCameraSettings.vue
@@ -265,6 +265,118 @@
     </div>
 
     <div class="flex flex-wrap gap-4">
+      <div class="w-full rounded-xl border border-cyan-500/20 bg-cyan-500/10 p-4">
+        <div class="text-sm font-semibold text-cyan-100">
+          {{ t('plugins.pinsAllSky.modals.camera.allSkyAutoExposure') }}
+        </div>
+        <p class="mt-2 text-sm text-cyan-50/90">
+          {{ t('plugins.pinsAllSky.modals.camera.allSkyAutoExposureHelp') }}
+        </p>
+
+        <div class="mt-4 flex flex-wrap gap-4">
+          <label :class="settingsFieldClass" class="block">
+            <span class="mb-2 block text-xs font-semibold uppercase tracking-wide text-gray-400">
+              {{ t('plugins.pinsAllSky.modals.camera.autoMeanTarget') }}
+            </span>
+            <input
+              v-model.number="config.camera.autoMeanTarget"
+              type="number"
+              min="0"
+              max="1"
+              step="0.01"
+              inputmode="decimal"
+              :title="t('plugins.pinsAllSky.modals.camera.autoMeanTargetTooltip')"
+              class="w-full rounded-xl border border-gray-600 bg-gray-800/70 px-3 py-2 text-white outline-none transition focus:border-cyan-400"
+            />
+          </label>
+          <label :class="settingsFieldClass" class="block">
+            <span class="mb-2 block text-xs font-semibold uppercase tracking-wide text-gray-400">
+              {{ t('plugins.pinsAllSky.modals.camera.autoMeanThreshold') }}
+            </span>
+            <input
+              v-model.number="config.camera.autoMeanThreshold"
+              type="number"
+              min="0"
+              max="1"
+              step="0.01"
+              inputmode="decimal"
+              :title="t('plugins.pinsAllSky.modals.camera.autoMeanThresholdTooltip')"
+              class="w-full rounded-xl border border-gray-600 bg-gray-800/70 px-3 py-2 text-white outline-none transition focus:border-cyan-400"
+            />
+          </label>
+          <label :class="settingsFieldClass" class="block">
+            <span class="mb-2 block text-xs font-semibold uppercase tracking-wide text-gray-400">
+              {{ t('plugins.pinsAllSky.modals.camera.autoMaxExposureMicroseconds') }}
+            </span>
+            <input
+              v-model.number="config.camera.autoMaxExposureMicroseconds"
+              type="number"
+              min="1"
+              inputmode="numeric"
+              :title="t('plugins.pinsAllSky.modals.camera.autoMaxExposureTooltip')"
+              class="w-full rounded-xl border border-gray-600 bg-gray-800/70 px-3 py-2 text-white outline-none transition focus:border-cyan-400"
+            />
+          </label>
+          <label :class="settingsFieldClass" class="block">
+            <span class="mb-2 block text-xs font-semibold uppercase tracking-wide text-gray-400">
+              {{ t('plugins.pinsAllSky.modals.camera.autoMaxGain') }}
+            </span>
+            <input
+              v-model.number="config.camera.autoMaxGain"
+              type="number"
+              min="1"
+              max="64"
+              step="0.1"
+              inputmode="decimal"
+              :title="t('plugins.pinsAllSky.modals.camera.autoMaxGainTooltip')"
+              class="w-full rounded-xl border border-gray-600 bg-gray-800/70 px-3 py-2 text-white outline-none transition focus:border-cyan-400"
+            />
+          </label>
+          <label :class="settingsFieldClass" class="block">
+            <span class="mb-2 block text-xs font-semibold uppercase tracking-wide text-gray-400">
+              {{ t('plugins.pinsAllSky.modals.camera.autoMeanP0') }}
+            </span>
+            <input
+              v-model.number="config.camera.autoMeanP0"
+              type="number"
+              min="0"
+              step="0.1"
+              inputmode="decimal"
+              :title="t('plugins.pinsAllSky.modals.camera.autoMeanP0Tooltip')"
+              class="w-full rounded-xl border border-gray-600 bg-gray-800/70 px-3 py-2 text-white outline-none transition focus:border-cyan-400"
+            />
+          </label>
+          <label :class="settingsFieldClass" class="block">
+            <span class="mb-2 block text-xs font-semibold uppercase tracking-wide text-gray-400">
+              {{ t('plugins.pinsAllSky.modals.camera.autoMeanP1') }}
+            </span>
+            <input
+              v-model.number="config.camera.autoMeanP1"
+              type="number"
+              min="0"
+              step="0.1"
+              inputmode="decimal"
+              :title="t('plugins.pinsAllSky.modals.camera.autoMeanP1Tooltip')"
+              class="w-full rounded-xl border border-gray-600 bg-gray-800/70 px-3 py-2 text-white outline-none transition focus:border-cyan-400"
+            />
+          </label>
+          <label :class="settingsFieldClass" class="block">
+            <span class="mb-2 block text-xs font-semibold uppercase tracking-wide text-gray-400">
+              {{ t('plugins.pinsAllSky.modals.camera.autoMeanP2') }}
+            </span>
+            <input
+              v-model.number="config.camera.autoMeanP2"
+              type="number"
+              min="0"
+              step="0.1"
+              inputmode="decimal"
+              :title="t('plugins.pinsAllSky.modals.camera.autoMeanP2Tooltip')"
+              class="w-full rounded-xl border border-gray-600 bg-gray-800/70 px-3 py-2 text-white outline-none transition focus:border-cyan-400"
+            />
+          </label>
+        </div>
+      </div>
+
       <div
         :class="settingsFullWidthClass"
         class="rounded-xl border border-cyan-500/20 bg-cyan-500/10 px-3 py-2 text-sm text-cyan-100"

--- a/src/plugins/pins-allsky/components/PinsAllSkyOutputsSettings.vue
+++ b/src/plugins/pins-allsky/components/PinsAllSkyOutputsSettings.vue
@@ -105,6 +105,42 @@
             class="w-full rounded-xl border border-gray-600 bg-gray-900/60 px-3 py-2 text-white outline-none transition focus:border-cyan-400"
           />
         </label>
+        <label
+          :class="settingsFieldClass"
+          class="rounded-xl border border-gray-700 bg-gray-900/60 px-3 py-2"
+          :title="t('plugins.pinsAllSky.modals.outputs.overlayTimestampTooltip')"
+        >
+          <span class="mb-2 block text-xs font-semibold uppercase tracking-wide text-gray-400">
+            {{ t('plugins.pinsAllSky.modals.outputs.overlayTimestamp') }}
+          </span>
+          <div class="flex items-center justify-between gap-3">
+            <span class="text-sm text-gray-300">
+              {{ t('plugins.pinsAllSky.modals.outputs.stampTimestamp') }}
+            </span>
+            <toggleButton
+              :status-value="Boolean(config.products.timelapseOverlayTimestamp)"
+              @update:statusValue="setProductSetting('timelapseOverlayTimestamp', $event)"
+            />
+          </div>
+        </label>
+        <label
+          :class="settingsFieldClass"
+          class="rounded-xl border border-gray-700 bg-gray-900/60 px-3 py-2"
+          :title="t('plugins.pinsAllSky.modals.outputs.overlayExposureGainTooltip')"
+        >
+          <span class="mb-2 block text-xs font-semibold uppercase tracking-wide text-gray-400">
+            {{ t('plugins.pinsAllSky.modals.outputs.overlayExposureGain') }}
+          </span>
+          <div class="flex items-center justify-between gap-3">
+            <span class="text-sm text-gray-300">
+              {{ t('plugins.pinsAllSky.modals.outputs.stampExposureGain') }}
+            </span>
+            <toggleButton
+              :status-value="Boolean(config.products.timelapseOverlayExposureGain)"
+              @update:statusValue="setProductSetting('timelapseOverlayExposureGain', $event)"
+            />
+          </div>
+        </label>
         <label :class="settingsFullWidthClass" class="block">
           <span class="mb-2 block text-xs font-semibold uppercase tracking-wide text-gray-400">
             {{ t('plugins.pinsAllSky.modals.outputs.extraFfmpegArguments') }}

--- a/src/plugins/pins-allsky/components/PinsAllSkyRecentSessions.vue
+++ b/src/plugins/pins-allsky/components/PinsAllSkyRecentSessions.vue
@@ -57,18 +57,24 @@
           </span>
         </div>
         <button
-          class="inline-flex h-10 w-10 items-center justify-center rounded-lg border border-rose-500/40 bg-rose-500/10 text-rose-100 transition hover:bg-rose-500/20 disabled:cursor-not-allowed disabled:opacity-40"
+          class="inline-flex h-10 w-10 items-center justify-center rounded-lg border text-rose-100 transition disabled:cursor-not-allowed disabled:opacity-40"
+          :class="
+            isDeleteAllBusy()
+              ? 'border-rose-300/50 bg-rose-500/30 text-white ring-2 ring-rose-300/20'
+              : 'border-rose-500/40 bg-rose-500/10 hover:bg-rose-500/20'
+          "
           :disabled="
             cleanupBusy ||
             status?.captureRunning ||
             status?.generateInProgress ||
-            recentSessions.length === 0
+            recentSessions.length === 0 ||
+            isDeleteAllBusy()
           "
           :title="t('plugins.pinsAllSky.buttons.deleteAllSessions')"
           :aria-label="t('plugins.pinsAllSky.buttons.deleteAllSessions')"
           @click.stop="$emit('delete-all')"
         >
-          <TrashIcon class="h-5 w-5" />
+          <TrashIcon class="h-5 w-5" :class="isDeleteAllBusy() ? 'animate-pulse' : ''" />
         </button>
       </div>
     </div>
@@ -91,6 +97,7 @@
         :details="sessionDetailsById?.[session.id] || null"
         :details-loading="Boolean(detailsLoadingById?.[session.id])"
         :details-open="Boolean(sessionDetailOpen?.[session.id])"
+        :is-action-busy="isActionBusy"
         :format-date="formatDate"
         :format-count="formatCount"
         :format-size="formatSize"
@@ -113,7 +120,7 @@ import { TrashIcon } from '@heroicons/vue/24/outline';
 import { useI18n } from 'vue-i18n';
 import PinsAllSkySessionCard from './PinsAllSkySessionCard.vue';
 
-defineProps({
+const props = defineProps({
   isOpen: {
     type: Boolean,
     default: false,
@@ -145,6 +152,10 @@ defineProps({
   detailsLoadingById: {
     type: Object,
     default: () => ({}),
+  },
+  isActionBusy: {
+    type: Function,
+    required: true,
   },
   sessionDetailOpen: {
     type: Object,
@@ -185,4 +196,5 @@ defineEmits([
 ]);
 
 const { t } = useI18n({ useScope: 'global' });
+const isDeleteAllBusy = () => props.isActionBusy('sessions:delete-all');
 </script>

--- a/src/plugins/pins-allsky/components/PinsAllSkySessionCard.vue
+++ b/src/plugins/pins-allsky/components/PinsAllSkySessionCard.vue
@@ -40,19 +40,30 @@
 
       <div class="flex flex-wrap gap-2">
         <button
-          class="rounded-lg border border-cyan-500/40 bg-cyan-500/10 px-3 py-2 text-sm font-medium text-cyan-100 transition hover:bg-cyan-500/20 disabled:cursor-not-allowed disabled:opacity-40"
-          :disabled="cleanupBusy"
+          class="rounded-lg border px-3 py-2 text-sm font-medium transition disabled:cursor-not-allowed disabled:opacity-40"
+          :class="
+            isGenerateBusy()
+              ? 'border-cyan-300/50 bg-cyan-500/30 text-white ring-2 ring-cyan-300/20'
+              : 'border-cyan-500/40 bg-cyan-500/10 text-cyan-100 hover:bg-cyan-500/20'
+          "
+          :disabled="cleanupBusy || isGenerateBusy()"
           @click="$emit('generate-artifacts', session.id)"
         >
           {{ t('plugins.pinsAllSky.buttons.regenerate') }}
         </button>
         <button
-          class="inline-flex h-10 w-10 items-center justify-center rounded-lg border border-rose-500/40 bg-rose-500/10 text-rose-100 transition hover:bg-rose-500/20 disabled:cursor-not-allowed disabled:opacity-40"
+          class="inline-flex h-10 w-10 items-center justify-center rounded-lg border text-rose-100 transition disabled:cursor-not-allowed disabled:opacity-40"
+          :class="
+            isDeleteSessionBusy()
+              ? 'border-rose-300/50 bg-rose-500/30 text-white ring-2 ring-rose-300/20'
+              : 'border-rose-500/40 bg-rose-500/10 hover:bg-rose-500/20'
+          "
           :disabled="
             cleanupBusy ||
             status?.captureRunning ||
             status?.generateInProgress ||
-            session.id === currentSessionId
+            session.id === currentSessionId ||
+            isDeleteSessionBusy()
           "
           :title="t('plugins.pinsAllSky.buttons.deleteSession')"
           :aria-label="t('plugins.pinsAllSky.buttons.deleteSession')"
@@ -61,7 +72,12 @@
           <TrashIcon class="h-5 w-5" />
         </button>
         <button
-          class="inline-flex h-10 items-center justify-center gap-2 rounded-lg border border-gray-600 bg-gray-800 px-3 py-2 text-sm text-white transition hover:border-cyan-400"
+          class="inline-flex h-10 items-center justify-center gap-2 rounded-lg border bg-gray-800 px-3 py-2 text-sm text-white transition"
+          :class="
+            isRefreshDetailsBusy()
+              ? 'border-cyan-300/50 ring-2 ring-cyan-300/20'
+              : 'border-gray-600 hover:border-cyan-400'
+          "
           :title="
             detailsOpen
               ? t('plugins.pinsAllSky.buttons.hideStoredFiles')
@@ -90,19 +106,39 @@
           <div>{{ describeArtifact(session.products?.timelapse) }}</div>
           <div v-if="session.products?.timelapse" class="flex items-center gap-2">
             <button
-              class="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-cyan-500/40 bg-cyan-500/10 text-cyan-100 transition hover:bg-cyan-500/20"
+              class="inline-flex h-9 w-9 items-center justify-center rounded-lg border text-cyan-100 transition"
+              :class="
+                isArtifactDownloadBusy(session.products.timelapse)
+                  ? 'border-cyan-300/50 bg-cyan-500/30 text-white ring-2 ring-cyan-300/20'
+                  : 'border-cyan-500/40 bg-cyan-500/10 hover:bg-cyan-500/20'
+              "
               :title="t('plugins.pinsAllSky.buttons.downloadTimelapse')"
               :aria-label="t('plugins.pinsAllSky.buttons.downloadTimelapse')"
+              :disabled="isArtifactDownloadBusy(session.products.timelapse)"
               @click="
-                $emit('download-file', { relativePath: session.products.timelapse.relativePath })
+                $emit('download-file', {
+                  relativePath: session.products.timelapse.relativePath,
+                  fallbackName: artifactDownloadName('timelapse', 'mp4'),
+                })
               "
             >
-              <ArrowDownTrayIcon class="h-4 w-4" />
+              <ArrowDownTrayIcon
+                class="h-4 w-4"
+                :class="isArtifactDownloadBusy(session.products.timelapse) ? 'animate-pulse' : ''"
+              />
             </button>
             <button
-              class="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-rose-500/40 bg-rose-500/10 text-rose-100 transition hover:bg-rose-500/20 disabled:cursor-not-allowed disabled:opacity-40"
+              class="inline-flex h-9 w-9 items-center justify-center rounded-lg border text-rose-100 transition disabled:cursor-not-allowed disabled:opacity-40"
+              :class="
+                isArtifactDeleteBusy(session.products.timelapse)
+                  ? 'border-rose-300/50 bg-rose-500/30 text-white ring-2 ring-rose-300/20'
+                  : 'border-rose-500/40 bg-rose-500/10 hover:bg-rose-500/20'
+              "
               :disabled="
-                cleanupBusy || status?.generateInProgress || session.id === currentSessionId
+                cleanupBusy ||
+                status?.generateInProgress ||
+                session.id === currentSessionId ||
+                isArtifactDeleteBusy(session.products.timelapse)
               "
               :title="t('plugins.pinsAllSky.buttons.deleteTimelapse')"
               :aria-label="t('plugins.pinsAllSky.buttons.deleteTimelapse')"
@@ -121,19 +157,39 @@
           <div>{{ describeArtifact(session.products?.keogram) }}</div>
           <div v-if="session.products?.keogram" class="flex items-center gap-2">
             <button
-              class="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-cyan-500/40 bg-cyan-500/10 text-cyan-100 transition hover:bg-cyan-500/20"
+              class="inline-flex h-9 w-9 items-center justify-center rounded-lg border text-cyan-100 transition"
+              :class="
+                isArtifactDownloadBusy(session.products.keogram)
+                  ? 'border-cyan-300/50 bg-cyan-500/30 text-white ring-2 ring-cyan-300/20'
+                  : 'border-cyan-500/40 bg-cyan-500/10 hover:bg-cyan-500/20'
+              "
               :title="t('plugins.pinsAllSky.buttons.downloadKeogram')"
               :aria-label="t('plugins.pinsAllSky.buttons.downloadKeogram')"
+              :disabled="isArtifactDownloadBusy(session.products.keogram)"
               @click="
-                $emit('download-file', { relativePath: session.products.keogram.relativePath })
+                $emit('download-file', {
+                  relativePath: session.products.keogram.relativePath,
+                  fallbackName: artifactDownloadName('keogram', 'jpg'),
+                })
               "
             >
-              <ArrowDownTrayIcon class="h-4 w-4" />
+              <ArrowDownTrayIcon
+                class="h-4 w-4"
+                :class="isArtifactDownloadBusy(session.products.keogram) ? 'animate-pulse' : ''"
+              />
             </button>
             <button
-              class="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-rose-500/40 bg-rose-500/10 text-rose-100 transition hover:bg-rose-500/20 disabled:cursor-not-allowed disabled:opacity-40"
+              class="inline-flex h-9 w-9 items-center justify-center rounded-lg border text-rose-100 transition disabled:cursor-not-allowed disabled:opacity-40"
+              :class="
+                isArtifactDeleteBusy(session.products.keogram)
+                  ? 'border-rose-300/50 bg-rose-500/30 text-white ring-2 ring-rose-300/20'
+                  : 'border-rose-500/40 bg-rose-500/10 hover:bg-rose-500/20'
+              "
               :disabled="
-                cleanupBusy || status?.generateInProgress || session.id === currentSessionId
+                cleanupBusy ||
+                status?.generateInProgress ||
+                session.id === currentSessionId ||
+                isArtifactDeleteBusy(session.products.keogram)
               "
               :title="t('plugins.pinsAllSky.buttons.deleteKeogram')"
               :aria-label="t('plugins.pinsAllSky.buttons.deleteKeogram')"
@@ -152,19 +208,39 @@
           <div>{{ describeArtifact(session.products?.startrails) }}</div>
           <div v-if="session.products?.startrails" class="flex items-center gap-2">
             <button
-              class="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-cyan-500/40 bg-cyan-500/10 text-cyan-100 transition hover:bg-cyan-500/20"
+              class="inline-flex h-9 w-9 items-center justify-center rounded-lg border text-cyan-100 transition"
+              :class="
+                isArtifactDownloadBusy(session.products.startrails)
+                  ? 'border-cyan-300/50 bg-cyan-500/30 text-white ring-2 ring-cyan-300/20'
+                  : 'border-cyan-500/40 bg-cyan-500/10 hover:bg-cyan-500/20'
+              "
               :title="t('plugins.pinsAllSky.buttons.downloadStartrails')"
               :aria-label="t('plugins.pinsAllSky.buttons.downloadStartrails')"
+              :disabled="isArtifactDownloadBusy(session.products.startrails)"
               @click="
-                $emit('download-file', { relativePath: session.products.startrails.relativePath })
+                $emit('download-file', {
+                  relativePath: session.products.startrails.relativePath,
+                  fallbackName: artifactDownloadName('startrails', 'jpg'),
+                })
               "
             >
-              <ArrowDownTrayIcon class="h-4 w-4" />
+              <ArrowDownTrayIcon
+                class="h-4 w-4"
+                :class="isArtifactDownloadBusy(session.products.startrails) ? 'animate-pulse' : ''"
+              />
             </button>
             <button
-              class="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-rose-500/40 bg-rose-500/10 text-rose-100 transition hover:bg-rose-500/20 disabled:cursor-not-allowed disabled:opacity-40"
+              class="inline-flex h-9 w-9 items-center justify-center rounded-lg border text-rose-100 transition disabled:cursor-not-allowed disabled:opacity-40"
+              :class="
+                isArtifactDeleteBusy(session.products.startrails)
+                  ? 'border-rose-300/50 bg-rose-500/30 text-white ring-2 ring-rose-300/20'
+                  : 'border-rose-500/40 bg-rose-500/10 hover:bg-rose-500/20'
+              "
               :disabled="
-                cleanupBusy || status?.generateInProgress || session.id === currentSessionId
+                cleanupBusy ||
+                status?.generateInProgress ||
+                session.id === currentSessionId ||
+                isArtifactDeleteBusy(session.products.startrails)
               "
               :title="t('plugins.pinsAllSky.buttons.deleteStartrails')"
               :aria-label="t('plugins.pinsAllSky.buttons.deleteStartrails')"
@@ -192,7 +268,13 @@
           </div>
         </div>
         <button
-          class="rounded-lg border border-gray-600 bg-gray-900/70 px-3 py-2 text-xs text-gray-200 transition hover:border-cyan-400"
+          class="rounded-lg border bg-gray-900/70 px-3 py-2 text-xs text-gray-200 transition"
+          :class="
+            isRefreshDetailsBusy()
+              ? 'border-cyan-300/50 ring-2 ring-cyan-300/20'
+              : 'border-gray-600 hover:border-cyan-400'
+          "
+          :disabled="isRefreshDetailsBusy()"
           @click="$emit('refresh-session-details', session.id)"
         >
           {{ t('plugins.pinsAllSky.buttons.refreshFiles') }}
@@ -225,9 +307,15 @@
           </div>
           <div class="flex items-center gap-2">
             <button
-              class="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-cyan-500/40 bg-cyan-500/10 text-cyan-100 transition hover:bg-cyan-500/20"
+              class="inline-flex h-9 w-9 items-center justify-center rounded-lg border text-cyan-100 transition"
+              :class="
+                isFrameDownloadBusy(frame)
+                  ? 'border-cyan-300/50 bg-cyan-500/30 text-white ring-2 ring-cyan-300/20'
+                  : 'border-cyan-500/40 bg-cyan-500/10 hover:bg-cyan-500/20'
+              "
               :title="t('plugins.pinsAllSky.buttons.downloadItem', { name: frame.name })"
               :aria-label="t('plugins.pinsAllSky.buttons.downloadItem', { name: frame.name })"
+              :disabled="isFrameDownloadBusy(frame)"
               @click="
                 $emit('download-file', {
                   relativePath: frame.relativePath,
@@ -235,12 +323,23 @@
                 })
               "
             >
-              <ArrowDownTrayIcon class="h-4 w-4" />
+              <ArrowDownTrayIcon
+                class="h-4 w-4"
+                :class="isFrameDownloadBusy(frame) ? 'animate-pulse' : ''"
+              />
             </button>
             <button
-              class="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-rose-500/40 bg-rose-500/10 text-rose-100 transition hover:bg-rose-500/20 disabled:cursor-not-allowed disabled:opacity-40"
+              class="inline-flex h-9 w-9 items-center justify-center rounded-lg border text-rose-100 transition disabled:cursor-not-allowed disabled:opacity-40"
+              :class="
+                isFrameDeleteBusy(frame)
+                  ? 'border-rose-300/50 bg-rose-500/30 text-white ring-2 ring-rose-300/20'
+                  : 'border-rose-500/40 bg-rose-500/10 hover:bg-rose-500/20'
+              "
               :disabled="
-                cleanupBusy || status?.generateInProgress || session.id === currentSessionId
+                cleanupBusy ||
+                status?.generateInProgress ||
+                session.id === currentSessionId ||
+                isFrameDeleteBusy(frame)
               "
               :title="t('plugins.pinsAllSky.buttons.deleteItem', { name: frame.name })"
               :aria-label="t('plugins.pinsAllSky.buttons.deleteItem', { name: frame.name })"
@@ -264,7 +363,7 @@ import {
 } from '@heroicons/vue/24/outline';
 import { useI18n } from 'vue-i18n';
 
-defineProps({
+const props = defineProps({
   session: {
     type: Object,
     required: true,
@@ -292,6 +391,10 @@ defineProps({
   detailsOpen: {
     type: Boolean,
     default: false,
+  },
+  isActionBusy: {
+    type: Function,
+    required: true,
   },
   formatDate: {
     type: Function,
@@ -326,4 +429,51 @@ defineEmits([
 ]);
 
 const { t } = useI18n({ useScope: 'global' });
+
+const sessionSlug = () =>
+  sanitizeDownloadName(props.session.label || props.session.id || 'session');
+const artifactDownloadName = (prefix, extension) => `${prefix}_${sessionSlug()}.${extension}`;
+const isGenerateBusy = () => props.isActionBusy(`session:generate:${props.session.id}`);
+const isDeleteSessionBusy = () => props.isActionBusy(`session:delete:${props.session.id}`);
+const isRefreshDetailsBusy = () => props.isActionBusy(`session:details:${props.session.id}`);
+const isArtifactDeleteBusy = (artifact) =>
+  props.isActionBusy(`artifact:delete:${props.session.id}:${artifact?.relativePath || ''}`);
+const isArtifactDownloadBusy = (artifact) =>
+  props.isActionBusy(
+    `download:${artifact?.relativePath || ''}:${artifactDownloadName(
+      pathLikeName(artifact?.relativePath),
+      pathLikeExtension(artifact?.relativePath)
+    )}`
+  );
+const isFrameDeleteBusy = (frame) =>
+  props.isActionBusy(`frame:delete:${props.session.id}:${frame?.relativePath || ''}`);
+const isFrameDownloadBusy = (frame) =>
+  props.isActionBusy(`download:${frame?.relativePath || ''}:${frame?.name || ''}`);
+
+function sanitizeDownloadName(value) {
+  return (
+    String(value || 'session')
+      .trim()
+      .replace(/\s+/g, '_')
+      .replace(/[\\/:*?"<>|]+/g, '_')
+      .replace(/^[_\.]+|[_\.]+$/g, '') || 'session'
+  );
+}
+
+function pathLikeName(relativePath) {
+  const fileName =
+    String(relativePath || '')
+      .split('/')
+      .pop() || '';
+  return fileName.includes('.') ? fileName.slice(0, fileName.lastIndexOf('.')) : fileName;
+}
+
+function pathLikeExtension(relativePath) {
+  const fileName =
+    String(relativePath || '')
+      .split('/')
+      .pop() || '';
+  const extension = fileName.includes('.') ? fileName.slice(fileName.lastIndexOf('.') + 1) : '';
+  return extension || 'bin';
+}
 </script>

--- a/src/plugins/pins-allsky/components/PinsAllSkySessionControls.vue
+++ b/src/plugins/pins-allsky/components/PinsAllSkySessionControls.vue
@@ -19,11 +19,16 @@
             type="button"
             :title="t('plugins.pinsAllSky.buttons.startCapture')"
             :aria-label="t('plugins.pinsAllSky.buttons.startCapture')"
-            class="inline-flex h-11 w-11 items-center justify-center rounded-xl bg-emerald-600 text-white transition hover:bg-emerald-500 disabled:cursor-not-allowed disabled:opacity-40"
-            :disabled="loading || status?.captureRunning"
+            class="inline-flex h-11 w-11 items-center justify-center rounded-xl text-white transition disabled:cursor-not-allowed disabled:opacity-40"
+            :class="
+              isStartBusy()
+                ? 'bg-emerald-400/70 ring-2 ring-emerald-300/40'
+                : 'bg-emerald-600 hover:bg-emerald-500'
+            "
+            :disabled="loading || status?.captureRunning || isStartBusy()"
             @click="$emit('start-session')"
           >
-            <PlayIcon class="h-5 w-5" />
+            <PlayIcon class="h-5 w-5" :class="isStartBusy() ? 'animate-pulse' : ''" />
           </button>
           <button
             type="button"
@@ -37,29 +42,40 @@
                 ? t('plugins.pinsAllSky.buttons.renderingProgress')
                 : t('plugins.pinsAllSky.buttons.renderProgress')
             "
-            class="inline-flex h-11 w-11 items-center justify-center rounded-xl border border-cyan-500/40 bg-cyan-500/10 text-cyan-100 transition hover:bg-cyan-500/20 disabled:cursor-not-allowed disabled:opacity-40"
+            class="inline-flex h-11 w-11 items-center justify-center rounded-xl border text-cyan-100 transition disabled:cursor-not-allowed disabled:opacity-40"
+            :class="
+              isGenerateBusy()
+                ? 'border-cyan-300/50 bg-cyan-500/30 text-white ring-2 ring-cyan-300/20'
+                : 'border-cyan-500/40 bg-cyan-500/10 hover:bg-cyan-500/20'
+            "
             :disabled="
               loading ||
               !status?.captureRunning ||
               !currentSession?.captureCount ||
-              status?.generateInProgress
+              status?.generateInProgress ||
+              isGenerateBusy()
             "
             @click="$emit('generate-artifacts')"
           >
             <ArrowDownTrayIcon
               class="h-5 w-5"
-              :class="status?.generateInProgress ? 'animate-pulse' : ''"
+              :class="status?.generateInProgress || isGenerateBusy() ? 'animate-pulse' : ''"
             />
           </button>
           <button
             type="button"
             :title="t('plugins.pinsAllSky.buttons.stopAndRender')"
             :aria-label="t('plugins.pinsAllSky.buttons.stopAndRender')"
-            class="inline-flex h-11 w-11 items-center justify-center rounded-xl bg-rose-600 text-white transition hover:bg-rose-500 disabled:cursor-not-allowed disabled:opacity-40"
-            :disabled="loading || !status?.captureRunning"
+            class="inline-flex h-11 w-11 items-center justify-center rounded-xl text-white transition disabled:cursor-not-allowed disabled:opacity-40"
+            :class="
+              isStopBusy()
+                ? 'bg-rose-400/70 ring-2 ring-rose-300/40'
+                : 'bg-rose-600 hover:bg-rose-500'
+            "
+            :disabled="loading || !status?.captureRunning || isStopBusy()"
             @click="$emit('stop-session')"
           >
-            <StopIcon class="h-5 w-5" />
+            <StopIcon class="h-5 w-5" :class="isStopBusy() ? 'animate-pulse' : ''" />
           </button>
         </div>
       </div>
@@ -104,11 +120,19 @@
                   ? t('plugins.pinsAllSky.buttons.refreshingPreview')
                   : t('plugins.pinsAllSky.buttons.refreshPreview')
               "
-              class="inline-flex h-10 w-10 items-center justify-center rounded-xl border border-white/10 bg-black/45 text-gray-200 backdrop-blur-sm transition hover:border-cyan-400 hover:text-white disabled:cursor-not-allowed disabled:opacity-40"
-              :disabled="loading"
+              class="inline-flex h-10 w-10 items-center justify-center rounded-xl border bg-black/45 text-gray-200 backdrop-blur-sm transition hover:text-white disabled:cursor-not-allowed disabled:opacity-40"
+              :class="
+                isRefreshBusy()
+                  ? 'border-cyan-300/50 text-white ring-2 ring-cyan-300/20'
+                  : 'border-white/10 hover:border-cyan-400'
+              "
+              :disabled="loading || isRefreshBusy()"
               @click="$emit('refresh-all')"
             >
-              <ArrowPathIcon class="h-5 w-5" :class="loading ? 'animate-spin' : ''" />
+              <ArrowPathIcon
+                class="h-5 w-5"
+                :class="loading || isRefreshBusy() ? 'animate-spin' : ''"
+              />
             </button>
           </div>
 
@@ -242,7 +266,7 @@
 import { ArrowDownTrayIcon, ArrowPathIcon, PlayIcon, StopIcon } from '@heroicons/vue/24/outline';
 import { useI18n } from 'vue-i18n';
 
-defineProps({
+const props = defineProps({
   manualLabel: {
     type: String,
     default: '',
@@ -254,6 +278,10 @@ defineProps({
   loading: {
     type: Boolean,
     default: false,
+  },
+  isActionBusy: {
+    type: Function,
+    required: true,
   },
   status: {
     type: Object,
@@ -336,4 +364,10 @@ defineEmits([
 ]);
 
 const { t } = useI18n({ useScope: 'global' });
+
+const isStartBusy = () => props.isActionBusy('session:start');
+const isStopBusy = () => props.isActionBusy('session:stop');
+const isRefreshBusy = () => props.isActionBusy('status:refresh');
+const isGenerateBusy = () =>
+  props.isActionBusy(`session:generate:${props.currentSession?.id || 'latest'}`);
 </script>

--- a/src/plugins/pins-allsky/components/PinsAllSkySessionControls.vue
+++ b/src/plugins/pins-allsky/components/PinsAllSkySessionControls.vue
@@ -119,7 +119,11 @@
               {{ t('plugins.pinsAllSky.preview.session') }}
             </div>
             <div class="mt-1 text-sm font-medium text-white">
-              {{ currentSession?.id || t('plugins.pinsAllSky.preview.noActiveSession') }}
+              {{
+                currentSession?.label ||
+                currentSession?.id ||
+                t('plugins.pinsAllSky.preview.noActiveSession')
+              }}
             </div>
           </div>
 
@@ -150,11 +154,19 @@
               </div>
               <div>
                 <span class="text-gray-300">{{ t('plugins.pinsAllSky.preview.exposure') }}</span>
-                {{ formatExposure(config?.camera) }}
+                {{ formatExposure(config?.camera, currentSession) }}
               </div>
               <div>
                 <span class="text-gray-300">{{ t('plugins.pinsAllSky.preview.gain') }}</span>
-                {{ formatGain(config?.camera) }}
+                {{ formatGain(config?.camera, currentSession) }}
+              </div>
+              <div>
+                <span class="text-gray-300">{{ t('plugins.pinsAllSky.preview.mean') }}</span>
+                {{
+                  Number.isFinite(Number(currentSession?.lastMeanBrightness))
+                    ? Number(currentSession?.lastMeanBrightness).toFixed(3)
+                    : t('plugins.pinsAllSky.common.notAvailable')
+                }}
               </div>
             </div>
           </div>

--- a/src/plugins/pins-allsky/store/pinsAllskyStore.js
+++ b/src/plugins/pins-allsky/store/pinsAllskyStore.js
@@ -16,6 +16,7 @@ export const usePinsAllSkyStore = defineStore('pinsAllSkyStore', {
     saving: false,
     cleanupBusy: false,
     backendUpdateBusy: false,
+    actionBusyByKey: {},
     manualLabel: '',
     actionMessage: null,
     sessionDetailsById: {},
@@ -65,14 +66,16 @@ export const usePinsAllSkyStore = defineStore('pinsAllSkyStore', {
     },
 
     async refreshAll() {
-      this.loading = true;
-      try {
-        await Promise.all([this.fetchStatus(), this.fetchConfig()]);
-      } catch (error) {
-        this.error = error?.message || i18n.global.t('plugins.pinsAllSky.errors.connectBackend');
-      } finally {
-        this.loading = false;
-      }
+      return this.withAction('status:refresh', async () => {
+        this.loading = true;
+        try {
+          await Promise.all([this.fetchStatus(), this.fetchConfig()]);
+        } catch (error) {
+          this.error = error?.message || i18n.global.t('plugins.pinsAllSky.errors.connectBackend');
+        } finally {
+          this.loading = false;
+        }
+      });
     },
 
     async saveConfig() {
@@ -94,125 +97,139 @@ export const usePinsAllSkyStore = defineStore('pinsAllSkyStore', {
     },
 
     async startSession() {
-      try {
-        const { data } = await axios.post(`${this.backendBaseUrl}/api/session/start`, {
-          label: this.manualLabel || null,
-        });
+      return this.withAction('session:start', async () => {
+        try {
+          const { data } = await axios.post(`${this.backendBaseUrl}/api/session/start`, {
+            label: this.manualLabel || null,
+          });
 
-        if (!data.success) {
-          throw new Error(data.error || i18n.global.t('plugins.pinsAllSky.errors.startSession'));
+          if (!data.success) {
+            throw new Error(data.error || i18n.global.t('plugins.pinsAllSky.errors.startSession'));
+          }
+
+          this.manualLabel = '';
+          await this.fetchStatus();
+          this.error = null;
+        } catch (error) {
+          this.error = error?.message || i18n.global.t('plugins.pinsAllSky.errors.startSession');
         }
-
-        this.manualLabel = '';
-        await this.fetchStatus();
-        this.error = null;
-      } catch (error) {
-        this.error = error?.message || i18n.global.t('plugins.pinsAllSky.errors.startSession');
-      }
+      });
     },
 
     async stopSession(generateArtifacts = true) {
-      try {
-        const { data } = await axios.post(`${this.backendBaseUrl}/api/session/stop`, {
-          generateArtifacts,
-        });
+      return this.withAction('session:stop', async () => {
+        try {
+          const { data } = await axios.post(`${this.backendBaseUrl}/api/session/stop`, {
+            generateArtifacts,
+          });
 
-        if (!data.success) {
-          throw new Error(data.error || i18n.global.t('plugins.pinsAllSky.errors.stopSession'));
+          if (!data.success) {
+            throw new Error(data.error || i18n.global.t('plugins.pinsAllSky.errors.stopSession'));
+          }
+
+          await this.fetchStatus();
+          this.error = null;
+        } catch (error) {
+          this.error = error?.message || i18n.global.t('plugins.pinsAllSky.errors.stopSession');
         }
-
-        await this.fetchStatus();
-        this.error = null;
-      } catch (error) {
-        this.error = error?.message || i18n.global.t('plugins.pinsAllSky.errors.stopSession');
-      }
+      });
     },
 
     async generateArtifacts(sessionId = null) {
-      try {
-        const { data } = await axios.post(`${this.backendBaseUrl}/api/session/generate`, {
-          sessionId,
-        });
+      const actionKey = `session:generate:${sessionId || this.status?.currentSession?.id || 'latest'}`;
 
-        if (!data.success) {
-          throw new Error(
-            data.error || i18n.global.t('plugins.pinsAllSky.errors.generateArtifacts')
-          );
+      return this.withAction(actionKey, async () => {
+        try {
+          const { data } = await axios.post(`${this.backendBaseUrl}/api/session/generate`, {
+            sessionId,
+          });
+
+          if (!data.success) {
+            throw new Error(
+              data.error || i18n.global.t('plugins.pinsAllSky.errors.generateArtifacts')
+            );
+          }
+
+          await this.fetchStatus();
+          this.error = null;
+        } catch (error) {
+          this.error =
+            error?.message || i18n.global.t('plugins.pinsAllSky.errors.generateArtifacts');
         }
-
-        await this.fetchStatus();
-        this.error = null;
-      } catch (error) {
-        this.error = error?.message || i18n.global.t('plugins.pinsAllSky.errors.generateArtifacts');
-      }
+      });
     },
 
     async deleteSession(sessionId) {
-      this.cleanupBusy = true;
-      try {
-        const { data } = await axios.post(`${this.backendBaseUrl}/api/session/delete`, {
-          sessionId,
-        });
+      return this.withAction(`session:delete:${sessionId}`, async () => {
+        this.cleanupBusy = true;
+        try {
+          const { data } = await axios.post(`${this.backendBaseUrl}/api/session/delete`, {
+            sessionId,
+          });
 
-        if (!data.success) {
-          throw new Error(data.error || i18n.global.t('plugins.pinsAllSky.errors.deleteSession'));
+          if (!data.success) {
+            throw new Error(data.error || i18n.global.t('plugins.pinsAllSky.errors.deleteSession'));
+          }
+
+          const deletedSessionCount = data.data?.deletedSessionCount || 0;
+          const freedBytes = data.data?.freedBytes || 0;
+          const remainingUsed = data.data?.storage?.pluginUsedBytes ?? 0;
+          this.actionMessage =
+            deletedSessionCount === 0
+              ? i18n.global.t('plugins.pinsAllSky.messages.noSessionsDeleted')
+              : i18n.global.t('plugins.pinsAllSky.messages.deletedSessions', {
+                  count: deletedSessionCount,
+                  suffix: deletedSessionCount === 1 ? '' : 's',
+                  freed: this.formatSize(freedBytes),
+                  remaining: this.formatSize(remainingUsed),
+                });
+          delete this.sessionDetailsById[sessionId];
+          delete this.detailsLoadingById[sessionId];
+          await this.fetchStatus();
+          this.error = null;
+        } catch (error) {
+          this.error = error?.message || i18n.global.t('plugins.pinsAllSky.errors.deleteSession');
+        } finally {
+          this.cleanupBusy = false;
         }
-
-        const deletedSessionCount = data.data?.deletedSessionCount || 0;
-        const freedBytes = data.data?.freedBytes || 0;
-        const remainingUsed = data.data?.storage?.pluginUsedBytes ?? 0;
-        this.actionMessage =
-          deletedSessionCount === 0
-            ? i18n.global.t('plugins.pinsAllSky.messages.noSessionsDeleted')
-            : i18n.global.t('plugins.pinsAllSky.messages.deletedSessions', {
-                count: deletedSessionCount,
-                suffix: deletedSessionCount === 1 ? '' : 's',
-                freed: this.formatSize(freedBytes),
-                remaining: this.formatSize(remainingUsed),
-              });
-        delete this.sessionDetailsById[sessionId];
-        delete this.detailsLoadingById[sessionId];
-        await this.fetchStatus();
-        this.error = null;
-      } catch (error) {
-        this.error = error?.message || i18n.global.t('plugins.pinsAllSky.errors.deleteSession');
-      } finally {
-        this.cleanupBusy = false;
-      }
+      });
     },
 
     async deleteAllSessions() {
-      this.cleanupBusy = true;
-      try {
-        const { data } = await axios.post(`${this.backendBaseUrl}/api/sessions/delete-all`, {});
+      return this.withAction('sessions:delete-all', async () => {
+        this.cleanupBusy = true;
+        try {
+          const { data } = await axios.post(`${this.backendBaseUrl}/api/sessions/delete-all`, {});
 
-        if (!data.success) {
-          throw new Error(
-            data.error || i18n.global.t('plugins.pinsAllSky.errors.deleteAllSessions')
-          );
+          if (!data.success) {
+            throw new Error(
+              data.error || i18n.global.t('plugins.pinsAllSky.errors.deleteAllSessions')
+            );
+          }
+
+          const deletedSessionCount = data.data?.deletedSessionCount || 0;
+          const freedBytes = data.data?.freedBytes || 0;
+          const remainingUsed = data.data?.storage?.pluginUsedBytes ?? 0;
+          this.actionMessage =
+            deletedSessionCount === 0
+              ? i18n.global.t('plugins.pinsAllSky.messages.noSessionsDeleted')
+              : i18n.global.t('plugins.pinsAllSky.messages.deletedSessions', {
+                  count: deletedSessionCount,
+                  suffix: deletedSessionCount === 1 ? '' : 's',
+                  freed: this.formatSize(freedBytes),
+                  remaining: this.formatSize(remainingUsed),
+                });
+          this.sessionDetailsById = {};
+          this.detailsLoadingById = {};
+          await this.fetchStatus();
+          this.error = null;
+        } catch (error) {
+          this.error =
+            error?.message || i18n.global.t('plugins.pinsAllSky.errors.deleteAllSessions');
+        } finally {
+          this.cleanupBusy = false;
         }
-
-        const deletedSessionCount = data.data?.deletedSessionCount || 0;
-        const freedBytes = data.data?.freedBytes || 0;
-        const remainingUsed = data.data?.storage?.pluginUsedBytes ?? 0;
-        this.actionMessage =
-          deletedSessionCount === 0
-            ? i18n.global.t('plugins.pinsAllSky.messages.noSessionsDeleted')
-            : i18n.global.t('plugins.pinsAllSky.messages.deletedSessions', {
-                count: deletedSessionCount,
-                suffix: deletedSessionCount === 1 ? '' : 's',
-                freed: this.formatSize(freedBytes),
-                remaining: this.formatSize(remainingUsed),
-              });
-        this.sessionDetailsById = {};
-        this.detailsLoadingById = {};
-        await this.fetchStatus();
-        this.error = null;
-      } catch (error) {
-        this.error = error?.message || i18n.global.t('plugins.pinsAllSky.errors.deleteAllSessions');
-      } finally {
-        this.cleanupBusy = false;
-      }
+      });
     },
 
     async fetchSessionDetails(sessionId) {
@@ -220,114 +237,164 @@ export const usePinsAllSkyStore = defineStore('pinsAllSkyStore', {
         return null;
       }
 
-      this.detailsLoadingById = {
-        ...this.detailsLoadingById,
-        [sessionId]: true,
-      };
-
-      try {
-        const { data } = await axios.post(`${this.backendBaseUrl}/api/session/details`, {
-          sessionId,
-        });
-
-        if (!data.success) {
-          throw new Error(
-            data.error || i18n.global.t('plugins.pinsAllSky.errors.loadSessionDetails')
-          );
-        }
-
-        this.sessionDetailsById = {
-          ...this.sessionDetailsById,
-          [sessionId]: data.data,
-        };
-        this.error = null;
-        return data.data;
-      } catch (error) {
-        this.error =
-          error?.message || i18n.global.t('plugins.pinsAllSky.errors.loadSessionDetails');
-        return null;
-      } finally {
+      return this.withAction(`session:details:${sessionId}`, async () => {
         this.detailsLoadingById = {
           ...this.detailsLoadingById,
-          [sessionId]: false,
+          [sessionId]: true,
         };
-      }
+
+        try {
+          const { data } = await axios.post(`${this.backendBaseUrl}/api/session/details`, {
+            sessionId,
+          });
+
+          if (!data.success) {
+            throw new Error(
+              data.error || i18n.global.t('plugins.pinsAllSky.errors.loadSessionDetails')
+            );
+          }
+
+          this.sessionDetailsById = {
+            ...this.sessionDetailsById,
+            [sessionId]: data.data,
+          };
+          this.error = null;
+          return data.data;
+        } catch (error) {
+          this.error =
+            error?.message || i18n.global.t('plugins.pinsAllSky.errors.loadSessionDetails');
+          return null;
+        } finally {
+          this.detailsLoadingById = {
+            ...this.detailsLoadingById,
+            [sessionId]: false,
+          };
+        }
+      });
     },
 
     async deleteArtifact(sessionId, relativePath) {
-      this.cleanupBusy = true;
-      try {
-        const { data } = await axios.post(`${this.backendBaseUrl}/api/session/artifact/delete`, {
-          sessionId,
-          relativePath,
-        });
+      const actionKey = `artifact:delete:${sessionId}:${relativePath}`;
 
-        if (!data.success) {
-          throw new Error(data.error || i18n.global.t('plugins.pinsAllSky.errors.deleteArtifact'));
+      return this.withAction(actionKey, async () => {
+        this.cleanupBusy = true;
+        try {
+          const { data } = await axios.post(`${this.backendBaseUrl}/api/session/artifact/delete`, {
+            sessionId,
+            relativePath,
+          });
+
+          if (!data.success) {
+            throw new Error(
+              data.error || i18n.global.t('plugins.pinsAllSky.errors.deleteArtifact')
+            );
+          }
+
+          this.actionMessage = i18n.global.t('plugins.pinsAllSky.messages.deletedArtifact', {
+            freed: this.formatSize(data.data?.freedBytes || 0),
+          });
+          await Promise.all([this.fetchStatus(), this.fetchSessionDetails(sessionId)]);
+          this.error = null;
+        } catch (error) {
+          this.error = error?.message || i18n.global.t('plugins.pinsAllSky.errors.deleteArtifact');
+        } finally {
+          this.cleanupBusy = false;
         }
-
-        this.actionMessage = i18n.global.t('plugins.pinsAllSky.messages.deletedArtifact', {
-          freed: this.formatSize(data.data?.freedBytes || 0),
-        });
-        await Promise.all([this.fetchStatus(), this.fetchSessionDetails(sessionId)]);
-        this.error = null;
-      } catch (error) {
-        this.error = error?.message || i18n.global.t('plugins.pinsAllSky.errors.deleteArtifact');
-      } finally {
-        this.cleanupBusy = false;
-      }
+      });
     },
 
     async deleteFrame(sessionId, relativePath) {
-      this.cleanupBusy = true;
-      try {
-        const { data } = await axios.post(`${this.backendBaseUrl}/api/session/frame/delete`, {
-          sessionId,
-          relativePath,
-        });
+      const actionKey = `frame:delete:${sessionId}:${relativePath}`;
 
-        if (!data.success) {
-          throw new Error(data.error || i18n.global.t('plugins.pinsAllSky.errors.deleteFrame'));
+      return this.withAction(actionKey, async () => {
+        this.cleanupBusy = true;
+        try {
+          const { data } = await axios.post(`${this.backendBaseUrl}/api/session/frame/delete`, {
+            sessionId,
+            relativePath,
+          });
+
+          if (!data.success) {
+            throw new Error(data.error || i18n.global.t('plugins.pinsAllSky.errors.deleteFrame'));
+          }
+
+          this.actionMessage = i18n.global.t('plugins.pinsAllSky.messages.deletedFrame', {
+            freed: this.formatSize(data.data?.freedBytes || 0),
+          });
+          await Promise.all([this.fetchStatus(), this.fetchSessionDetails(sessionId)]);
+          this.error = null;
+        } catch (error) {
+          this.error = error?.message || i18n.global.t('plugins.pinsAllSky.errors.deleteFrame');
+        } finally {
+          this.cleanupBusy = false;
         }
-
-        this.actionMessage = i18n.global.t('plugins.pinsAllSky.messages.deletedFrame', {
-          freed: this.formatSize(data.data?.freedBytes || 0),
-        });
-        await Promise.all([this.fetchStatus(), this.fetchSessionDetails(sessionId)]);
-        this.error = null;
-      } catch (error) {
-        this.error = error?.message || i18n.global.t('plugins.pinsAllSky.errors.deleteFrame');
-      } finally {
-        this.cleanupBusy = false;
-      }
+      });
     },
 
     async updateBackend() {
-      this.backendUpdateBusy = true;
-      try {
-        const { data } = await axios.post(`${this.backendBaseUrl}/api/backend/update`, {});
+      return this.withAction('backend:update', async () => {
+        this.backendUpdateBusy = true;
+        try {
+          const { data } = await axios.post(`${this.backendBaseUrl}/api/backend/update`, {});
 
-        if (!data.success) {
-          throw new Error(
-            data.error || i18n.global.t('plugins.pinsAllSky.errors.startBackendUpdate')
-          );
+          if (!data.success) {
+            throw new Error(
+              data.error || i18n.global.t('plugins.pinsAllSky.errors.startBackendUpdate')
+            );
+          }
+
+          this.actionMessage =
+            data.data?.message || i18n.global.t('plugins.pinsAllSky.messages.backendUpdateStarted');
+          this.error = null;
+          return data.data;
+        } catch (error) {
+          this.error =
+            error?.message || i18n.global.t('plugins.pinsAllSky.errors.startBackendUpdate');
+          return null;
+        } finally {
+          this.backendUpdateBusy = false;
         }
-
-        this.actionMessage =
-          data.data?.message || i18n.global.t('plugins.pinsAllSky.messages.backendUpdateStarted');
-        this.error = null;
-        return data.data;
-      } catch (error) {
-        this.error =
-          error?.message || i18n.global.t('plugins.pinsAllSky.errors.startBackendUpdate');
-        return null;
-      } finally {
-        this.backendUpdateBusy = false;
-      }
+      });
     },
 
     clearActionMessage() {
       this.actionMessage = null;
+    },
+
+    setActionBusy(key, busy) {
+      if (!key) {
+        return;
+      }
+
+      const nextState = { ...this.actionBusyByKey };
+      if (busy) {
+        nextState[key] = true;
+      } else {
+        delete nextState[key];
+      }
+
+      this.actionBusyByKey = nextState;
+    },
+
+    isActionBusy(key) {
+      return Boolean(key && this.actionBusyByKey[key]);
+    },
+
+    async withAction(key, callback) {
+      if (!key) {
+        return callback();
+      }
+
+      if (this.isActionBusy(key)) {
+        return null;
+      }
+
+      this.setActionBusy(key, true);
+      try {
+        return await callback();
+      } finally {
+        this.setActionBusy(key, false);
+      }
     },
 
     artifactUrl(relativePath) {
@@ -338,38 +405,72 @@ export const usePinsAllSkyStore = defineStore('pinsAllSkyStore', {
       return `${this.backendBaseUrl}/media/${relativePath}`;
     },
 
+    downloadUrl(relativePath, suggestedName = null) {
+      if (!relativePath) {
+        return null;
+      }
+
+      const params = new URLSearchParams({ path: relativePath });
+      if (suggestedName) {
+        params.set('name', suggestedName);
+      }
+
+      return `${this.backendBaseUrl}/api/download?${params.toString()}`;
+    },
+
+    isNativeDownloadEnvironment() {
+      const userAgent = navigator?.userAgent || '';
+      return Boolean(window?.Capacitor?.isNativePlatform?.()) || /; wv\)|\bwv\b/i.test(userAgent);
+    },
+
     async downloadFile(
       relativePath,
       fallbackName = i18n.global.t('plugins.pinsAllSky.common.download')
     ) {
-      const url = this.artifactUrl(relativePath);
-      if (!url) {
-        return;
-      }
+      const actionKey = `download:${relativePath}:${fallbackName || ''}`;
 
-      try {
-        const response = await fetch(url);
-        if (!response.ok) {
-          throw new Error(
-            i18n.global.t('plugins.pinsAllSky.errors.downloadFailed', { status: response.status })
-          );
+      return this.withAction(actionKey, async () => {
+        const url = this.downloadUrl(relativePath, fallbackName);
+        if (!url) {
+          return;
         }
 
-        const blob = await response.blob();
-        const objectUrl = window.URL.createObjectURL(blob);
-        const link = document.createElement('a');
-        link.href = objectUrl;
-        link.download = fallbackName;
-        document.body.appendChild(link);
-        link.click();
-        link.remove();
-        window.setTimeout(() => {
-          window.URL.revokeObjectURL(objectUrl);
-        }, 1000);
-        this.error = null;
-      } catch (error) {
-        this.error = error?.message || i18n.global.t('plugins.pinsAllSky.errors.downloadFile');
-      }
+        try {
+          if (this.isNativeDownloadEnvironment()) {
+            const openedWindow = window.open(url, '_blank', 'noopener');
+            if (!openedWindow) {
+              window.location.href = url;
+            }
+
+            this.error = null;
+            return;
+          }
+
+          const response = await fetch(url);
+          if (!response.ok) {
+            throw new Error(
+              i18n.global.t('plugins.pinsAllSky.errors.downloadFailed', {
+                status: response.status,
+              })
+            );
+          }
+
+          const blob = await response.blob();
+          const objectUrl = window.URL.createObjectURL(blob);
+          const link = document.createElement('a');
+          link.href = objectUrl;
+          link.download = fallbackName;
+          document.body.appendChild(link);
+          link.click();
+          link.remove();
+          window.setTimeout(() => {
+            window.URL.revokeObjectURL(objectUrl);
+          }, 1000);
+          this.error = null;
+        } catch (error) {
+          this.error = error?.message || i18n.global.t('plugins.pinsAllSky.errors.downloadFile');
+        }
+      });
     },
 
     formatSize(bytes) {

--- a/src/plugins/pins-allsky/views/PinsAllSkyView.vue
+++ b/src/plugins/pins-allsky/views/PinsAllSkyView.vue
@@ -875,16 +875,7 @@ const formatInterval = (seconds) => {
   return `${seconds}s`;
 };
 
-const formatExposure = (camera) => {
-  if (!camera) {
-    return t('plugins.pinsAllSky.common.notAvailable');
-  }
-
-  if (!camera.useManualExposure) {
-    return t('plugins.pinsAllSky.common.auto');
-  }
-
-  const shutterMicroseconds = Number(camera.shutterMicroseconds || 0);
+const formatExposureValue = (shutterMicroseconds) => {
   if (!Number.isFinite(shutterMicroseconds) || shutterMicroseconds <= 0) {
     return t('plugins.pinsAllSky.common.notAvailable');
   }
@@ -897,21 +888,50 @@ const formatExposure = (camera) => {
   return `${exposureSeconds.toFixed(exposureSeconds >= 0.1 ? 2 : 3)}s`;
 };
 
-const formatGain = (camera) => {
+const formatExposure = (camera, session = null) => {
   if (!camera) {
     return t('plugins.pinsAllSky.common.notAvailable');
+  }
+
+  const actualExposure = Number(session?.lastExposureMicroseconds || 0);
+  if (actualExposure > 0) {
+    return camera.useManualExposure
+      ? formatExposureValue(actualExposure)
+      : `${formatExposureValue(actualExposure)} (${t('plugins.pinsAllSky.common.auto')})`;
+  }
+
+  if (!camera.useManualExposure) {
+    return t('plugins.pinsAllSky.common.auto');
+  }
+
+  return formatExposureValue(Number(camera.shutterMicroseconds || 0));
+};
+
+const formatGainValue = (gain) => {
+  if (!Number.isFinite(gain) || gain <= 0) {
+    return t('plugins.pinsAllSky.common.notAvailable');
+  }
+
+  return gain >= 10 ? gain.toFixed(0) : gain.toFixed(1).replace(/\.0$/, '');
+};
+
+const formatGain = (camera, session = null) => {
+  if (!camera) {
+    return t('plugins.pinsAllSky.common.notAvailable');
+  }
+
+  const actualGain = Number(session?.lastAnalogGain || 0);
+  if (actualGain > 0) {
+    return camera.useManualGain
+      ? formatGainValue(actualGain)
+      : `${formatGainValue(actualGain)} (${t('plugins.pinsAllSky.common.auto')})`;
   }
 
   if (!camera.useManualGain) {
     return t('plugins.pinsAllSky.common.auto');
   }
 
-  const gain = Number(camera.analogGain || 0);
-  if (!Number.isFinite(gain) || gain <= 0) {
-    return t('plugins.pinsAllSky.common.notAvailable');
-  }
-
-  return gain >= 10 ? gain.toFixed(0) : gain.toFixed(1).replace(/\.0$/, '');
+  return formatGainValue(Number(camera.analogGain || 0));
 };
 
 const formatCount = (value) => {

--- a/src/plugins/pins-allsky/views/PinsAllSkyView.vue
+++ b/src/plugins/pins-allsky/views/PinsAllSkyView.vue
@@ -127,6 +127,7 @@
         :format-gain="formatGain"
         :format-count="formatCount"
         :format-size="formatSize"
+        :is-action-busy="isActionBusy"
         @update:manual-label="manualLabelInput = $event"
         @update:estimate-start-local="estimateWindow.startLocal = $event"
         @update:estimate-end-local="estimateWindow.endLocal = $event"
@@ -189,6 +190,7 @@
         :session-details-by-id="sessionDetailsById"
         :details-loading-by-id="detailsLoadingById"
         :session-detail-open="sessionDetailOpen"
+        :is-action-busy="isActionBusy"
         :format-date="formatDate"
         :format-count="formatCount"
         :format-size="formatSize"
@@ -648,6 +650,8 @@ const generateArtifacts = async (sessionId = null) => {
 const updateBackend = async () => {
   await store.updateBackend();
 };
+
+const isActionBusy = (key) => store.isActionBusy(key);
 
 const formatSessionReason = (reason) => {
   if (!reason) {


### PR DESCRIPTION
## Summary
  - add the latest PINS AllSky frontend controls for AllSky auto-exposure tuning, timelapse overlays, and live preview values
  - improve action feedback by showing in-flight state for capture, render, cleanup, and refresh actions
  - switch product and frame downloads to attachment-style URLs with session-based filenames so browser and Android/WebView clients behave
  consistently
  - clarify overlay tooltips to state that timestamp and exposure/gain overlays apply on the next render or regenerate

  ## Notes
  - frontend only; this keeps the TNS plugin aligned with the current companion backend behavior
  - no core TNS behavior changes outside `pins-allsky`

  ## Testing
  - `npm run format`
  - `npm run lint:fix`
  - `npm run testbuild`