### PR TITLE
feat: add PHD2 Log Viewer plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Flatassistant: Stop tracking after slew to zenith
 - Plugin: Add filebrowser
 - Stellarium: Add Camera FOV
+- Plugin: PHD2 Log Viewer – visualize PHD2 guiding sessions with guide graph, RMS statistics, FFT periodic error analysis and calibration data - thanks to Florin Dumitrescu
 
 ### Changed
 - Plate Solve: Use the NINA-style toolbar icon in the shared image viewer

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -3660,6 +3660,71 @@
       "deviceCamera": "Camera",
       "deviceFocuser": "Focuser",
       "deviceFilterWheel": "Filter Wheel"
+    },
+    "phd2logviewer": {
+      "title": "PHD2 Log Viewer",
+      "subtitle": "Select a PHD2 guide log to visualize guiding performance and statistics.",
+      "loading": "Loading…",
+      "selectLog": "— select a log —",
+      "noLogs": "No logs found",
+      "refresh": "Refresh log list",
+      "clear": "Clear",
+      "session": "Session:",
+      "excludeDither": "Auto-exclude dither settling",
+      "rawRa": "Raw, uncorrected RA",
+      "emptyState": "Select a PHD2 guide log from the dropdown above.",
+      "tabs": {
+        "guide": "Guide Graph",
+        "calibration": "Calibration"
+      },
+      "legend": {
+        "ra": "RA",
+        "raRaw": "RA (raw)",
+        "dec": "Dec",
+        "dither": "Dither"
+      },
+      "info": {
+        "started": "Session started",
+        "ended": "Ended",
+        "duration": "Duration",
+        "camera": "Camera",
+        "mount": "Mount",
+        "focalLength": "Focal length",
+        "pixelScale": "Pixel scale",
+        "profile": "Profile",
+        "totalFrames": "Total frames"
+      },
+      "statistics": "Statistics",
+      "stats": {
+        "totalRms": "Total RMS",
+        "raRms": "RA RMS",
+        "decRms": "Dec RMS",
+        "peakRa": "Peak RA",
+        "peakDec": "Peak Dec",
+        "frames": "Frames",
+        "combined": "combined",
+        "rightAscension": "right ascension",
+        "declination": "declination",
+        "maxError": "max error",
+        "of": "of {total}"
+      },
+      "fft": {
+        "title": "RA Frequency Analysis",
+        "subtitle": "Identifies periodic error harmonics in RA guiding.",
+        "dominantPeriod": "Dominant period"
+      },
+      "cal": {
+        "axis": "Axis",
+        "angle": "Angle (°)",
+        "rate": "Rate (px/s)",
+        "parity": "Parity",
+        "steps": "Steps",
+        "dist": "Dist (px)",
+        "backlash": "Backlash",
+        "over": "over",
+        "noSummary": "No summary data (calibration may have been interrupted)",
+        "noData": "No calibration data for this session."
+      }
     }
   },
   "pinsDevices": {

--- a/src/plugins/phd2-logviewer/components/Phd2Icon.vue
+++ b/src/plugins/phd2-logviewer/components/Phd2Icon.vue
@@ -1,0 +1,17 @@
+<template>
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="1.5"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  >
+    <circle cx="12" cy="12" r="9" />
+    <line x1="12" y1="3" x2="12" y2="6" />
+    <line x1="12" y1="18" x2="12" y2="21" />
+    <line x1="3" y1="12" x2="6" y2="12" />
+    <line x1="18" y1="12" x2="21" y2="12" />
+    <path d="M 6,12 C 7,9 11,9 12,12 S 17,15 18,12" />
+  </svg>
+</template>

--- a/src/plugins/phd2-logviewer/index.js
+++ b/src/plugins/phd2-logviewer/index.js
@@ -1,0 +1,48 @@
+import { markRaw } from 'vue';
+import Phd2LogView from './views/Phd2LogView.vue';
+import Phd2Icon from './components/Phd2Icon.vue';
+import { usePluginStore } from '@/store/pluginStore';
+import metadata from './plugin.json';
+
+export default {
+  metadata,
+  install(app, options) {
+    const pluginStore = usePluginStore();
+    const router = options.router;
+
+    const currentPlugin = pluginStore.plugins.find((p) => p.id === metadata.id);
+
+    let pluginPath;
+    if (currentPlugin?.pluginPath) {
+      pluginPath = currentPlugin.pluginPath;
+    } else {
+      const existingNums = pluginStore.plugins
+        .map((p) => p.pluginPath)
+        .filter((path) => path?.match(/^\/plugin\d+$/))
+        .map((path) => parseInt(path.replace('/plugin', '')))
+        .sort((a, b) => a - b);
+
+      let next = 1;
+      for (const n of existingNums) {
+        if (n === next) next++;
+        else break;
+      }
+      pluginPath = `/plugin${next}`;
+    }
+
+    router.addRoute({
+      path: pluginPath,
+      component: Phd2LogView,
+      meta: { requiresSetup: true },
+    });
+
+    if (currentPlugin?.enabled) {
+      pluginStore.addNavigationItem({
+        pluginId: metadata.id,
+        path: pluginPath,
+        icon: markRaw(Phd2Icon),
+        title: metadata.name,
+      });
+    }
+  },
+};

--- a/src/plugins/phd2-logviewer/plugin.json
+++ b/src/plugins/phd2-logviewer/plugin.json
@@ -1,0 +1,9 @@
+{
+  "id": "phd2-logviewer",
+  "name": "PHD2 Log Viewer",
+  "description": "Visualize and analyze PHD2 guiding log files — guide graph, RMS statistics, calibration data and FFT frequency analysis",
+  "version": "1.0.0",
+  "author": "Florin Dumitrescu",
+  "defaultEnabled": false,
+  "enabled": true
+}

--- a/src/plugins/phd2-logviewer/utils/fft.js
+++ b/src/plugins/phd2-logviewer/utils/fft.js
@@ -1,0 +1,80 @@
+// Cooley-Tukey radix-2 FFT with Hann window.
+// Returns { frequencies (Hz), magnitudes (arcsec or px), periods (seconds) }
+
+function nextPow2(n) {
+  let p = 1;
+  while (p < n) p <<= 1;
+  return p;
+}
+
+function fftInPlace(re, im) {
+  const n = re.length;
+  // Bit-reverse permutation
+  for (let i = 1, j = 0; i < n; i++) {
+    let bit = n >> 1;
+    for (; j & bit; bit >>= 1) j ^= bit;
+    j ^= bit;
+    if (i < j) {
+      [re[i], re[j]] = [re[j], re[i]];
+      [im[i], im[j]] = [im[j], im[i]];
+    }
+  }
+  // Butterfly passes
+  for (let len = 2; len <= n; len <<= 1) {
+    const half = len >> 1;
+    const ang = -Math.PI / half;
+    const dwRe = Math.cos(ang);
+    const dwIm = Math.sin(ang);
+    for (let i = 0; i < n; i += len) {
+      let wRe = 1,
+        wIm = 0;
+      for (let k = 0; k < half; k++) {
+        const uRe = re[i + k],
+          uIm = im[i + k];
+        const vRe = re[i + k + half] * wRe - im[i + k + half] * wIm;
+        const vIm = re[i + k + half] * wIm + im[i + k + half] * wRe;
+        re[i + k] = uRe + vRe;
+        im[i + k] = uIm + vIm;
+        re[i + k + half] = uRe - vRe;
+        im[i + k + half] = uIm - vIm;
+        const nwRe = wRe * dwRe - wIm * dwIm;
+        wIm = wRe * dwIm + wIm * dwRe;
+        wRe = nwRe;
+      }
+    }
+  }
+}
+
+// signal: array of RA error values
+// sampleInterval: mean time between frames in seconds
+export function computeFFT(signal, sampleInterval) {
+  if (signal.length < 8) return null;
+
+  const n = nextPow2(signal.length);
+  const re = new Float64Array(n);
+  const im = new Float64Array(n);
+
+  // Apply Hann window to reduce spectral leakage
+  for (let i = 0; i < signal.length; i++) {
+    const w = 0.5 * (1 - Math.cos((2 * Math.PI * i) / (signal.length - 1)));
+    re[i] = signal[i] * w;
+  }
+
+  fftInPlace(re, im);
+
+  // Build output — positive frequencies only, skip DC (i=0)
+  const halfN = n >> 1;
+  const freqs = [];
+  const mags = [];
+  const periods = [];
+
+  for (let i = 1; i < halfN; i++) {
+    const freq = i / (n * sampleInterval); // Hz
+    const mag = (2 * Math.sqrt(re[i] ** 2 + im[i] ** 2)) / signal.length;
+    freqs.push(freq);
+    mags.push(mag);
+    periods.push(1 / freq); // seconds
+  }
+
+  return { frequencies: freqs, magnitudes: mags, periods };
+}

--- a/src/plugins/phd2-logviewer/utils/phd2Parser.js
+++ b/src/plugins/phd2-logviewer/utils/phd2Parser.js
@@ -1,0 +1,291 @@
+// Parses PHD2 guide log text into structured sessions.
+
+const DITHER_SETTLE_FRAMES = 30;
+
+function splitCsv(line) {
+  const out = [];
+  let cur = '';
+  let inQ = false;
+  for (const ch of line) {
+    if (ch === '"') {
+      inQ = !inQ;
+    } else if (ch === ',' && !inQ) {
+      out.push(cur);
+      cur = '';
+    } else {
+      cur += ch;
+    }
+  }
+  out.push(cur);
+  return out;
+}
+
+export function parsePhd2Log(text) {
+  const lines = text.split(/\r?\n/);
+  const sessions = [];
+  const calibrations = [];
+  let info = {};
+  let calibLines = [];
+  let inCalib = false;
+  let current = null;
+  let headers = null;
+  let framesUntilSettled = 0;
+
+  // New-format calibration state
+  let calibCurrent = null;
+  let inCalibStep = false;
+  let lastCalibIdx = null; // most recent calibration — reused by all sessions until a new one runs
+
+  for (const raw of lines) {
+    const line = raw.trim();
+    if (!line) continue;
+
+    // PHD2 version
+    const verM = line.match(/^PHD2 version (.+)/);
+    if (verM) {
+      info.version = verM[1].trim();
+      continue;
+    }
+
+    // Calibration setup params (on the same Mount = ... line, before equipFields consumes it)
+    if (calibCurrent) {
+      const csM = line.match(/Calibration Step\s*=\s*(\d+)\s*ms/i);
+      if (csM) calibCurrent.stepSize = parseInt(csM[1]);
+      const cdM = line.match(/Calibration Distance\s*=\s*(\d+)\s*px/i);
+      if (cdM) calibCurrent.calDistance = parseInt(cdM[1]);
+    }
+
+    // Equipment fields — also update calibCurrent.info when active
+    const equipFields = [
+      [/^Equipment Profile\s*=\s*(.+)/, 'profile'],
+      [/^Camera\s*=\s*(.+)/, 'camera'],
+      [/^Mount\s*=\s*(.+)/, 'mount'],
+      [/^Focal length\s*=\s*([\d.]+)\s*mm/i, 'focalLength', parseFloat],
+      [/^Pixel scale\s*=\s*([\d.]+)\s*arc-sec\/px/i, 'pixelScale', parseFloat],
+      [/^Scale\s*=\s*([\d.]+)\s*arc-sec\/px/i, 'pixelScale', parseFloat],
+    ];
+    let matched = false;
+    for (const [re, key, fn] of equipFields) {
+      const m = line.match(re);
+      if (m) {
+        const val = fn ? fn(m[1]) : m[1].trim();
+        info[key] = val;
+        if (calibCurrent) calibCurrent.info[key] = val;
+        matched = true;
+        break;
+      }
+    }
+    if (matched) continue;
+
+    // ── New-format calibration session (Calibration Begins at ...) ──────────
+    const cbM = line.match(/^Calibration Begins at (.+)/);
+    if (cbM) {
+      inCalib = false;
+      if (calibCurrent?.steps.length) calibrations.push(calibCurrent);
+      calibCurrent = { startTime: cbM[1].trim(), info: { ...info }, steps: [], results: [] };
+      inCalibStep = false;
+      continue;
+    }
+
+    if (calibCurrent) {
+      // Guiding begins right after calibration — flush and fall through
+      if (/^Guiding Begins/.test(line)) {
+        if (calibCurrent.steps.length) {
+          lastCalibIdx = calibrations.length;
+          calibrations.push(calibCurrent);
+        }
+        calibCurrent = null;
+        inCalibStep = false;
+        // fall through to Guiding Begins handler below
+      } else {
+        // Column header
+        if (/^Direction,Step,dx,dy/.test(line)) {
+          inCalibStep = true;
+          continue;
+        }
+
+        // Calibration complete (closes session)
+        if (/^Calibration complete/.test(line)) {
+          lastCalibIdx = calibrations.length;
+          calibrations.push(calibCurrent);
+          calibCurrent = null;
+          inCalibStep = false;
+          continue;
+        }
+
+        // Per-axis summary: "West calibration complete. Angle = ..."
+        const sumM = line.match(
+          /^(\w+) calibration complete\.\s*Angle = ([-\d.]+) deg,\s*Rate = ([\d.]+) px\/sec,\s*Parity = (\w+)/
+        );
+        if (sumM) {
+          calibCurrent.results.push({
+            direction: sumM[1],
+            angle: parseFloat(sumM[2]),
+            rate: parseFloat(sumM[3]),
+            parity: sumM[4],
+          });
+          continue;
+        }
+
+        // Step data row
+        if (inCalibStep) {
+          const stepM = line.match(
+            /^(\w+),(\d+),([-\d.]+),([-\d.]+),([-\d.]+),([-\d.]+),([-\d.]+)/
+          );
+          if (stepM) {
+            calibCurrent.steps.push({
+              direction: stepM[1],
+              step: parseInt(stepM[2]),
+              dx: parseFloat(stepM[3]),
+              dy: parseFloat(stepM[4]),
+              x: parseFloat(stepM[5]),
+              y: parseFloat(stepM[6]),
+              dist: parseFloat(stepM[7]),
+            });
+            continue;
+          }
+        }
+
+        continue; // skip other header lines inside calibration section
+      }
+    }
+
+    // ── Old-format calibration section (legacy logs) ─────────────────────────
+    if (/^Calibration data/i.test(line)) {
+      inCalib = true;
+      calibLines = [];
+      continue;
+    }
+    if (inCalib) {
+      const cm = line.match(
+        /Direction\s*=\s*(\w+),\s*Steps\s*=\s*(\d+),\s*Dx\s*=\s*([-\d.]+),\s*Dy\s*=\s*([-\d.]+),\s*Angle\s*=\s*([\d.]+),\s*Rate\s*=\s*([\d.]+)\s*px\/s/
+      );
+      if (cm) {
+        calibLines.push({
+          direction: cm[1],
+          steps: parseInt(cm[2]),
+          dx: parseFloat(cm[3]),
+          dy: parseFloat(cm[4]),
+          angle: parseFloat(cm[5]),
+          rate: parseFloat(cm[6]),
+        });
+        continue;
+      }
+    }
+
+    // Guiding Begins
+    const gbM = line.match(/^Guiding Begins at (.+)/);
+    if (gbM) {
+      inCalib = false;
+      if (current?.frames.length) sessions.push(current);
+      headers = null;
+      framesUntilSettled = 0;
+      current = {
+        startTime: gbM[1].trim(),
+        frames: [],
+        ditherFrames: new Set(),
+        calibration: [...calibLines],
+        info: { ...info },
+        calibrationIdx: lastCalibIdx,
+      };
+      continue;
+    }
+
+    if (!current) continue;
+
+    // Guiding Ends
+    const geM = line.match(/^Guiding Ends at (.+)/);
+    if (geM) {
+      current.endTime = geM[1].trim();
+      if (current.frames.length) sessions.push(current);
+      current = null;
+      continue;
+    }
+
+    // Normalized guide rates (arcsec/sec) from guiding-start header
+    const normM = line.match(/Norm rates RA\s*=\s*([\d.]+)"\/s[^,]*,\s*Dec\s*=\s*([\d.]+)"\/s/i);
+    if (normM) {
+      current.normRaRate = parseFloat(normM[1]);
+      current.normDecRate = parseFloat(normM[2]);
+      continue;
+    }
+
+    // Dither / settling events (non-data lines)
+    if (!/^\d/.test(line) && !line.startsWith('"Frame"') && !/^Frame[,"']/.test(line)) {
+      if (/dither/i.test(line)) framesUntilSettled = DITHER_SETTLE_FRAMES;
+      if (/settling complete/i.test(line)) framesUntilSettled = 0;
+      continue;
+    }
+
+    // Column headers
+    if (line.startsWith('"Frame"') || line.startsWith('Frame')) {
+      headers = splitCsv(line).map((h) => h.replace(/"/g, '').trim());
+      continue;
+    }
+
+    // Data row
+    if (headers && /^\d/.test(line)) {
+      const vals = splitCsv(line);
+      if (vals.length < 5) continue;
+
+      const col = (name) => {
+        const lower = name.toLowerCase();
+        const idx = headers.findIndex((h) => h.toLowerCase() === lower);
+        return idx >= 0 ? vals[idx] : '0';
+      };
+
+      const frameNum = parseInt(vals[0]) || current.frames.length + 1;
+      if (framesUntilSettled > 0) {
+        framesUntilSettled--;
+        current.ditherFrames.add(frameNum);
+      }
+
+      current.frames.push({
+        frame: frameNum,
+        time: parseFloat(vals[1]) || 0,
+        dx: parseFloat(col('dx')) || 0,
+        dy: parseFloat(col('dy')) || 0,
+        raRaw: parseFloat(col('RaRawDistance')) || 0,
+        decRaw: parseFloat(col('DecRawDistance')) || 0,
+        raGuide: parseFloat(col('RaGuideDistance')) || 0,
+        decGuide: parseFloat(col('DecGuideDistance')) || 0,
+        raDuration: parseInt(col('RaDuration')) || 0,
+        decDuration: parseInt(col('DecDuration')) || 0,
+        raDir: col('RaDirection').trim(),
+        decDir: col('DecDirection').trim(),
+        snr: parseFloat(col('SNR')) || 0,
+        starMass: parseFloat(col('StarMass')) || 0,
+        starError: parseFloat(col('StarError')) || 0,
+      });
+    }
+  }
+
+  if (current?.frames.length) sessions.push(current);
+  if (calibCurrent?.steps.length) calibrations.push(calibCurrent);
+  return { sessions, calibrations };
+}
+
+export function calcStats(frames, pixelScale, excluded) {
+  const ps = pixelScale || 1;
+  const active = frames.filter((f) => !excluded.has(f.frame));
+  if (!active.length) return null;
+
+  const ra = active.map((f) => f.raRaw * ps);
+  const dec = active.map((f) => f.decRaw * ps);
+  const rms = (arr) => Math.sqrt(arr.reduce((s, v) => s + v * v, 0) / arr.length);
+
+  const rmsRa = rms(ra);
+  const rmsDec = rms(dec);
+
+  return {
+    rmsRa: rmsRa.toFixed(2),
+    rmsDec: rmsDec.toFixed(2),
+    rmsTotal: Math.sqrt(rmsRa ** 2 + rmsDec ** 2).toFixed(2),
+    peakRa: Math.max(...ra.map(Math.abs)).toFixed(2),
+    peakDec: Math.max(...dec.map(Math.abs)).toFixed(2),
+    unit: pixelScale ? '"' : 'px',
+    frameCount: active.length,
+    totalFrames: frames.length,
+    excludedCount: frames.length - active.length,
+  };
+}

--- a/src/plugins/phd2-logviewer/views/Phd2LogView.vue
+++ b/src/plugins/phd2-logviewer/views/Phd2LogView.vue
@@ -1,0 +1,1210 @@
+<template>
+  <div ref="rootEl" class="px-4 py-6 lg:px-8">
+    <div class="mx-auto flex max-w-6xl flex-col gap-6">
+      <!-- Header -->
+      <header
+        class="rounded-2xl border border-gray-700/70 bg-gray-900/80 p-6 shadow-lg backdrop-blur"
+      >
+        <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h1 class="text-3xl font-semibold text-white">
+              {{ t('plugins.phd2logviewer.title') }}
+            </h1>
+            <p class="mt-1 text-sm text-gray-400">{{ t('plugins.phd2logviewer.subtitle') }}</p>
+          </div>
+          <div class="flex flex-wrap items-center gap-3">
+            <select
+              v-model="selectedLogPath"
+              :disabled="loadingList || loadingFile"
+              class="rounded-lg border border-gray-600 bg-gray-800 px-3 py-2 text-sm text-gray-200 focus:outline-none focus:ring-2 focus:ring-cyan-500 disabled:opacity-50"
+              @change="loadSelectedLog"
+            >
+              <option value="">
+                {{
+                  loadingList
+                    ? t('plugins.phd2logviewer.loading')
+                    : logFiles.length
+                      ? t('plugins.phd2logviewer.selectLog')
+                      : t('plugins.phd2logviewer.noLogs')
+                }}
+              </option>
+              <option v-for="f in logFiles" :key="f.path" :value="f.path">
+                {{ logLabel(f.name) }}
+              </option>
+            </select>
+            <button
+              type="button"
+              :disabled="loadingList"
+              class="inline-flex items-center justify-center rounded-lg border border-gray-600 bg-gray-800/50 p-2 text-gray-300 transition hover:bg-gray-700/60 disabled:opacity-50"
+              :title="t('plugins.phd2logviewer.refresh')"
+              @click="fetchLogList"
+            >
+              <svg
+                class="h-4 w-4"
+                :class="{ 'animate-spin': loadingList }"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.5"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0l3.181 3.183a8.25 8.25 0 0013.803-3.7M4.031 9.865a8.25 8.25 0 0113.803-3.7l3.181 3.182m0-4.991v4.99"
+                />
+              </svg>
+            </button>
+            <span v-if="loadingFile" class="text-xs text-gray-400">{{
+              t('plugins.phd2logviewer.loading')
+            }}</span>
+            <span v-if="listError" class="text-xs text-red-400">{{ listError }}</span>
+            <button
+              v-if="sessions.length || calibrations.length"
+              type="button"
+              class="inline-flex items-center gap-2 rounded-lg border border-gray-600 bg-gray-800/50 px-4 py-2 text-sm font-medium text-gray-300 transition hover:bg-gray-700/60"
+              @click="clearLog"
+            >
+              {{ t('plugins.phd2logviewer.clear') }}
+            </button>
+          </div>
+        </div>
+
+        <!-- Controls row (after file loaded) -->
+        <div
+          v-if="fileName"
+          class="mt-4 flex flex-wrap items-center gap-4 border-t border-gray-700/50 pt-4"
+        >
+          <span class="font-mono text-xs text-gray-300">{{ fileName }}</span>
+          <div v-if="sessions.length > 1" class="flex items-center gap-2">
+            <label class="text-xs text-gray-400">{{ t('plugins.phd2logviewer.session') }}</label>
+            <select
+              v-model="activeSessionIdx"
+              class="rounded-md border border-gray-600 bg-gray-800 px-2 py-1 text-sm text-gray-200 focus:outline-none focus:ring-2 focus:ring-cyan-500"
+            >
+              <option v-for="(s, i) in sessions" :key="i" :value="i">
+                {{ i + 1 }} — {{ s.startTime }}
+              </option>
+            </select>
+          </div>
+          <label
+            v-if="activeSession"
+            class="flex cursor-pointer select-none items-center gap-1.5 text-xs text-gray-400"
+          >
+            <input
+              type="checkbox"
+              v-model="excludeDither"
+              class="rounded border-gray-600 bg-gray-800 text-cyan-500 focus:ring-cyan-500"
+            />
+            {{ t('plugins.phd2logviewer.excludeDither') }}
+            <span class="text-gray-500">({{ activeSession.ditherFrames.size }} frames)</span>
+          </label>
+          <label
+            v-if="activeSession"
+            class="flex cursor-pointer select-none items-center gap-1.5 text-xs text-gray-400"
+          >
+            <input
+              type="checkbox"
+              v-model="showRawRA"
+              class="rounded border-gray-600 bg-gray-800 text-cyan-500 focus:ring-cyan-500"
+            />
+            {{ t('plugins.phd2logviewer.rawRa') }}
+          </label>
+        </div>
+      </header>
+
+      <!-- Empty state -->
+      <div
+        v-if="!sessions.length && !calibrations.length"
+        class="rounded-2xl border border-dashed border-gray-700 bg-gray-900/40 p-16 text-center"
+      >
+        <svg
+          class="mx-auto mb-4 h-12 w-12 text-gray-600"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1"
+        >
+          <circle cx="12" cy="12" r="9" />
+          <circle cx="12" cy="12" r="3" />
+          <line x1="12" y1="3" x2="12" y2="6" />
+          <line x1="12" y1="18" x2="12" y2="21" />
+          <line x1="3" y1="12" x2="6" y2="12" />
+          <line x1="18" y1="12" x2="21" y2="12" />
+        </svg>
+        <p class="text-gray-400">{{ t('plugins.phd2logviewer.emptyState') }}</p>
+        <p class="mt-1 font-mono text-xs text-gray-600">~/Documents/PHD2/PHD2_GuideLog_*.txt</p>
+      </div>
+
+      <!-- Content (session or calibration loaded) -->
+      <template v-if="activeSession || calibrations.length">
+        <!-- Session info -->
+        <section
+          v-if="activeSession"
+          class="rounded-2xl border border-gray-700/70 bg-gray-900/70 p-5 shadow-inner"
+        >
+          <div class="grid grid-cols-2 gap-x-6 gap-y-2 text-sm sm:grid-cols-3 lg:grid-cols-4">
+            <div v-for="item in sessionInfoItems" :key="item.label" class="flex flex-col gap-0.5">
+              <span class="text-xs text-gray-500">{{ item.label }}</span>
+              <span class="truncate font-medium text-gray-200" :title="item.value">{{
+                item.value
+              }}</span>
+            </div>
+          </div>
+        </section>
+
+        <!-- Guide Graph / Calibration (tabbed) -->
+        <section class="rounded-2xl border border-gray-700/70 bg-gray-900/80 p-5 shadow-inner">
+          <div class="mb-3 flex flex-wrap items-center justify-between gap-3">
+            <!-- Tab buttons -->
+            <div class="flex">
+              <button
+                v-if="sessions.length"
+                type="button"
+                class="rounded-l-md border border-gray-600 px-4 py-1.5 text-sm font-medium transition"
+                :class="
+                  activeTab === 'guide'
+                    ? 'border-cyan-500/50 bg-cyan-500/10 text-cyan-200'
+                    : 'bg-transparent text-gray-500 hover:bg-gray-700/40 hover:text-gray-300'
+                "
+                @click="setTab('guide')"
+              >
+                {{ t('plugins.phd2logviewer.tabs.guide') }}
+              </button>
+              <button
+                v-if="calibrations.length"
+                type="button"
+                class="border border-gray-600 px-4 py-1.5 text-sm font-medium transition"
+                :class="[
+                  activeTab === 'cal'
+                    ? 'border-cyan-500/50 bg-cyan-500/10 text-cyan-200'
+                    : 'bg-transparent text-gray-500 hover:bg-gray-700/40 hover:text-gray-300',
+                  sessions.length ? '-ml-px rounded-r-md' : 'rounded-md',
+                ]"
+                @click="setTab('cal')"
+              >
+                {{ t('plugins.phd2logviewer.tabs.calibration') }}
+              </button>
+            </div>
+
+            <!-- Guide tab controls -->
+            <template v-if="activeTab === 'guide' && activeSession">
+              <div class="flex flex-wrap items-center gap-3">
+                <div class="flex items-center gap-1.5">
+                  <span class="text-xs text-gray-500">X</span>
+                  <div class="flex gap-1">
+                    <button class="zoom-btn" :disabled="xZoomSpan < 0.04" @click="xZoomIn">
+                      +
+                    </button>
+                    <button
+                      class="zoom-btn"
+                      :disabled="xZoomStart <= 0 && xZoomEnd >= 1"
+                      @click="xZoomOut"
+                    >
+                      −
+                    </button>
+                    <button
+                      class="zoom-btn text-xs"
+                      :disabled="xZoomStart <= 0 && xZoomEnd >= 1 && yZoom <= 1"
+                      @click="resetZoom"
+                    >
+                      ⟳
+                    </button>
+                  </div>
+                  <div class="h-4 w-px bg-gray-700"></div>
+                  <span class="text-xs text-gray-500">Y</span>
+                  <div class="flex gap-1">
+                    <button class="zoom-btn" :disabled="yZoom >= 16" @click="yZoomIn">+</button>
+                    <button class="zoom-btn" :disabled="yZoom <= 1" @click="yZoomOut">−</button>
+                  </div>
+                </div>
+                <div class="flex items-center gap-3 text-xs">
+                  <span class="flex items-center gap-1.5">
+                    <span class="inline-block h-2 w-6 rounded bg-cyan-400"></span>
+                    <span class="text-gray-400">{{
+                      showRawRA
+                        ? t('plugins.phd2logviewer.legend.raRaw')
+                        : t('plugins.phd2logviewer.legend.ra')
+                    }}</span>
+                  </span>
+                  <span class="flex items-center gap-1.5">
+                    <span class="inline-block h-2 w-6 rounded bg-orange-400"></span>
+                    <span class="text-gray-400">{{ t('plugins.phd2logviewer.legend.dec') }}</span>
+                  </span>
+                  <span
+                    v-if="excludeDither && activeSession.ditherFrames.size"
+                    class="flex items-center gap-1.5"
+                  >
+                    <span
+                      class="inline-block h-2 w-4 rounded"
+                      style="background: rgba(234, 179, 8, 0.4)"
+                    ></span>
+                    <span class="text-gray-400">{{
+                      t('plugins.phd2logviewer.legend.dither')
+                    }}</span>
+                  </span>
+                </div>
+              </div>
+            </template>
+
+            <!-- Cal tab time label -->
+            <span v-if="activeTab === 'cal' && activeCalibration" class="text-xs text-gray-400">
+              {{ activeCalibration.startTime }}
+            </span>
+          </div>
+
+          <!-- Guide tab -->
+          <div v-show="activeTab === 'guide'">
+            <div
+              class="relative w-full overflow-hidden rounded-lg border border-gray-700 bg-gray-950"
+              style="height: 220px"
+            >
+              <canvas ref="guideCanvas" class="absolute inset-0 h-full w-full" />
+            </div>
+            <p class="mt-2 text-right text-xs text-gray-500">{{ guideLabel }}</p>
+          </div>
+
+          <!-- Calibration tab -->
+          <div v-show="activeTab === 'cal'">
+            <template v-if="activeCalibration">
+              <div
+                class="relative w-full overflow-hidden rounded-lg border border-gray-700 bg-gray-950"
+                style="height: 300px"
+              >
+                <canvas ref="calCanvas" class="absolute inset-0 h-full w-full" />
+              </div>
+              <div class="mt-2 flex flex-wrap gap-3 text-xs">
+                <span v-for="dir in calDirs" :key="dir" class="flex items-center gap-1.5">
+                  <span
+                    class="inline-block h-px w-5"
+                    :style="{ background: CAL_COLORS[dir]?.stroke || '#cbd5e1' }"
+                  ></span>
+                  <span class="text-gray-400">{{ dir }}</span>
+                </span>
+              </div>
+              <div
+                v-if="calMetaItems.length"
+                class="mt-3 flex flex-wrap gap-x-4 gap-y-1 text-xs text-gray-400"
+              >
+                <span v-for="m in calMetaItems" :key="m.label">
+                  {{ m.label }}: <span :class="m.color || 'text-gray-200'">{{ m.value }}</span>
+                </span>
+              </div>
+              <div v-if="activeCalibration.results.length" class="mt-4 overflow-x-auto">
+                <table class="w-full text-sm">
+                  <thead>
+                    <tr class="border-b border-gray-700">
+                      <th class="pb-2 text-left text-xs font-medium text-gray-500">
+                        {{ t('plugins.phd2logviewer.cal.axis') }}
+                      </th>
+                      <th class="pb-2 text-right text-xs font-medium text-gray-500">
+                        {{ t('plugins.phd2logviewer.cal.angle') }}
+                      </th>
+                      <th class="pb-2 text-right text-xs font-medium text-gray-500">
+                        {{ t('plugins.phd2logviewer.cal.rate') }}
+                      </th>
+                      <th class="pb-2 text-right text-xs font-medium text-gray-500">
+                        {{ t('plugins.phd2logviewer.cal.parity') }}
+                      </th>
+                      <th class="pb-2 text-right text-xs font-medium text-gray-500">
+                        {{ t('plugins.phd2logviewer.cal.steps') }}
+                      </th>
+                      <th class="pb-2 text-right text-xs font-medium text-gray-500">
+                        {{ t('plugins.phd2logviewer.cal.dist') }}
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr
+                      v-for="(r, i) in activeCalibration.results"
+                      :key="i"
+                      class="border-b border-gray-800/60 last:border-0"
+                    >
+                      <td
+                        class="py-2 font-medium"
+                        :class="
+                          /west|east/i.test(r.direction) ? 'text-cyan-400' : 'text-orange-400'
+                        "
+                      >
+                        {{ r.direction }}
+                      </td>
+                      <td class="py-2 text-right font-mono text-gray-300">
+                        {{ r.angle.toFixed(1) }}
+                      </td>
+                      <td class="py-2 text-right font-mono text-gray-300">
+                        {{ r.rate.toFixed(3) }}
+                      </td>
+                      <td class="py-2 text-right font-mono text-gray-300">{{ r.parity }}</td>
+                      <td class="py-2 text-right font-mono text-gray-400">
+                        {{ calStepInfo[r.direction]?.count ?? '—' }}
+                      </td>
+                      <td class="py-2 text-right font-mono text-gray-400">
+                        {{ calStepInfo[r.direction]?.lastDist.toFixed(1) ?? '—' }}
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+                <p v-if="calBacklash" class="mt-2 text-xs text-gray-400">
+                  {{ t('plugins.phd2logviewer.cal.backlash') }}:
+                  <span class="text-gray-200">{{ calBacklash.lastDist.toFixed(1) }} px</span>
+                  {{ t('plugins.phd2logviewer.cal.over') }}
+                  <span class="text-gray-200">{{ calBacklash.count }}</span>
+                  {{ t('plugins.phd2logviewer.cal.steps') }}
+                </p>
+              </div>
+              <p v-else class="mt-4 text-xs text-gray-500">
+                {{ t('plugins.phd2logviewer.cal.noSummary') }}
+              </p>
+            </template>
+            <p v-else class="text-sm text-gray-500">{{ t('plugins.phd2logviewer.cal.noData') }}</p>
+          </div>
+        </section>
+
+        <!-- Statistics -->
+        <section
+          v-if="activeSession"
+          class="rounded-2xl border border-gray-700/70 bg-gray-900/80 p-5 shadow-inner"
+        >
+          <h2 class="mb-4 text-lg font-semibold text-white">
+            {{ t('plugins.phd2logviewer.statistics') }}
+          </h2>
+          <div v-if="stats" class="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">
+            <div
+              v-for="card in statCards"
+              :key="card.label"
+              class="rounded-xl border border-gray-700/60 bg-gray-900/60 p-4 text-center"
+            >
+              <div class="text-2xl font-mono font-semibold" :class="card.color">
+                {{ card.value }}
+              </div>
+              <div class="mt-1 text-xs text-gray-400">{{ card.label }}</div>
+              <div v-if="card.sub" class="mt-0.5 text-[10px] text-gray-500">{{ card.sub }}</div>
+            </div>
+          </div>
+          <div class="mt-4 flex flex-wrap items-center gap-4 text-xs text-gray-500">
+            <span>{{ stats?.frameCount }} / {{ stats?.totalFrames }} frames used</span>
+            <span v-if="stats?.excludedCount">· {{ stats.excludedCount }} excluded</span>
+            <span v-if="activeSession.info.pixelScale"
+              >· {{ activeSession.info.pixelScale }}" /px scale</span
+            >
+          </div>
+        </section>
+
+        <!-- FFT -->
+        <section
+          v-if="activeSession"
+          class="rounded-2xl border border-gray-700/70 bg-gray-900/80 p-5 shadow-inner"
+        >
+          <div class="mb-3 flex flex-wrap items-center justify-between gap-2">
+            <div>
+              <h2 class="text-lg font-semibold text-white">
+                {{ t('plugins.phd2logviewer.fft.title') }}
+              </h2>
+              <p class="mt-0.5 text-xs text-gray-500">
+                {{ t('plugins.phd2logviewer.fft.subtitle') }}
+              </p>
+            </div>
+            <div
+              v-if="fftPeak"
+              class="rounded-lg border border-cyan-500/30 bg-cyan-500/5 px-3 py-1.5 text-right"
+            >
+              <div class="text-xs text-gray-400">
+                {{ t('plugins.phd2logviewer.fft.dominantPeriod') }}
+              </div>
+              <div class="text-base font-mono font-semibold text-cyan-300">{{ fftPeak }}</div>
+            </div>
+          </div>
+          <div
+            class="relative w-full overflow-hidden rounded-lg border border-gray-700 bg-gray-950"
+            style="height: 180px"
+          >
+            <canvas ref="fftCanvas" class="absolute inset-0 h-full w-full" />
+          </div>
+          <p class="mt-2 text-xs text-gray-600">
+            X axis shows period in minutes. Peaks indicate periodic error sources.
+          </p>
+        </section>
+      </template>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, watch, nextTick, onMounted, onBeforeUnmount } from 'vue';
+import { parsePhd2Log, calcStats } from '../utils/phd2Parser.js';
+import { computeFFT } from '../utils/fft.js';
+import { useSettingsStore } from '@/store/settingsStore';
+import { useI18n } from 'vue-i18n';
+
+// ── Refs ──────────────────────────────────────────────────────────────────
+const { t } = useI18n();
+const settingsStore = useSettingsStore();
+
+const rootEl = ref(null);
+const guideCanvas = ref(null);
+const calCanvas = ref(null);
+const fftCanvas = ref(null);
+
+const fileName = ref('');
+const logFiles = ref([]); // [{ name, path, size, lastModified }]
+const selectedLogPath = ref('');
+const loadingList = ref(false);
+const loadingFile = ref(false);
+const listError = ref('');
+const sessions = ref([]);
+const calibrations = ref([]);
+const activeSessionIdx = ref(0);
+const excludeDither = ref(true);
+const showRawRA = ref(false);
+const activeTab = ref('guide');
+const fftPeak = ref('');
+const guideLabel = ref('');
+
+const xZoomStart = ref(0);
+const xZoomEnd = ref(1);
+const yZoom = ref(1.0);
+
+// ── Computed ──────────────────────────────────────────────────────────────
+const activeSession = computed(() => sessions.value[activeSessionIdx.value] ?? null);
+
+const excludedFrames = computed(() => {
+  if (!activeSession.value) return new Set();
+  return excludeDither.value ? activeSession.value.ditherFrames : new Set();
+});
+
+const stats = computed(() => {
+  if (!activeSession.value) return null;
+  return calcStats(
+    activeSession.value.frames,
+    activeSession.value.info.pixelScale,
+    excludedFrames.value
+  );
+});
+
+const activeCalibration = computed(() => {
+  if (!calibrations.value.length) return null;
+  const idx = activeSession.value?.calibrationIdx ?? null;
+  return idx != null ? calibrations.value[idx] : null;
+});
+
+const xZoomSpan = computed(() => xZoomEnd.value - xZoomStart.value);
+
+const pluginServerUrl = computed(() => {
+  const protocol = settingsStore.backendProtocol || 'http';
+  const host = settingsStore.connection?.ip || window.location.hostname;
+  const port = settingsStore.connection?.port || 5000;
+  return `${protocol}://${host}:${port}`;
+});
+
+const CAL_COLORS = {
+  West: { stroke: '#22d3ee', dash: [] },
+  East: { stroke: '#67e8f9', dash: [5, 3] },
+  North: { stroke: '#fb923c', dash: [] },
+  South: { stroke: '#fdba74', dash: [5, 3] },
+  Backlash: { stroke: '#c084fc', dash: [3, 3] },
+};
+
+const calDirs = computed(() =>
+  activeCalibration.value ? [...new Set(activeCalibration.value.steps.map((s) => s.direction))] : []
+);
+
+const calStepInfo = computed(() => {
+  if (!activeCalibration.value) return {};
+  const info = {};
+  for (const s of activeCalibration.value.steps) {
+    if (!info[s.direction]) info[s.direction] = { count: 0, lastDist: 0 };
+    if (s.step + 1 > info[s.direction].count) info[s.direction].count = s.step + 1;
+    info[s.direction].lastDist = s.dist;
+  }
+  return info;
+});
+
+const calBacklash = computed(() => calStepInfo.value['Backlash'] ?? null);
+
+const calMetaItems = computed(() => {
+  const cal = activeCalibration.value;
+  const session = activeSession.value;
+  if (!cal) return [];
+  const items = [];
+  if (cal.stepSize != null) items.push({ label: 'Step size', value: `${cal.stepSize} ms` });
+  if (cal.calDistance != null)
+    items.push({ label: 'Cal distance', value: `${cal.calDistance} px` });
+  if (session?.normRaRate != null)
+    items.push({
+      label: 'RA rate',
+      value: `${session.normRaRate.toFixed(1)}"/s`,
+      color: 'text-cyan-400',
+    });
+  if (session?.normDecRate != null)
+    items.push({
+      label: 'Dec rate',
+      value: `${session.normDecRate.toFixed(1)}"/s`,
+      color: 'text-orange-400',
+    });
+  return items;
+});
+
+const sessionInfoItems = computed(() => {
+  if (!activeSession.value) return [];
+  const s = activeSession.value;
+  const frames = s.frames;
+  const durSec = frames.length ? frames[frames.length - 1].time - frames[0].time : 0;
+  const dm = Math.floor(durSec / 60),
+    ds = Math.round(durSec % 60);
+  const items = [{ label: t('plugins.phd2logviewer.info.started'), value: s.startTime || '—' }];
+  if (s.endTime) items.push({ label: t('plugins.phd2logviewer.info.ended'), value: s.endTime });
+  items.push({ label: t('plugins.phd2logviewer.info.duration'), value: `${dm}m ${ds}s` });
+  if (s.info.focalLength)
+    items.push({
+      label: t('plugins.phd2logviewer.info.focalLength'),
+      value: `${s.info.focalLength} mm`,
+    });
+  if (s.info.pixelScale)
+    items.push({
+      label: t('plugins.phd2logviewer.info.pixelScale'),
+      value: `${s.info.pixelScale}" /px`,
+    });
+  return items;
+});
+
+const statCards = computed(() => {
+  if (!stats.value) return [];
+  const u = stats.value.unit;
+  return [
+    {
+      label: t('plugins.phd2logviewer.stats.totalRms'),
+      value: `${stats.value.rmsTotal}${u}`,
+      color: 'text-white',
+      sub: t('plugins.phd2logviewer.stats.combined'),
+    },
+    {
+      label: t('plugins.phd2logviewer.stats.raRms'),
+      value: `${stats.value.rmsRa}${u}`,
+      color: 'text-cyan-400',
+      sub: t('plugins.phd2logviewer.stats.rightAscension'),
+    },
+    {
+      label: t('plugins.phd2logviewer.stats.decRms'),
+      value: `${stats.value.rmsDec}${u}`,
+      color: 'text-orange-400',
+      sub: t('plugins.phd2logviewer.stats.declination'),
+    },
+    {
+      label: t('plugins.phd2logviewer.stats.peakRa'),
+      value: `${stats.value.peakRa}${u}`,
+      color: 'text-cyan-600',
+      sub: t('plugins.phd2logviewer.stats.maxError'),
+    },
+    {
+      label: t('plugins.phd2logviewer.stats.peakDec'),
+      value: `${stats.value.peakDec}${u}`,
+      color: 'text-orange-600',
+      sub: t('plugins.phd2logviewer.stats.maxError'),
+    },
+    {
+      label: t('plugins.phd2logviewer.stats.frames'),
+      value: stats.value.frameCount.toString(),
+      color: 'text-gray-300',
+      sub: t('plugins.phd2logviewer.stats.of', { total: stats.value.totalFrames }),
+    },
+  ];
+});
+
+function logLabel(name) {
+  const m = name.match(/PHD2_GuideLog_(\d{4}-\d{2}-\d{2})_(\d{2})(\d{2})(\d{2})/);
+  if (!m) return name;
+  return `${m[1]} ${m[2]}:${m[3]}:${m[4]}`;
+}
+
+// ── File handling ─────────────────────────────────────────────────────────
+function loadLogText(text, name) {
+  const result = parsePhd2Log(text);
+  fileName.value = name;
+  sessions.value = result.sessions;
+  calibrations.value = result.calibrations;
+  activeSessionIdx.value = 0;
+  activeTab.value = result.sessions.length ? 'guide' : 'cal';
+  fftPeak.value = '';
+  guideLabel.value = '';
+  resetZoom();
+}
+
+async function fetchLogList() {
+  loadingList.value = true;
+  listError.value = '';
+  try {
+    const base = pluginServerUrl.value;
+
+    // Step 1: get Documents folder (browse with no path → returns currentPath = Documents)
+    const docsRes = await fetch(`${base}/api/filesystem/browse`);
+    const docsData = await docsRes.json();
+    if (!docsData.success) throw new Error(docsData.error || 'Failed to browse Documents');
+
+    // Step 2: browse the PHD2 subfolder
+    const phd2Path = docsData.currentPath.replace(/\\/g, '/') + '/PHD2';
+    const phd2Res = await fetch(
+      `${base}/api/filesystem/browse?path=${encodeURIComponent(phd2Path)}`
+    );
+    const phd2Data = await phd2Res.json();
+    if (!phd2Data.success) throw new Error('PHD2 log directory not found');
+
+    const candidates = phd2Data.files.filter(
+      (f) => f.name.startsWith('PHD2_GuideLog_') && f.name.endsWith('.txt')
+    );
+
+    const checked = await Promise.all(
+      candidates.map(async (f) => {
+        try {
+          const r = await fetch(`${base}/api/filesystem/file?path=${encodeURIComponent(f.path)}`, {
+            headers: { Range: 'bytes=0-16383' },
+          });
+          const text = await r.text();
+          return text.includes('Guiding Begins') ? f : null;
+        } catch {
+          return null;
+        }
+      })
+    );
+
+    logFiles.value = checked
+      .filter(Boolean)
+      .sort((a, b) => b.lastModified.localeCompare(a.lastModified));
+  } catch (e) {
+    listError.value = e.message;
+  } finally {
+    loadingList.value = false;
+  }
+}
+
+async function loadSelectedLog() {
+  if (!selectedLogPath.value) return;
+  loadingFile.value = true;
+  listError.value = '';
+  try {
+    const res = await fetch(
+      `${pluginServerUrl.value}/api/filesystem/file?path=${encodeURIComponent(selectedLogPath.value)}`
+    );
+    if (!res.ok) throw new Error(`Server returned ${res.status}`);
+    const text = await res.text();
+    const name = selectedLogPath.value.split(/[\\/]/).pop();
+    loadLogText(text, name);
+  } catch (e) {
+    listError.value = e.message;
+  } finally {
+    loadingFile.value = false;
+  }
+}
+
+function clearLog() {
+  sessions.value = [];
+  calibrations.value = [];
+  fileName.value = '';
+  selectedLogPath.value = '';
+  activeSessionIdx.value = 0;
+  activeTab.value = 'guide';
+  fftPeak.value = '';
+  guideLabel.value = '';
+  resetZoom();
+}
+
+// ── Tab ───────────────────────────────────────────────────────────────────
+function setTab(tab) {
+  activeTab.value = tab;
+  nextTick(() => {
+    if (tab === 'guide') drawGuideChart();
+    if (tab === 'cal') drawCalibration();
+  });
+}
+
+// ── Zoom ──────────────────────────────────────────────────────────────────
+function resetZoom() {
+  xZoomStart.value = 0;
+  xZoomEnd.value = 1;
+  yZoom.value = 1.0;
+}
+
+function xZoomIn() {
+  const c = (xZoomStart.value + xZoomEnd.value) / 2,
+    h = xZoomSpan.value / 4;
+  xZoomStart.value = Math.max(0, c - h);
+  xZoomEnd.value = Math.min(1, c + h);
+  drawGuideChart();
+}
+
+function xZoomOut() {
+  const c = (xZoomStart.value + xZoomEnd.value) / 2,
+    h = xZoomSpan.value;
+  xZoomStart.value = Math.max(0, c - h);
+  xZoomEnd.value = Math.min(1, c + h);
+  drawGuideChart();
+}
+
+function yZoomIn() {
+  yZoom.value = Math.min(16, yZoom.value * 2);
+  drawGuideChart();
+}
+function yZoomOut() {
+  yZoom.value = Math.max(1, yZoom.value / 2);
+  drawGuideChart();
+}
+
+// ── Canvas: guide chart ───────────────────────────────────────────────────
+function drawGuideChart() {
+  const canvas = guideCanvas.value;
+  if (!canvas || !activeSession.value) return;
+
+  const session = activeSession.value;
+  const allFrames = session.frames;
+  if (!allFrames.length) return;
+
+  const dpr = window.devicePixelRatio || 1;
+  const rect = canvas.getBoundingClientRect();
+  if (!rect.width) return;
+  canvas.width = rect.width * dpr;
+  canvas.height = rect.height * dpr;
+  const ctx = canvas.getContext('2d');
+  ctx.scale(dpr, dpr);
+
+  const W = rect.width,
+    H = rect.height;
+  const PAD = { top: 14, right: 14, bottom: 36, left: 52 };
+  const PW = W - PAD.left - PAD.right;
+  const PH = H - PAD.top - PAD.bottom;
+
+  ctx.fillStyle = '#030712';
+  ctx.fillRect(0, 0, W, H);
+
+  const ps = session.info.pixelScale || 1;
+  const fullMinT = allFrames[0].time;
+  const fullMaxT = allFrames[allFrames.length - 1].time;
+  const fullSpan = fullMaxT - fullMinT || 1;
+
+  const viewMinT = fullMinT + xZoomStart.value * fullSpan;
+  const viewMaxT = fullMinT + xZoomEnd.value * fullSpan;
+  const viewSpan = viewMaxT - viewMinT || 1;
+
+  // Reconstruct raw (unguided) RA by accumulating guide corrections
+  let cumGuide = 0;
+  const rawRAValues = allFrames.map((f) => {
+    cumGuide += f.raGuide;
+    return (f.raRaw + cumGuide) * ps;
+  });
+
+  const maxErr = Math.max(
+    ...allFrames.flatMap((f) => [Math.abs(f.raRaw * ps), Math.abs(f.decRaw * ps)]),
+    ...(showRawRA.value ? rawRAValues.map(Math.abs) : []),
+    0.5
+  );
+  const yRange = Math.ceil(maxErr * 1.3 * 10) / 10 / yZoom.value;
+
+  const xOf = (t) => PAD.left + ((t - viewMinT) / viewSpan) * PW;
+  const yOf = (v) => PAD.top + PH / 2 - (v / yRange) * (PH / 2);
+
+  // Grid lines
+  ctx.strokeStyle = '#1f2937';
+  ctx.lineWidth = 1;
+  for (let i = 0; i <= 4; i++) {
+    const y = PAD.top + (PH / 4) * i;
+    ctx.beginPath();
+    ctx.moveTo(PAD.left, y);
+    ctx.lineTo(PAD.left + PW, y);
+    ctx.stroke();
+  }
+
+  // Dither regions
+  if (excludeDither.value && session.ditherFrames.size) {
+    ctx.fillStyle = 'rgba(234,179,8,0.08)';
+    const vis = allFrames.filter((f) => f.time >= viewMinT && f.time <= viewMaxT);
+    let inD = false,
+      dx0 = 0;
+    for (const f of vis) {
+      const is = session.ditherFrames.has(f.frame);
+      if (is && !inD) {
+        dx0 = xOf(f.time);
+        inD = true;
+      } else if (!is && inD) {
+        ctx.fillRect(dx0, PAD.top, xOf(f.time) - dx0, PH);
+        inD = false;
+      }
+    }
+    if (inD) ctx.fillRect(dx0, PAD.top, xOf(viewMaxT) - dx0, PH);
+  }
+
+  // Zero line
+  ctx.strokeStyle = '#374151';
+  ctx.lineWidth = 1;
+  ctx.setLineDash([4, 4]);
+  ctx.beginPath();
+  ctx.moveTo(PAD.left, yOf(0));
+  ctx.lineTo(PAD.left + PW, yOf(0));
+  ctx.stroke();
+  ctx.setLineDash([]);
+
+  // Data lines (clipped to plot area)
+  ctx.save();
+  ctx.beginPath();
+  ctx.rect(PAD.left, PAD.top, PW, PH);
+  ctx.clip();
+  const rawMap = new Map(allFrames.map((f, i) => [f, rawRAValues[i]]));
+  const drawLine = (color, getV) => {
+    ctx.strokeStyle = color;
+    ctx.lineWidth = 1.2;
+    ctx.beginPath();
+    let started = false;
+    for (const f of allFrames) {
+      const x = xOf(f.time),
+        y = yOf(getV(f));
+      if (!started) {
+        ctx.moveTo(x, y);
+        started = true;
+      } else {
+        ctx.lineTo(x, y);
+      }
+    }
+    ctx.stroke();
+  };
+  drawLine('#22d3ee', (f) => (showRawRA.value ? rawMap.get(f) : f.raRaw * ps));
+  drawLine('#fb923c', (f) => f.decRaw * ps);
+  ctx.restore();
+
+  // Y axis labels
+  const unit = session.info.pixelScale ? '"' : 'px';
+  ctx.fillStyle = '#cbd5e1';
+  ctx.font = '11px monospace';
+  ctx.textAlign = 'right';
+  for (let i = -2; i <= 2; i++) {
+    const v = (i / 2) * yRange;
+    ctx.fillText(v.toFixed(1) + unit, PAD.left - 4, yOf(v) + 3);
+  }
+
+  // Direction labels on right edge
+  const rx = PAD.left + PW + 3;
+  ctx.font = 'bold 9px monospace';
+  ctx.textAlign = 'left';
+  ctx.fillStyle = 'rgba(251,146,60,0.55)';
+  ctx.fillText('N', rx, PAD.top + 9);
+  ctx.fillText('S', rx, PAD.top + PH - 3);
+  ctx.fillStyle = 'rgba(34,211,238,0.55)';
+  ctx.fillText('E', rx, PAD.top + 20);
+  ctx.fillText('W', rx, PAD.top + PH - 14);
+
+  // X axis — tick labels anchored to full data range, scroll with pan
+  ctx.textAlign = 'center';
+  ctx.fillStyle = '#cbd5e1';
+  ctx.font = '11px monospace';
+  const niceIntervals = [5, 10, 15, 20, 30, 60, 120, 180, 300, 600, 900, 1200, 1800, 3600];
+  const targetTicks = Math.max(3, Math.floor(PW / 75));
+  const interval =
+    niceIntervals.find((iv) => fullSpan / iv <= targetTicks * 1.5) ||
+    niceIntervals[niceIntervals.length - 1];
+  for (let t = Math.ceil(fullMinT / interval) * interval; t <= fullMaxT; t += interval) {
+    if (t < viewMinT - interval || t > viewMaxT + interval) continue;
+    const x = xOf(t);
+    if (x < PAD.left - 1 || x > PAD.left + PW + 1) continue;
+    const rel = t - fullMinT;
+    ctx.fillText(
+      rel < 120 ? `${rel.toFixed(0)}s` : `${(rel / 60).toFixed(rel < 600 ? 1 : 0)}m`,
+      x,
+      H - 6
+    );
+  }
+
+  // Border
+  ctx.strokeStyle = '#374151';
+  ctx.lineWidth = 1;
+  ctx.strokeRect(PAD.left, PAD.top, PW, PH);
+
+  // Update label
+  const visCount = allFrames.filter((f) => f.time >= viewMinT && f.time <= viewMaxT).length;
+  const vd = viewMaxT - viewMinT;
+  const vm = Math.floor(vd / 60),
+    vs = Math.round(vd % 60);
+  const zoomSuffix =
+    xZoomStart.value === 0 && xZoomEnd.value === 1
+      ? ''
+      : `  ·  ${((xZoomEnd.value - xZoomStart.value) * 100) | 0}% view`;
+  guideLabel.value = `${unit === '"' ? `arcsec (${session.info.pixelScale}"/px)` : 'pixels'}  ·  ${visCount} frames  ·  ${vm}m ${vs}s${zoomSuffix}`;
+}
+
+// ── Canvas: calibration chart ─────────────────────────────────────────────
+function drawCalibration() {
+  const canvas = calCanvas.value;
+  const cal = activeCalibration.value;
+  if (!canvas || !cal?.steps.length) return;
+
+  const dpr = window.devicePixelRatio || 1;
+  const rect = canvas.getBoundingClientRect();
+  if (!rect.width) return;
+  canvas.width = rect.width * dpr;
+  canvas.height = rect.height * dpr;
+  const ctx = canvas.getContext('2d');
+  ctx.scale(dpr, dpr);
+
+  const W = rect.width,
+    H = rect.height;
+  const PAD = { top: 14, right: 14, bottom: 14, left: 14 };
+  const PW = W - PAD.left - PAD.right;
+  const PH = H - PAD.top - PAD.bottom;
+
+  ctx.fillStyle = '#030712';
+  ctx.fillRect(0, 0, W, H);
+
+  const origin = cal.steps[0];
+  const maxDist = Math.max(
+    ...cal.steps.map((s) => Math.sqrt((s.x - origin.x) ** 2 + (s.y - origin.y) ** 2)),
+    1
+  );
+  const range = maxDist * 1.18;
+  const cx = PAD.left + PW / 2,
+    cy = PAD.top + PH / 2;
+  const sc = Math.min(PW, PH) / 2 / range;
+  const px = (x) => cx + (x - origin.x) * sc;
+  const py = (y) => cy + (y - origin.y) * sc;
+
+  // Range circles + crosshair
+  ctx.strokeStyle = '#1f2937';
+  ctx.lineWidth = 0.5;
+  [0.25, 0.5, 0.75, 1.0].forEach((f) => {
+    ctx.beginPath();
+    ctx.arc(cx, cy, f * range * sc, 0, Math.PI * 2);
+    ctx.stroke();
+  });
+  ctx.setLineDash([3, 5]);
+  ctx.beginPath();
+  ctx.moveTo(PAD.left, cy);
+  ctx.lineTo(PAD.left + PW, cy);
+  ctx.stroke();
+  ctx.beginPath();
+  ctx.moveTo(cx, PAD.top);
+  ctx.lineTo(cx, PAD.top + PH);
+  ctx.stroke();
+  ctx.setLineDash([]);
+
+  // Step paths grouped by direction
+  const groups = {};
+  for (const s of cal.steps) (groups[s.direction] ??= []).push(s);
+  for (const [dir, steps] of Object.entries(groups)) {
+    const { stroke, dash } = CAL_COLORS[dir] || { stroke: '#cbd5e1', dash: [] };
+    ctx.strokeStyle = stroke;
+    ctx.lineWidth = 1.5;
+    ctx.setLineDash(dash);
+    ctx.beginPath();
+    steps.forEach((s, i) => {
+      i === 0 ? ctx.moveTo(px(s.x), py(s.y)) : ctx.lineTo(px(s.x), py(s.y));
+    });
+    ctx.stroke();
+    ctx.setLineDash([]);
+    const last = steps[steps.length - 1];
+    ctx.fillStyle = stroke;
+    ctx.beginPath();
+    ctx.arc(px(last.x), py(last.y), 3, 0, Math.PI * 2);
+    ctx.fill();
+  }
+
+  // Origin ring
+  ctx.strokeStyle = '#ffffff';
+  ctx.lineWidth = 1.5;
+  ctx.beginPath();
+  ctx.arc(px(cal.steps[0].x), py(cal.steps[0].y), 5, 0, Math.PI * 2);
+  ctx.stroke();
+
+  // Annotations
+  ctx.fillStyle = '#4b5563';
+  ctx.font = '10px monospace';
+  ctx.textAlign = 'left';
+  ctx.fillText(`±${range.toFixed(1)} px`, cx + 4, cy - range * sc - 4);
+  ctx.fillStyle = '#374151';
+  ctx.textAlign = 'center';
+  ctx.fillText('x →', PAD.left + PW - 8, cy - 4);
+  ctx.textAlign = 'right';
+  ctx.fillText('y ↓', cx - 4, PAD.top + 12);
+  ctx.strokeStyle = '#374151';
+  ctx.lineWidth = 1;
+  ctx.strokeRect(PAD.left, PAD.top, PW, PH);
+}
+
+// ── Canvas: FFT chart ─────────────────────────────────────────────────────
+function drawFftChart() {
+  const canvas = fftCanvas.value;
+  if (!canvas || !activeSession.value) return;
+
+  const frames = activeSession.value.frames.filter((f) => !excludedFrames.value.has(f.frame));
+  if (frames.length < 16) return;
+
+  const ps = activeSession.value.info.pixelScale || 1;
+  const signal = frames.map((f) => f.raRaw * ps);
+  const times = frames.map((f) => f.time);
+  const meanDt = (times[times.length - 1] - times[0]) / (times.length - 1) || 2;
+
+  const result = computeFFT(signal, meanDt);
+  if (!result) return;
+
+  const filtered = result.periods
+    .map((p, i) => ({ p, m: result.magnitudes[i] }))
+    .filter(({ p }) => p >= 10 && p <= 1800);
+  if (!filtered.length) return;
+
+  const peak = filtered.reduce((a, b) => (b.m > a.m ? b : a));
+  fftPeak.value = `${(peak.p / 60).toFixed(1)} min`;
+
+  const dpr = window.devicePixelRatio || 1;
+  const rect = canvas.getBoundingClientRect();
+  if (!rect.width) return;
+  canvas.width = rect.width * dpr;
+  canvas.height = rect.height * dpr;
+  const ctx = canvas.getContext('2d');
+  ctx.scale(dpr, dpr);
+
+  const W = rect.width,
+    H = rect.height;
+  const PAD = { top: 10, right: 14, bottom: 36, left: 52 };
+  const PW = W - PAD.left - PAD.right;
+  const PH = H - PAD.top - PAD.bottom;
+
+  ctx.fillStyle = '#030712';
+  ctx.fillRect(0, 0, W, H);
+
+  const maxMag = Math.max(...filtered.map((d) => d.m), 0.01);
+  const pMin = filtered[0].p,
+    pMax = filtered[filtered.length - 1].p;
+  const pSpan = pMax - pMin || 1;
+  const barW = Math.max(1, PW / filtered.length);
+
+  filtered.forEach(({ p, m }) => {
+    const x = PAD.left + ((p - pMin) / pSpan) * PW;
+    const bh = (m / maxMag) * PH;
+    ctx.fillStyle = p === peak.p ? 'rgba(34,211,238,0.85)' : 'rgba(34,211,238,0.3)';
+    ctx.fillRect(x, PAD.top + PH - bh, Math.max(1, barW - 0.5), bh);
+  });
+
+  const unit = activeSession.value.info.pixelScale ? '"' : 'px';
+  const numTicks = Math.min(8, Math.max(3, Math.floor(PW / 80)));
+  ctx.font = '11px monospace';
+  ctx.textAlign = 'center';
+  ctx.fillStyle = '#cbd5e1';
+  for (let i = 0; i <= numTicks; i++) {
+    const p = pMin + (i / numTicks) * pSpan;
+    const x = PAD.left + (i / numTicks) * PW;
+    ctx.fillText(
+      p >= 60 ? `${(p / 60).toFixed(p >= 120 ? 0 : 1)}m` : `${Math.round(p)}s`,
+      x,
+      H - 6
+    );
+    ctx.strokeStyle = '#1f2937';
+    ctx.lineWidth = 0.5;
+    ctx.beginPath();
+    ctx.moveTo(x, PAD.top);
+    ctx.lineTo(x, PAD.top + PH);
+    ctx.stroke();
+  }
+
+  ctx.textAlign = 'right';
+  ctx.fillStyle = '#cbd5e1';
+  ctx.font = '11px monospace';
+  for (let i = 0; i <= 3; i++) {
+    const v = (i / 3) * maxMag,
+      y = PAD.top + PH - (i / 3) * PH;
+    ctx.fillText(v.toFixed(2) + unit, PAD.left - 4, y + 3);
+    ctx.strokeStyle = '#1f2937';
+    ctx.lineWidth = 0.5;
+    ctx.beginPath();
+    ctx.moveTo(PAD.left, y);
+    ctx.lineTo(PAD.left + PW, y);
+    ctx.stroke();
+  }
+
+  ctx.strokeStyle = '#374151';
+  ctx.lineWidth = 1;
+  ctx.strokeRect(PAD.left, PAD.top, PW, PH);
+}
+
+function redrawAll() {
+  nextTick(() => {
+    if (activeTab.value === 'guide') drawGuideChart();
+    if (activeTab.value === 'cal') drawCalibration();
+    drawFftChart();
+  });
+}
+
+// ── Watchers ──────────────────────────────────────────────────────────────
+watch([activeSession, excludeDither, showRawRA], () => {
+  nextTick(() => {
+    drawGuideChart();
+    drawFftChart();
+  });
+});
+watch(activeTab, (tab) => {
+  nextTick(() => {
+    if (tab === 'guide') drawGuideChart();
+    if (tab === 'cal') drawCalibration();
+  });
+});
+
+// ── Drag-to-pan ───────────────────────────────────────────────────────────
+let dragState = null;
+
+watch(guideCanvas, (canvas) => {
+  if (!canvas) return;
+  function dragStart(clientX) {
+    if (xZoomEnd.value - xZoomStart.value >= 1) return;
+    dragState = { startX: clientX, z0: xZoomStart.value, z1: xZoomEnd.value };
+    canvas.style.cursor = 'grabbing';
+  }
+  function dragMove(clientX) {
+    if (!dragState) return;
+    const span = dragState.z1 - dragState.z0;
+    const delta = ((dragState.startX - clientX) / canvas.clientWidth) * span;
+    xZoomStart.value = Math.max(0, Math.min(1 - span, dragState.z0 + delta));
+    xZoomEnd.value = xZoomStart.value + span;
+    drawGuideChart();
+  }
+  function dragEnd() {
+    dragState = null;
+    canvas.style.cursor = xZoomStart.value <= 0 && xZoomEnd.value >= 1 ? '' : 'grab';
+  }
+  canvas.addEventListener('mousedown', (e) => dragStart(e.clientX));
+  window.addEventListener('mousemove', (e) => dragMove(e.clientX));
+  window.addEventListener('mouseup', () => dragEnd());
+  canvas.addEventListener(
+    'touchstart',
+    (e) => {
+      e.preventDefault();
+      dragStart(e.touches[0].clientX);
+    },
+    { passive: false }
+  );
+  window.addEventListener(
+    'touchmove',
+    (e) => {
+      if (dragState) {
+        e.preventDefault();
+        dragMove(e.touches[0].clientX);
+      }
+    },
+    { passive: false }
+  );
+  window.addEventListener('touchend', () => dragEnd());
+  canvas.addEventListener('mouseenter', () => {
+    if (xZoomEnd.value - xZoomStart.value < 1) canvas.style.cursor = 'grab';
+  });
+  canvas.addEventListener('mouseleave', () => {
+    if (!dragState) canvas.style.cursor = '';
+  });
+});
+
+// ── Resize handling ───────────────────────────────────────────────────────
+let resizeObserver = null;
+
+onMounted(() => {
+  resizeObserver = new ResizeObserver(redrawAll);
+  if (rootEl.value) resizeObserver.observe(rootEl.value);
+  fetchLogList();
+});
+
+onBeforeUnmount(() => resizeObserver?.disconnect());
+</script>
+
+<style scoped>
+.zoom-btn {
+  @apply flex h-7 w-7 items-center justify-center rounded-md border border-gray-600 bg-gray-800/50 text-sm font-semibold text-gray-300 transition hover:bg-gray-700/60 disabled:cursor-default disabled:opacity-30;
+}
+</style>


### PR DESCRIPTION
## Summary

- Adds a new **PHD2 Log Viewer** plugin that lets users inspect PHD2 guiding sessions directly from the TNS interface — no need to go back to the NINA/PINS machine
- Uses the existing `FilesystemController` endpoints (`/api/filesystem/browse` + `/api/filesystem/file`) — no C# changes required
- Filters log files by fetching the first 16 KB and checking for a `Guiding Begins` line, so only sessions with actual guiding data appear in the dropdown

## Features

- **Guide graph** — canvas-based RA + Dec error plot, HiDPI, zoom and drag-to-pan
- **RMS statistics** — Total/RA/Dec RMS, Peak RA/Dec, frame count; in arcsec when pixel scale is available
- **FFT periodic error analysis** — Hann-windowed FFT bar chart with dominant period badge
- **Calibration tab** — step path plot (West/East/North/South/Backlash) + results table
- **Auto-exclude dither settling** — marks frames after each dither event
- **Raw, uncorrected RA toggle** — reconstructs unguided RA by accumulating guide corrections
- **Multi-session support** — dropdown when a log contains multiple guiding sessions
- **Session info panel** — start/end time, duration, focal length, pixel scale
- Full i18n (English strings in `en.json`)

## Test plan

- [ ] Open TNS, navigate to PHD2 Log Viewer in the plugin nav
- [ ] Dropdown populates with logs from `~/Documents/PHD2/` that contain guiding data
- [ ] Selecting a log renders the guide graph, statistics, and calibration tab
- [ ] Zoom, pan, dither exclusion, raw RA toggle all work
- [ ] FFT chart appears and dominant period badge is shown
- [ ] Multi-session logs show a session selector
- [ ] Plugin works on both desktop and mobile layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)