### PR TITLE
fix(sequence): correct altitude chart for negative Dec targets

### DIFF
--- a/src/components/framing/SkyChart.vue
+++ b/src/components/framing/SkyChart.vue
@@ -106,7 +106,7 @@ function interpolateHorizon(azimuth) {
 }
 
 const altitudeData = computed(() => {
-  if (!props.target?.RA || !props.target?.Dec) return [];
+  if (props.target?.RA == null || props.target?.Dec == null) return [];
 
   const points = [];
   const steps = 96; // 24h * 4 (alle 15 Minuten)

--- a/src/components/sequence/RecursiveItemState.vue
+++ b/src/components/sequence/RecursiveItemState.vue
@@ -1125,7 +1125,7 @@ function getTargetForSkyChart(target) {
   const decSeconds = coords.DecSeconds || 0;
   let decDegrees = degrees + decMinutes / 60 + decSeconds / 3600;
 
-  if (coords.NegativeDec) {
+  if (coords.NegativeDec || (coords.DecDegrees ?? 0) < 0) {
     decDegrees = -decDegrees;
   }
   return {

--- a/src/components/sequence/SequenceItem.vue
+++ b/src/components/sequence/SequenceItem.vue
@@ -329,8 +329,8 @@ const dsoTarget = computed(() => {
   const co = t.InputCoordinates;
   if (!co) return null;
   const raH = (co.RAHours ?? 0) + (co.RAMinutes ?? 0) / 60 + (co.RASeconds ?? 0) / 3600;
-  const decAbs = (co.DecDegrees ?? 0) + (co.DecMinutes ?? 0) / 60 + (co.DecSeconds ?? 0) / 3600;
-  return { RA: raH * 15, Dec: co.NegativeDec ? -decAbs : decAbs };
+  const decAbs = Math.abs(co.DecDegrees ?? 0) + (co.DecMinutes ?? 0) / 60 + (co.DecSeconds ?? 0) / 3600;
+  return { RA: raH * 15, Dec: (co.NegativeDec || (co.DecDegrees ?? 0) < 0) ? -decAbs : decAbs };
 });
 const typeComponent = computed(() => ITEM_COMPONENTS[props.item.FullTypeName] ?? GenericItem);
 


### PR DESCRIPTION
## Summary

The target altitude chart in the sequencer showed incorrect (too high) altitudes for targets with negative declination (southern sky objects).

**Root cause:** NINA can send `DecDegrees` as a negative value (e.g. `-20`) alongside `NegativeDec: true`. Without `Math.abs`, the calculation becomes `(-20 + minutes/60 + seconds/3600)` = `-19.5`, then flipping the sign gives `+19.5` — showing the target ~40° higher than reality.

The correct pattern is already documented in `coordinateUtils.js`: use `Math.abs(DecDegrees)` and check `NegativeDec || DecDegrees < 0` for the sign.

## Changes

- **`SequenceItem.vue`**: add `Math.abs` to Dec degrees and check `NegativeDec || DecDegrees < 0`
- **`RecursiveItemState.vue`**: same sign check fix (already had `Math.abs`)
- **`SkyChart.vue`**: fix guard `!Dec` → `Dec == null` (previously dropped Dec=0 targets silently)

## Test plan

- [ ] Add a DSO container with a target at negative Dec (e.g. anything in Orion, Lepus, southern Eridanus) — verify the altitude chart peak matches what planetarium software shows
- [ ] Verify a Dec=0 target (celestial equator) still shows a chart

🤖 Generated with [Claude Code](https://claude.com/claude-code)