### PR TITLE
feat(flats): add zenith slew side selection

### DIFF
--- a/src/store/settingsStore.js
+++ b/src/store/settingsStore.js
@@ -81,6 +81,7 @@ export const useSettingsStore = defineStore('settings', {
     flats: {
       activeMode: 'single',
       selectedOption: 'AutoExposure',
+      altitudeSite: 'EAST',
       minBrightness: 0,
       maxBrightness: 100,
       brightness: 50,

--- a/src/views/FlatassistantPage.vue
+++ b/src/views/FlatassistantPage.vue
@@ -16,12 +16,22 @@
     />
 
     <div class="flex flex-col items-center justify-center max-w-md p-2 mx-auto">
-      <ButtonSlew
-        class="p-4 w-full"
-        :label="t('components.flatassistant.button_slew_to_zenith')"
-        :raAngle="computedRa"
-        :decAngle="computedDec"
-      />
+      <div class="flex w-full items-center gap-2 p-4">
+        <select
+          v-model="settingsStore.flats.altitudeSite"
+          class="w-28 border border-gray-500 rounded-lg bg-gray-800 p-2 text-white"
+        >
+          <option value="EAST">{{ $t('components.tppa.east') }}</option>
+          <option value="WEST">{{ $t('components.tppa.west') }}</option>
+        </select>
+
+        <ButtonSlew
+          class="w-full"
+          :label="t('components.flatassistant.button_slew_to_zenith')"
+          :raAngle="computedRa"
+          :decAngle="computedDec"
+        />
+      </div>
 
       <!-- Single Mode: sub-type selector -->
       <select
@@ -81,6 +91,10 @@ const flatsStore = useFlatassistantStore();
 const settingsStore = useSettingsStore();
 const store = apiStore();
 const { t } = useI18n();
+const ALTITUDE_SITE = {
+  EAST: 'EAST',
+  WEST: 'WEST',
+};
 
 const selectedComponent = computed(() => {
   switch (settingsStore.flats.selectedOption) {
@@ -93,10 +107,14 @@ const selectedComponent = computed(() => {
   }
 });
 
+const zenithAzimuth = computed(() =>
+  settingsStore.flats.altitudeSite === ALTITUDE_SITE.WEST ? 90 : 270
+);
+
 const computedRa = computed(() => {
   const { ra } = altAzToRaDec(
     89,
-    90,
+    zenithAzimuth.value,
     store.profileInfo.AstrometrySettings.Latitude,
     store.profileInfo.AstrometrySettings.Longitude
   );
@@ -106,7 +124,7 @@ const computedRa = computed(() => {
 const computedDec = computed(() => {
   const { dec } = altAzToRaDec(
     89,
-    90,
+    zenithAzimuth.value,
     store.profileInfo.AstrometrySettings.Latitude,
     store.profileInfo.AstrometrySettings.Longitude
   );
@@ -114,6 +132,10 @@ const computedDec = computed(() => {
 });
 
 onMounted(() => {
+  if (!settingsStore.flats.altitudeSite) {
+    settingsStore.flats.altitudeSite = ALTITUDE_SITE.EAST;
+  }
+
   if (store.isPINS) {
     settingsStore.flats.activeMode = 'single';
   }


### PR DESCRIPTION
 ## What
  Adds an East/West selector next to the Flats "Slew to zenith" button.

  ## Why
  N.I.N.A.'s Flat Wizard allows choosing which side the mount should approach zenith from. Sometimes a side is not Ideal while slewing because the camera can bump the tripod on that side. So the flexibility of choosing east/west like NINA does is nice to have.

  ## Implementation
  - adds persisted flat assistant `altitudeSite` state with default `EAST`
  - adds an East/West combo box next to the existing button
  - maps the selection exactly like N.I.N.A. Flat Wizard:
    - `EAST -> azimuth 270`
    - `WEST -> azimuth 90`
  - keeps using the existing TNS mount slew flow

  ## Tested
  - built successfully with `npm run build:app`
  - updated the live Touch-N-Stars bundle on the Pi for manual testing