### PR TITLE
🐞 fix(pins.vue): Fixed z-index for navigation bar

### DIFF
--- a/src/plugins/pins/views/pins.vue
+++ b/src/plugins/pins/views/pins.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="min-h-screen bg-gray-900">
-    <SubNav v-if="store.isPINS" :items="pinsNavItems" v-model:activeItem="activeTab" />
+    <SubNav v-if="store.isPINS" :items="pinsNavItems" v-model:activeItem="activeTab" class="z-20" />
 
     <div
       class="container py-8 sm:py-16 flex items-center justify-center px-4"


### PR DESCRIPTION
Content was scrolling over navigation bar. Fixed it by increasing the z-index of the navbar