### PR TITLE
feat(target-scheduler): add twilight/sun/moon session modes and moon …

### DIFF
--- a/src/locales/cn.json
+++ b/src/locales/cn.json
@@ -162,7 +162,8 @@
         "setMosaicTargets": "设置马赛克目标",
         "title": "马赛克模式",
         "willBeSaved": "面板将单独保存"
-      }
+      },
+      "customTarget": "Custom Target"
     },
     "tutorial": {
       "previous": "上一步",
@@ -1452,7 +1453,15 @@
       "status_stopped_darks": "Stopped early - {completed} of {total} darks captured",
       "status_stopped_flats": "Stopped early - {completed} of {total} flats captured",
       "status_success_darks": "Done - {count} darks captured",
-      "status_success_flats": "Done - {count} flats captured"
+      "status_success_flats": "Done - {count} flats captured",
+      "filter_label": "Filter",
+      "result_bright": "too bright",
+      "result_dim": "too dim",
+      "status_completed_flats": "Completed",
+      "status_failed_flats_multi": "All filters failed to determine valid exposure",
+      "status_partial_flats_multi": "Failed filters: {filters}",
+      "status_running_unknown": "Determining…",
+      "target": "Target"
     },
     "weatherModal": {
       "weatherInformation": "天气信息",
@@ -1479,7 +1488,13 @@
     },
     "switch": {
       "gauges": "仪表",
-      "switch": "开关"
+      "switch": "开关",
+      "indi": {
+        "settings": "Switch Settings"
+      },
+      "sv241pro": {
+        "preConnectDelay": "Pre Connect Delay (ms)"
+      }
     },
     "stellarium": {
       "selected_object": {
@@ -3494,7 +3509,10 @@
         "timeWindowEnd": "Time window end",
         "timeWindowHint": "Leave time window blank to allow scheduling for the full session range.",
         "timeWindowStart": "Time window start",
-        "title": "Constraints"
+        "title": "Constraints",
+        "maxMoonAltitude": "Max moon altitude",
+        "maxMoonAltitudeHint": "Set to 0° or below to schedule only while the Moon is below the horizon.",
+        "minMoonSeparationInfo": "Minimum angular distance between target and Moon required for scheduling."
       },
       "defaults": {
         "favoriteTargetName": "Favorite Target",
@@ -3607,6 +3625,17 @@
       },
       "warnings": {
         "sequenceVersionRequired": "Sequence insertion requires TNS plugin 1.2.8.0  (or PINS mode)."
+      },
+      "sessionModes": {
+        "moonRise": "Moon rise",
+        "moonSet": "Moon set",
+        "sunRise": "Sun rise",
+        "sunSet": "Sun set",
+        "time": "Time",
+        "twilightEndAstronomical": "Twilight end astronomical",
+        "twilightEndNautical": "Twilight end nautical",
+        "twilightStartAstronomical": "Twilight start astronomical",
+        "twilightStartNautical": "Twilight start nautical"
       }
     },
     "filterOffset": {

--- a/src/locales/cz.json
+++ b/src/locales/cz.json
@@ -162,7 +162,8 @@
         "setMosaicTargets": "Stanovte si mozaikové cíle",
         "panelsSet": "panely nastavené v pořadí",
         "willBeSaved": "panely budou uloženy jednotlivě"
-      }
+      },
+      "customTarget": "Custom Target"
     },
     "tutorial": {
       "previous": "Předchozí",
@@ -1452,7 +1453,15 @@
       "status_stopped_darks": "Stopped early - {completed} of {total} darks captured",
       "status_stopped_flats": "Stopped early - {completed} of {total} flats captured",
       "status_success_darks": "Done - {count} darks captured",
-      "status_success_flats": "Done - {count} flats captured"
+      "status_success_flats": "Done - {count} flats captured",
+      "filter_label": "Filter",
+      "result_bright": "too bright",
+      "result_dim": "too dim",
+      "status_completed_flats": "Completed",
+      "status_failed_flats_multi": "All filters failed to determine valid exposure",
+      "status_partial_flats_multi": "Failed filters: {filters}",
+      "status_running_unknown": "Determining…",
+      "target": "Target"
     },
     "weatherModal": {
       "weatherInformation": "Informace o Počasí",
@@ -1479,7 +1488,13 @@
     },
     "switch": {
       "gauges": "Měřící přístroje",
-      "switch": "Přepínač"
+      "switch": "Přepínač",
+      "indi": {
+        "settings": "Switch Settings"
+      },
+      "sv241pro": {
+        "preConnectDelay": "Pre Connect Delay (ms)"
+      }
     },
     "stellarium": {
       "selected_object": {
@@ -3494,7 +3509,10 @@
         "timeWindowEnd": "Time window end",
         "timeWindowHint": "Leave time window blank to allow scheduling for the full session range.",
         "timeWindowStart": "Time window start",
-        "title": "Constraints"
+        "title": "Constraints",
+        "maxMoonAltitude": "Max moon altitude",
+        "maxMoonAltitudeHint": "Set to 0° or below to schedule only while the Moon is below the horizon.",
+        "minMoonSeparationInfo": "Minimum angular distance between target and Moon required for scheduling."
       },
       "defaults": {
         "favoriteTargetName": "Favorite Target",
@@ -3607,6 +3625,17 @@
       },
       "warnings": {
         "sequenceVersionRequired": "Sequence insertion requires TNS plugin 1.2.8.0  (or PINS mode)."
+      },
+      "sessionModes": {
+        "moonRise": "Moon rise",
+        "moonSet": "Moon set",
+        "sunRise": "Sun rise",
+        "sunSet": "Sun set",
+        "time": "Time",
+        "twilightEndAstronomical": "Twilight end astronomical",
+        "twilightEndNautical": "Twilight end nautical",
+        "twilightStartAstronomical": "Twilight start astronomical",
+        "twilightStartNautical": "Twilight start nautical"
       }
     },
     "filterOffset": {

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -202,7 +202,8 @@
       "moveRotator": "Camera rotieren",
       "infoTargetImage": "Wenn das Bild nur in Schwarz angezeigt wird, muss der 'Offline Sky Map Cache' in NINA eingerichtet oder die Option 'NINA cache' deaktiviert werden",
       "useCenter": "Center",
-      "useRotate": "Rotieren"
+      "useRotate": "Rotieren",
+      "customTarget": "Benutzerdefiniertes Ziel"
     },
     "tutorial": {
       "previous": "Zurück",
@@ -1492,7 +1493,15 @@
       "status_failed": "Fehlgeschlagen",
       "status_running": "Läuft",
       "status_stopped": "Angehalten",
-      "status_success": "Erfolgreich"
+      "status_success": "Erfolgreich",
+      "filter_label": "Filter",
+      "result_bright": "zu hell",
+      "result_dim": "zu dunkel",
+      "status_completed_flats": "Vollendet",
+      "status_failed_flats_multi": "Alle Filter konnten keine gültige Belichtung ermitteln",
+      "status_partial_flats_multi": "Fehlerhafte Filter: {filters}",
+      "status_running_unknown": "Bestimmen…",
+      "target": "Ziel"
     },
     "weatherModal": {
       "weatherInformation": "Wetterinformationen",
@@ -1519,7 +1528,13 @@
     },
     "switch": {
       "gauges": "Messwerte",
-      "switch": "Schalter"
+      "switch": "Schalter",
+      "indi": {
+        "settings": "Einstellungen wechseln"
+      },
+      "sv241pro": {
+        "preConnectDelay": "Pre-Connect-Verzögerung (ms)"
+      }
     },
     "stellarium": {
       "selected_object": {
@@ -3531,6 +3546,17 @@
         "siteAlt": "Höhe",
         "scheduled": "geplant"
       },
+      "sessionModes": {
+        "time": "Zeit",
+        "twilightEndNautical": "Nautische Daemmerung Ende",
+        "twilightEndAstronomical": "Astronomische Daemmerung Ende",
+        "sunSet": "Sonnenuntergang",
+        "moonSet": "Monduntergang",
+        "twilightStartNautical": "Nautische Daemmerung Beginn",
+        "twilightStartAstronomical": "Astronomische Daemmerung Beginn",
+        "sunRise": "Sonnenaufgang",
+        "moonRise": "Mondaufgang"
+      },
       "warnings": {
         "sequenceVersionRequired": "Für das Einfügen in die Sequenz wird TNS-Plugin 1.2.8.0+ benötigt (oder PINS-Modus)."
       },
@@ -3554,6 +3580,9 @@
         "minAltitude": "Minimale Höhe",
         "maxAltitude": "Maximale Höhe",
         "minMoonSeparation": "Mindest-Mondabstand",
+        "minMoonSeparationInfo": "Minimaler Winkelabstand zwischen Ziel und Mond, der fuer die Planung erforderlich ist.",
+        "maxMoonAltitude": "Maximale Mondhoehe",
+        "maxMoonAltitudeHint": "Auf 0° oder darunter setzen, um nur bei Mond unter dem Horizont zu planen.",
         "timeWindowStart": "Zeitfenster Start",
         "timeWindowEnd": "Zeitfenster Ende",
         "timeWindowHint": "Zeitfenster leer lassen, um den gesamten Sitzungszeitraum zu planen."

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -3546,6 +3546,17 @@
         "siteAlt": "alt",
         "scheduled": "scheduled"
       },
+      "sessionModes": {
+        "time": "Time",
+        "twilightEndNautical": "Twilight end nautical",
+        "twilightEndAstronomical": "Twilight end astronomical",
+        "sunSet": "Sun set",
+        "moonSet": "Moon set",
+        "twilightStartNautical": "Twilight start nautical",
+        "twilightStartAstronomical": "Twilight start astronomical",
+        "sunRise": "Sun rise",
+        "moonRise": "Moon rise"
+      },
       "warnings": {
         "sequenceVersionRequired": "Sequence insertion requires TNS plugin 1.2.8.0+ (or PINS mode)."
       },
@@ -3569,6 +3580,9 @@
         "minAltitude": "Min altitude",
         "maxAltitude": "Max altitude",
         "minMoonSeparation": "Min moon separation",
+        "minMoonSeparationInfo": "Minimum angular distance between target and Moon required for scheduling.",
+        "maxMoonAltitude": "Max moon altitude",
+        "maxMoonAltitudeHint": "Set to 0° or below to schedule only while the Moon is below the horizon.",
         "timeWindowStart": "Time window start",
         "timeWindowEnd": "Time window end",
         "timeWindowHint": "Leave time window blank to allow scheduling for the full session range."

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -162,7 +162,8 @@
         "setMosaicTargets": "Establecer objetivos de mosaico",
         "panelsSet": "paneles colocados en secuencia",
         "willBeSaved": "Los paneles se guardarán individualmente."
-      }
+      },
+      "customTarget": "Objetivo personalizado"
     },
     "tutorial": {
       "previous": "Anterior",
@@ -1452,7 +1453,15 @@
       "status_stopped_darks": "Detenido antes de tiempo: {completed} de {total} oscuridades capturadas",
       "status_stopped_flats": "Detenido antes de tiempo: {completed} de {total} departamentos capturados",
       "status_success_darks": "Listo: {count} darks capturados",
-      "status_success_flats": "Listo: {count} flats capturados"
+      "status_success_flats": "Listo: {count} flats capturados",
+      "filter_label": "Filtrar",
+      "result_bright": "demasiado brillante",
+      "result_dim": "demasiado oscuro",
+      "status_completed_flats": "Terminado",
+      "status_failed_flats_multi": "Ninguno de los filtros pudo determinar la exposición válida",
+      "status_partial_flats_multi": "Filtros fallidos: {filters}",
+      "status_running_unknown": "Determinando…",
+      "target": "Objetivo"
     },
     "weatherModal": {
       "weatherInformation": "Información meteorológica",
@@ -1479,7 +1488,13 @@
     },
     "switch": {
       "gauges": "Medidores",
-      "switch": "Cambiar"
+      "switch": "Cambiar",
+      "indi": {
+        "settings": "Cambiar configuración"
+      },
+      "sv241pro": {
+        "preConnectDelay": "Retardo previo a la conexión (ms)"
+      }
     },
     "stellarium": {
       "selected_object": {
@@ -3494,7 +3509,10 @@
         "timeWindowEnd": "Fin de la ventana de tiempo",
         "timeWindowHint": "Deje la ventana de tiempo en blanco para permitir la programación para todo el rango de sesiones.",
         "timeWindowStart": "Inicio de la ventana de tiempo",
-        "title": "Restricciones"
+        "title": "Restricciones",
+        "maxMoonAltitude": "Altitud máxima de la luna",
+        "maxMoonAltitudeHint": "Configúrelo en 0° o menos para programar solo mientras la Luna esté debajo del horizonte.",
+        "minMoonSeparationInfo": "Distancia angular mínima entre el objetivo y la Luna requerida para la programación."
       },
       "defaults": {
         "favoriteTargetName": "Objetivo favorito",
@@ -3567,7 +3585,9 @@
         "sessionStart": "Inicio de sesión",
         "siteAlt": "alternativo",
         "siteLat": "Latitud del sitio",
-        "siteLon": "lon"
+        "siteLon": "lon",
+        "maxChunkInfo": "Limita el bloque programado continuo máximo por objetivo antes de que el programador pueda cambiar a otro objetivo.",
+        "samplingStepInfo": "Define el intervalo de cálculo en minutos. \nLos valores más bajos aumentan la precisión pero evalúan más puntos de la línea de tiempo."
       },
       "subtitle": "Planificación móvil primero para visibilidad de objetivos, restricciones e inserción de secuencias.",
       "targetCard": {
@@ -3605,6 +3625,17 @@
       },
       "warnings": {
         "sequenceVersionRequired": "La inserción de secuencia requiere el complemento TNS 1.2.8.0 (o modo PINS)."
+      },
+      "sessionModes": {
+        "moonRise": "salida de la luna",
+        "moonSet": "Conjunto de luna",
+        "sunRise": "Amanecer",
+        "sunSet": "Atardecer",
+        "time": "Tiempo",
+        "twilightEndAstronomical": "Crepúsculo final astronómico",
+        "twilightEndNautical": "Crepúsculo final náutico",
+        "twilightStartAstronomical": "Inicio del crepúsculo astronómico",
+        "twilightStartNautical": "Crepúsculo inicio náutico"
       }
     },
     "filterOffset": {
@@ -3713,6 +3744,77 @@
       "visVisible": "Visible tonight",
       "visHidden": "Below horizon tonight",
       "page": "{n} / {total}"
+    },
+    "phd2logviewer": {
+      "cal": {
+        "angle": "Ángulo (°)",
+        "axis": "Eje",
+        "backlash": "Reacción",
+        "dist": "Dist (px)",
+        "noData": "No hay datos de calibración para esta sesión.",
+        "noSummary": "No hay datos resumidos (es posible que se haya interrumpido la calibración)",
+        "over": "encima",
+        "parity": "Paridad",
+        "rate": "Velocidad (px/s)",
+        "steps": "Pasos"
+      },
+      "clear": "Claro",
+      "emptyState": "Seleccione un registro de guía PHD2 del menú desplegable de arriba.",
+      "excludeDither": "Excluir automáticamente la resolución de tramado",
+      "fft": {
+        "dominantPeriod": "Periodo dominante",
+        "subtitle": "Identifica armónicos de error periódico en el guiado RA.",
+        "title": "Análisis de frecuencia AR"
+      },
+      "info": {
+        "camera": "Cámara",
+        "duration": "Duración",
+        "ended": "Terminado",
+        "focalLength": "Longitud focal",
+        "mount": "Montar",
+        "pixelScale": "Escala de píxeles",
+        "profile": "Perfil",
+        "started": "Sesión iniciada",
+        "totalFrames": "Cuadros totales"
+      },
+      "legend": {
+        "dec": "Dic",
+        "dither": "Vacilar",
+        "ra": "REAL ACADEMIA DE BELLAS ARTES",
+        "raRaw": "RA (cruda)"
+      },
+      "loading": "Cargando…",
+      "noLogs": "No se encontraron registros",
+      "rawRa": "AR cruda y sin corregir",
+      "refresh": "Actualizar lista de registros",
+      "selectLog": "— seleccione un registro —",
+      "session": "Sesión:",
+      "settings": {
+        "notConfigured": "Configure el directorio de registro de PHD2",
+        "placeholder": "No hay ruta configurada",
+        "saveError": "No se pudo guardar la ruta",
+        "title": "Directorio de registros"
+      },
+      "statistics": "Estadística",
+      "stats": {
+        "combined": "conjunto",
+        "decRms": "RMS de diciembre",
+        "declination": "declinación",
+        "frames": "Marcos",
+        "maxError": "error máximo",
+        "of": "de {total}",
+        "peakDec": "Pico diciembre",
+        "peakRa": "RA máxima",
+        "raRms": "RA RMS",
+        "rightAscension": "ascensión recta",
+        "totalRms": "RMS totales"
+      },
+      "subtitle": "Seleccione un registro de guía PHD2 para visualizar el rendimiento y las estadísticas de la guía.",
+      "tabs": {
+        "calibration": "Calibración",
+        "guide": "Gráfico guía"
+      },
+      "title": "Visor de registros PHD2"
     }
   },
   "pinsDevices": {
@@ -4015,7 +4117,13 @@
       "smtpSsl": "Usar TLS/SSL",
       "testDiscord": "Enviar mensaje de prueba",
       "testEmail": "Enviar correo electrónico de prueba",
-      "testPushover": "Enviar notificación de prueba"
+      "testPushover": "Enviar notificación de prueba",
+      "localDashboardEnabled": "Habilitar servidor web local",
+      "localDashboardHint": "Proporciona su historial de sesiones desde un servidor web local accesible desde cualquier navegador de su red. \nUtilice una VPN para acceso remoto.",
+      "localDashboardPort": "Puerto",
+      "localDashboardTitle": "Panel de control local",
+      "showChartFilterChips": "Mostrar fila de chips de filtro",
+      "showChartTargetChips": "Mostrar fila de chips objetivo"
     },
     "stats": {
       "accepted": "Aceptado",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -162,7 +162,8 @@
         "setMosaicTargets": "Définir des cibles de mosaïque",
         "panelsSet": "panneaux disposés en séquence",
         "willBeSaved": "les panneaux seront enregistrés individuellement"
-      }
+      },
+      "customTarget": "Cible personnalisée"
     },
     "tutorial": {
       "previous": "Précédent",
@@ -1452,7 +1453,15 @@
       "status_stopped_darks": "Arrêté plus tôt – {terminé} sur {total} darks capturés",
       "status_stopped_flats": "Arrêté prématurément – {terminé} sur {total} appartements capturés",
       "status_success_darks": "Terminé – {count} darks capturés",
-      "status_success_flats": "Terminé – {count} appartements capturés"
+      "status_success_flats": "Terminé – {count} appartements capturés",
+      "filter_label": "Filtre",
+      "result_bright": "trop brillant",
+      "result_dim": "trop sombre",
+      "status_completed_flats": "Complété",
+      "status_failed_flats_multi": "Tous les filtres n'ont pas réussi à déterminer une exposition valide",
+      "status_partial_flats_multi": "Filtres ayant échoué : {filters}",
+      "status_running_unknown": "Déterminer…",
+      "target": "Cible"
     },
     "weatherModal": {
       "weatherInformation": "Informations météorologiques",
@@ -1479,7 +1488,13 @@
     },
     "switch": {
       "gauges": "Jauges",
-      "switch": "Commutateur"
+      "switch": "Commutateur",
+      "indi": {
+        "settings": "Paramètres du commutateur"
+      },
+      "sv241pro": {
+        "preConnectDelay": "Délai de pré-connexion (ms)"
+      }
     },
     "stellarium": {
       "selected_object": {
@@ -3494,7 +3509,10 @@
         "timeWindowEnd": "Fin de la fenêtre horaire",
         "timeWindowHint": "Laissez la fenêtre horaire vide pour permettre la planification de la plage complète des sessions.",
         "timeWindowStart": "Début de la fenêtre horaire",
-        "title": "Contraintes"
+        "title": "Contraintes",
+        "maxMoonAltitude": "Altitude maximale de la lune",
+        "maxMoonAltitudeHint": "Réglez sur 0° ou moins pour programmer uniquement lorsque la Lune est sous l'horizon.",
+        "minMoonSeparationInfo": "Distance angulaire minimale entre la cible et la Lune requise pour la planification."
       },
       "defaults": {
         "favoriteTargetName": "Cible préférée",
@@ -3607,6 +3625,17 @@
       },
       "warnings": {
         "sequenceVersionRequired": "L'insertion de séquence nécessite le plugin TNS 1.2.8.0 (ou le mode PINS)."
+      },
+      "sessionModes": {
+        "moonRise": "Lever de la lune",
+        "moonSet": "Lune réglée",
+        "sunRise": "Lever du soleil",
+        "sunSet": "Coucher de soleil",
+        "time": "Temps",
+        "twilightEndAstronomical": "Fin du crépuscule astronomique",
+        "twilightEndNautical": "Fin du crépuscule nautique",
+        "twilightStartAstronomical": "Le crépuscule commence astronomique",
+        "twilightStartNautical": "Début du crépuscule nautique"
       }
     },
     "filterOffset": {

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -162,7 +162,8 @@
         "setMosaicTargets": "Stabilisci obiettivi a mosaico",
         "panelsSet": "pannelli disposti in sequenza",
         "willBeSaved": "i pannelli verranno salvati singolarmente"
-      }
+      },
+      "customTarget": "Obiettivo personalizzato"
     },
     "tutorial": {
       "previous": "Precedente",
@@ -1452,7 +1453,15 @@
       "status_stopped_darks": "Interrotto in anticipo: {completato} di {totale} oscuri catturati",
       "status_stopped_flats": "Interrotto in anticipo: {completato} di {totale} appartamenti catturati",
       "status_success_darks": "Fatto: {count} oscuri catturati",
-      "status_success_flats": "Fatto: {count} appartamenti catturati"
+      "status_success_flats": "Fatto: {count} appartamenti catturati",
+      "filter_label": "Filtro",
+      "result_bright": "troppo luminoso",
+      "result_dim": "troppo debole",
+      "status_completed_flats": "Completato",
+      "status_failed_flats_multi": "Tutti i filtri non sono riusciti a determinare un'esposizione valida",
+      "status_partial_flats_multi": "Filtri non riusciti: {filters}",
+      "status_running_unknown": "Determinazione...",
+      "target": "Bersaglio"
     },
     "weatherModal": {
       "weatherInformation": "Informazioni meteo",
@@ -1479,7 +1488,13 @@
     },
     "switch": {
       "gauges": "Misuratori",
-      "switch": "Interruttore"
+      "switch": "Interruttore",
+      "indi": {
+        "settings": "Cambia impostazioni"
+      },
+      "sv241pro": {
+        "preConnectDelay": "Ritardo pre-connessione (ms)"
+      }
     },
     "stellarium": {
       "selected_object": {
@@ -3494,7 +3509,10 @@
         "timeWindowEnd": "Fine della finestra temporale",
         "timeWindowHint": "Lasciare vuota la finestra temporale per consentire la pianificazione dell'intero intervallo di sessioni.",
         "timeWindowStart": "Inizio della finestra temporale",
-        "title": "Vincoli"
+        "title": "Vincoli",
+        "maxMoonAltitude": "Altitudine massima della luna",
+        "maxMoonAltitudeHint": "Impostare su 0° o inferiore per programmare solo mentre la Luna è sotto l'orizzonte.",
+        "minMoonSeparationInfo": "Distanza angolare minima tra target e Luna richiesta per la pianificazione."
       },
       "defaults": {
         "favoriteTargetName": "Bersaglio preferito",
@@ -3607,6 +3625,17 @@
       },
       "warnings": {
         "sequenceVersionRequired": "L'inserimento della sequenza richiede il plugin TNS 1.2.8.0 (o la modalità PINS)."
+      },
+      "sessionModes": {
+        "moonRise": "Sorgere della luna",
+        "moonSet": "Luna tramontata",
+        "sunRise": "Alba",
+        "sunSet": "Tramonto",
+        "time": "Tempo",
+        "twilightEndAstronomical": "Crepuscolo e fine astronomica",
+        "twilightEndNautical": "Crepuscolo e nautica",
+        "twilightStartAstronomical": "Il crepuscolo inizia in modo astronomico",
+        "twilightStartNautical": "Twilight inizia nautico"
       }
     },
     "filterOffset": {

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -170,7 +170,8 @@
       "moveRotator": "カメラを回転",
       "infoTargetImage": "画像が真っ黒に表示される場合は、NINAで「オフライン・スカイマップ・キャッシュ」を設定するか、「NINAキャッシュを使用する」オプションを無効にする必要があります",
       "useCenter": "中心",
-      "useRotate": "回転"
+      "useRotate": "回転",
+      "customTarget": "カスタムターゲット"
     },
     "tutorial": {
       "previous": "前へ",
@@ -1460,7 +1461,15 @@
       "status_stopped_darks": "早期に停止しました - {total} 件中 {completed} 件のダークをキャプチャしました",
       "status_stopped_flats": "早期に停止しました - {total} 件中 {completed} 件のアパートを確保しました",
       "status_success_darks": "完了 - {count} 個のダークを捕獲しました",
-      "status_success_flats": "完了 - {count} 軒のアパートを占領しました"
+      "status_success_flats": "完了 - {count} 軒のアパートを占領しました",
+      "filter_label": "フィルター",
+      "result_bright": "明るすぎる",
+      "result_dim": "薄暗すぎる",
+      "status_completed_flats": "完了",
+      "status_failed_flats_multi": "すべてのフィルターが有効な露出を決定できませんでした",
+      "status_partial_flats_multi": "失敗したフィルター: {filters}",
+      "status_running_unknown": "決定中…",
+      "target": "ターゲット"
     },
     "weatherModal": {
       "weatherInformation": "気象情報",
@@ -1487,7 +1496,13 @@
     },
     "switch": {
       "gauges": "ゲージ",
-      "switch": "スイッチ"
+      "switch": "スイッチ",
+      "indi": {
+        "settings": "スイッチ設定"
+      },
+      "sv241pro": {
+        "preConnectDelay": "接続前遅延 (ミリ秒)"
+      }
     },
     "stellarium": {
       "selected_object": {
@@ -3527,7 +3542,10 @@
         "timeWindowEnd": "タイムウィンドウの終了",
         "timeWindowHint": "セッション範囲全体をスケジュールできるようにするには、時間枠を空白のままにします。",
         "timeWindowStart": "タイムウィンドウの開始",
-        "title": "制約"
+        "title": "制約",
+        "maxMoonAltitude": "最大月高度",
+        "maxMoonAltitudeHint": "月が地平線の下にある間のみスケジュールを設定するには、0° 以下に設定します。",
+        "minMoonSeparationInfo": "スケジュールに必要なターゲットと月の間の最小角距離。"
       },
       "defaults": {
         "favoriteTargetName": "お気に入りのターゲット",
@@ -3640,6 +3658,17 @@
       },
       "warnings": {
         "sequenceVersionRequired": "シーケンスの挿入には、TNS プラグイン 1.2.8.0 (または PINS モード) が必要です。"
+      },
+      "sessionModes": {
+        "moonRise": "月の出",
+        "moonSet": "ムーンセット",
+        "sunRise": "日の出",
+        "sunSet": "日没",
+        "time": "時間",
+        "twilightEndAstronomical": "トワイライトエンドの天文学的",
+        "twilightEndNautical": "トワイライトエンド航海",
+        "twilightStartAstronomical": "天文学的なトワイライトスタート",
+        "twilightStartNautical": "トワイライトスタート航海"
       }
     },
     "filterOffset": {

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -162,7 +162,8 @@
         "setMosaicTargets": "Stel mozaïekdoelen in",
         "panelsSet": "panelen op volgorde geplaatst",
         "willBeSaved": "panelen worden afzonderlijk opgeslagen"
-      }
+      },
+      "customTarget": "Aangepast doel"
     },
     "tutorial": {
       "previous": "Vorige",
@@ -1452,7 +1453,15 @@
       "status_stopped_darks": "Vroeg gestopt - {voltooid} van {totaal} duisternis vastgelegd",
       "status_stopped_flats": "Vroeg gestopt - {voltooid} van {totaal} flats veroverd",
       "status_success_darks": "Klaar - {count} darks vastgelegd",
-      "status_success_flats": "Klaar - {count} flats veroverd"
+      "status_success_flats": "Klaar - {count} flats veroverd",
+      "filter_label": "Filter",
+      "result_bright": "te helder",
+      "result_dim": "te zwak",
+      "status_completed_flats": "Voltooid",
+      "status_failed_flats_multi": "Alle filters konden geen geldige blootstelling vaststellen",
+      "status_partial_flats_multi": "Mislukte filters: {filters}",
+      "status_running_unknown": "Bepalend…",
+      "target": "Doel"
     },
     "weatherModal": {
       "weatherInformation": "Weer Informatie",
@@ -1479,7 +1488,13 @@
     },
     "switch": {
       "gauges": "Meters",
-      "switch": "Schakelaar"
+      "switch": "Schakelaar",
+      "indi": {
+        "settings": "Schakel instellingen"
+      },
+      "sv241pro": {
+        "preConnectDelay": "Vertraging vóór verbinding (ms)"
+      }
     },
     "stellarium": {
       "selected_object": {
@@ -3494,7 +3509,10 @@
         "timeWindowEnd": "Einde van het tijdvenster",
         "timeWindowHint": "Laat het tijdvenster leeg om planning voor het volledige sessiebereik mogelijk te maken.",
         "timeWindowStart": "Tijdvenster starten",
-        "title": "Beperkingen"
+        "title": "Beperkingen",
+        "maxMoonAltitude": "Maximale maanhoogte",
+        "maxMoonAltitudeHint": "Stel deze in op 0° of lager om alleen een planning te maken als de maan zich onder de horizon bevindt.",
+        "minMoonSeparationInfo": "Minimale hoekafstand tussen doel en maan vereist voor planning."
       },
       "defaults": {
         "favoriteTargetName": "Favoriete doelwit",
@@ -3607,6 +3625,17 @@
       },
       "warnings": {
         "sequenceVersionRequired": "Voor het invoegen van sequenties is TNS-plug-in 1.2.8.0 (of PINS-modus) vereist."
+      },
+      "sessionModes": {
+        "moonRise": "Maan opkomst",
+        "moonSet": "Maan ingesteld",
+        "sunRise": "Zon opkomen",
+        "sunSet": "Zonsondergang",
+        "time": "Tijd",
+        "twilightEndAstronomical": "Het einde van de schemering is astronomisch",
+        "twilightEndNautical": "Schemering einde nautisch",
+        "twilightStartAstronomical": "De schemering begint astronomisch",
+        "twilightStartNautical": "Schemering start nautisch"
       }
     },
     "filterOffset": {

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -162,7 +162,8 @@
         "setMosaicTargets": "Ustaw cele mozaikowe",
         "panelsSet": "panele ustawione w kolejności",
         "willBeSaved": "panele zostaną zapisane indywidualnie"
-      }
+      },
+      "customTarget": "Cel niestandardowy"
     },
     "tutorial": {
       "previous": "Poprzedni",
@@ -1452,7 +1453,15 @@
       "status_stopped_darks": "Zatrzymano wcześniej – {ukończono} z {total} zdobytych ciemności",
       "status_stopped_flats": "Zatrzymano wcześniej – {ukończono} z {total} zdobytych mieszkań",
       "status_success_darks": "Gotowe — przechwycono {count} ciemności",
-      "status_success_flats": "Gotowe – zajęto {count} mieszkań"
+      "status_success_flats": "Gotowe – zajęto {count} mieszkań",
+      "filter_label": "Filtr",
+      "result_bright": "zbyt jasny",
+      "result_dim": "zbyt ciemne",
+      "status_completed_flats": "Zakończony",
+      "status_failed_flats_multi": "Żadne filtry nie określiły prawidłowego narażenia",
+      "status_partial_flats_multi": "Nieudane filtry: {filters}",
+      "status_running_unknown": "Określający…",
+      "target": "Cel"
     },
     "weatherModal": {
       "weatherInformation": "Informacje o pogodzie",
@@ -1479,7 +1488,13 @@
     },
     "switch": {
       "gauges": "Wskaźniki",
-      "switch": "Przełącznik"
+      "switch": "Przełącznik",
+      "indi": {
+        "settings": "Zmień ustawienia"
+      },
+      "sv241pro": {
+        "preConnectDelay": "Opóźnienie wstępnego połączenia (ms)"
+      }
     },
     "stellarium": {
       "selected_object": {
@@ -3494,7 +3509,10 @@
         "timeWindowEnd": "Koniec okna czasowego",
         "timeWindowHint": "Pozostaw okno czasowe puste, aby umożliwić planowanie pełnego zakresu sesji.",
         "timeWindowStart": "Rozpoczęcie okna czasowego",
-        "title": "Ograniczenia"
+        "title": "Ograniczenia",
+        "maxMoonAltitude": "Maksymalna wysokość księżyca",
+        "maxMoonAltitudeHint": "Ustaw na 0° lub mniej, aby zaplanować tylko wtedy, gdy Księżyc znajduje się poniżej horyzontu.",
+        "minMoonSeparationInfo": "Minimalna odległość kątowa między celem a Księżycem wymagana do planowania."
       },
       "defaults": {
         "favoriteTargetName": "Ulubiony cel",
@@ -3607,6 +3625,17 @@
       },
       "warnings": {
         "sequenceVersionRequired": "Wstawianie sekwencji wymaga wtyczki TNS 1.2.8.0 (lub trybu PINS)."
+      },
+      "sessionModes": {
+        "moonRise": "Wschód księżyca",
+        "moonSet": "Zachód księżyca",
+        "sunRise": "Wschód słońca",
+        "sunSet": "Zachód słońca",
+        "time": "Czas",
+        "twilightEndAstronomical": "Zmierzch koniec astronomiczny",
+        "twilightEndNautical": "Żeglarski koniec zmierzchu",
+        "twilightStartAstronomical": "Zmierzch zaczyna się astronomicznie",
+        "twilightStartNautical": "Zmierzch zaczyna się nautycznie"
       }
     },
     "filterOffset": {

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -162,7 +162,8 @@
         "setMosaicTargets": "Definir metas de mosaico",
         "panelsSet": "painéis definidos em sequência",
         "willBeSaved": "os painéis serão salvos individualmente"
-      }
+      },
+      "customTarget": "Alvo personalizado"
     },
     "tutorial": {
       "previous": "Anterior",
@@ -1452,7 +1453,15 @@
       "status_stopped_darks": "Interrompido cedo - {concluído} de {total} darks capturados",
       "status_stopped_flats": "Interrompido antecipadamente - {concluído} de {total} apartamentos capturados",
       "status_success_darks": "Concluído - {count} darks capturados",
-      "status_success_flats": "Concluído - {count} apartamentos capturados"
+      "status_success_flats": "Concluído - {count} apartamentos capturados",
+      "filter_label": "Filtro",
+      "result_bright": "muito brilhante",
+      "result_dim": "muito escuro",
+      "status_completed_flats": "Concluído",
+      "status_failed_flats_multi": "Todos os filtros não conseguiram determinar a exposição válida",
+      "status_partial_flats_multi": "Filtros com falha: {filtros}",
+      "status_running_unknown": "Determinando…",
+      "target": "Alvo"
     },
     "weatherModal": {
       "weatherInformation": "Informações meteorológicas",
@@ -1479,7 +1488,13 @@
     },
     "switch": {
       "gauges": "Medidores",
-      "switch": "Interruptor"
+      "switch": "Interruptor",
+      "indi": {
+        "settings": "Alternar configurações"
+      },
+      "sv241pro": {
+        "preConnectDelay": "Atraso de pré-conexão (ms)"
+      }
     },
     "stellarium": {
       "selected_object": {
@@ -3494,7 +3509,10 @@
         "timeWindowEnd": "Fim da janela de tempo",
         "timeWindowHint": "Deixe a janela de tempo em branco para permitir o agendamento de todo o intervalo da sessão.",
         "timeWindowStart": "Início da janela de tempo",
-        "title": "Restrições"
+        "title": "Restrições",
+        "maxMoonAltitude": "Altitude máxima da lua",
+        "maxMoonAltitudeHint": "Defina para 0° ou menos para programar apenas enquanto a Lua estiver abaixo do horizonte.",
+        "minMoonSeparationInfo": "Distância angular mínima entre o alvo e a Lua necessária para o agendamento."
       },
       "defaults": {
         "favoriteTargetName": "Alvo favorito",
@@ -3607,6 +3625,17 @@
       },
       "warnings": {
         "sequenceVersionRequired": "A inserção de sequência requer o plugin TNS 1.2.8.0 (ou modo PINS)."
+      },
+      "sessionModes": {
+        "moonRise": "Nascer da lua",
+        "moonSet": "Lua definida",
+        "sunRise": "Nascer do sol",
+        "sunSet": "Pôr do sol",
+        "time": "Tempo",
+        "twilightEndAstronomical": "Fim do crepúsculo astronômico",
+        "twilightEndNautical": "Fim do crepúsculo náutico",
+        "twilightStartAstronomical": "Crepúsculo começa astronômico",
+        "twilightStartNautical": "Crepúsculo começa náutico"
       }
     },
     "filterOffset": {

--- a/src/locales/uk.json
+++ b/src/locales/uk.json
@@ -162,7 +162,8 @@
         "setMosaicTargets": "Встановити цілі мозаїки",
         "panelsSet": "панелі встановлені в послідовності",
         "willBeSaved": "панелі будуть збережені окремо"
-      }
+      },
+      "customTarget": "Спеціальна ціль"
     },
     "tutorial": {
       "previous": "Назад",
@@ -1432,7 +1433,15 @@
       "status_failed": "не вдалося",
       "status_running": "Виконується",
       "status_stopped": "Зупинено",
-      "status_success": "Успішно"
+      "status_success": "Успішно",
+      "filter_label": "фільтр",
+      "result_bright": "занадто яскравий",
+      "result_dim": "занадто тьмяний",
+      "status_completed_flats": "Виконано",
+      "status_failed_flats_multi": "Усім фільтрам не вдалося визначити дійсну експозицію",
+      "status_partial_flats_multi": "Невдалі фільтри: {filters}",
+      "status_running_unknown": "Визначення…",
+      "target": "Цільова"
     },
     "weatherModal": {
       "weatherInformation": "Інформація про погоду",
@@ -1459,7 +1468,13 @@
     },
     "switch": {
       "gauges": "Датчики",
-      "switch": "Перемикач"
+      "switch": "Перемикач",
+      "indi": {
+        "settings": "Налаштування перемикача"
+      },
+      "sv241pro": {
+        "preConnectDelay": "Затримка перед підключенням (мс)"
+      }
     },
     "stellarium": {
       "selected_object": {
@@ -3366,7 +3381,10 @@
         "minMoonSeparation": "Мін. відстань від Місяця",
         "timeWindowStart": "Початок вікна часу",
         "timeWindowEnd": "Кінець вікна часу",
-        "timeWindowHint": "Залиште вікно часу порожнім для планування на весь діапазон сесії."
+        "timeWindowHint": "Залиште вікно часу порожнім для планування на весь діапазон сесії.",
+        "maxMoonAltitude": "Максимальна висота місяця",
+        "maxMoonAltitudeHint": "Встановіть 0° або нижче, щоб запланувати лише коли Місяць знаходиться за горизонтом.",
+        "minMoonSeparationInfo": "Мінімальна кутова відстань між метою та Місяцем, необхідна для планування."
       },
       "timeline": {
         "title": "Часова шкала сесії",
@@ -3450,6 +3468,17 @@
         "noImagingContainerFound": "Не вдалося знайти контейнер зйомки в активній послідовності.",
         "noValidTargetsForExport": "Не знайдено дійсних цілей для експорту.",
         "failedToApplySchedule": "Не вдалося застосувати розклад до послідовності."
+      },
+      "sessionModes": {
+        "moonRise": "Схід місяця",
+        "moonSet": "Місяць зайшов",
+        "sunRise": "Схід сонця",
+        "sunSet": "Сонце зайшло",
+        "time": "час",
+        "twilightEndAstronomical": "Астрономічні сутінки",
+        "twilightEndNautical": "Сутінковий кінець морський",
+        "twilightStartAstronomical": "Початок сутінків астрономічний",
+        "twilightStartNautical": "Сутінковий старт морський"
       }
     },
     "pinsDevices": {

--- a/src/plugins/target-scheduler/components/ConstraintEditor.vue
+++ b/src/plugins/target-scheduler/components/ConstraintEditor.vue
@@ -57,7 +57,16 @@
     <div v-if="advancedOpen" class="space-y-3 border-t border-slate-700 pt-3">
       <div>
         <div class="flex items-center justify-between text-xs text-slate-400 mb-1">
-          <span>{{ t('plugins.targetScheduler.constraints.minMoonSeparation') }}</span>
+          <span class="flex items-center gap-1">
+            <span>{{ t('plugins.targetScheduler.constraints.minMoonSeparation') }}</span>
+            <span
+              class="inline-flex items-center"
+              :title="t('plugins.targetScheduler.constraints.minMoonSeparationInfo')"
+              v-tooltip="t('plugins.targetScheduler.constraints.minMoonSeparationInfo')"
+            >
+              <InformationCircleIcon class="h-4 w-4 text-slate-400 cursor-help" />
+            </span>
+          </span>
           <span>
             {{ localValue.minMoonSeparation }} {{ t('plugins.targetScheduler.common.deg') }}
           </span>
@@ -70,6 +79,26 @@
           step="1"
           class="w-full accent-amber-500"
         />
+      </div>
+
+      <div>
+        <div class="flex items-center justify-between text-xs text-slate-400 mb-1">
+          <span>{{ t('plugins.targetScheduler.constraints.maxMoonAltitude') }}</span>
+          <span>
+            {{ localValue.maxMoonAltitude }} {{ t('plugins.targetScheduler.common.deg') }}
+          </span>
+        </div>
+        <input
+          v-model.number="localValue.maxMoonAltitude"
+          type="range"
+          min="-30"
+          max="90"
+          step="1"
+          class="w-full accent-amber-500"
+        />
+        <p class="text-[11px] text-slate-500 mt-1">
+          {{ t('plugins.targetScheduler.constraints.maxMoonAltitudeHint') }}
+        </p>
       </div>
 
       <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
@@ -102,6 +131,7 @@
 <script setup>
 import { reactive, watch, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
+import { InformationCircleIcon } from '@heroicons/vue/24/outline';
 import { DEFAULT_CONSTRAINTS } from '../services/TargetSchedulerService';
 
 const props = defineProps({
@@ -140,6 +170,7 @@ watch(
       minAltitude: Number(value.minAltitude),
       maxAltitude: Number(value.maxAltitude),
       minMoonSeparation: Number(value.minMoonSeparation),
+      maxMoonAltitude: Number(value.maxMoonAltitude),
       enabled: value.enabled !== false,
     });
   },

--- a/src/plugins/target-scheduler/composables/useTargetScheduler.js
+++ b/src/plugins/target-scheduler/composables/useTargetScheduler.js
@@ -9,6 +9,7 @@ import { useToastStore } from '@/store/toastStore';
 import {
   DEFAULT_MAX_CHUNK_MINUTES,
   DEFAULT_STEP_MINUTES,
+  computeNightSessionEvents,
   computeSchedulePlan,
   createDefaultTarget,
   createExposure,
@@ -19,6 +20,23 @@ const STORAGE_KEY = 'tns.targetScheduler.state.v1';
 const DSO_CONTAINER_TYPE = 'NINA.Sequencer.Container.DeepSkyObjectContainer';
 const SMART_EXPOSURE_TYPE = 'NINA.Sequencer.SequenceItem.Imaging.SmartExposure';
 const ALTITUDE_CONDITION_TYPE = 'NINA.Sequencer.Conditions.AltitudeCondition';
+
+const SESSION_START_MODE_VALUES = Object.freeze([
+  'time',
+  'twilight_end_nautical',
+  'twilight_end_astronomical',
+  'sun_set',
+  'moon_set',
+]);
+const SESSION_END_MODE_VALUES = Object.freeze([
+  'time',
+  'twilight_start_nautical',
+  'twilight_start_astronomical',
+  'sun_rise',
+  'moon_rise',
+]);
+const DEFAULT_SESSION_START_MODE = 'twilight_end_astronomical';
+const DEFAULT_SESSION_END_MODE = 'twilight_start_astronomical';
 
 function pad(value) {
   return String(value).padStart(2, '0');
@@ -83,6 +101,54 @@ function resolveInitialSessionInputs(persisted) {
     sessionStartInput: toInputDateTime(start),
     sessionEndInput: toInputDateTime(end),
   };
+}
+
+function getValidMode(value, validValues, fallback) {
+  return validValues.includes(value) ? value : fallback;
+}
+
+function getDateOnlyOrToday(value) {
+  const parsed = new Date(value);
+  const out = Number.isNaN(parsed.getTime()) ? new Date() : new Date(parsed);
+  out.setHours(0, 0, 0, 0);
+  return out;
+}
+
+function buildDateWithInputTime(baseDate, inputValue, fallbackDate) {
+  const parsed = new Date(inputValue);
+  const hours = Number.isNaN(parsed.getTime()) ? fallbackDate.getHours() : parsed.getHours();
+  const minutes = Number.isNaN(parsed.getTime()) ? fallbackDate.getMinutes() : parsed.getMinutes();
+
+  const out = new Date(baseDate);
+  out.setHours(hours, minutes, 0, 0);
+  return out;
+}
+
+function resolveStartDateForMode(mode, events, nightDate, currentInput) {
+  const manualStart = buildDateWithInputTime(nightDate, currentInput, defaultSessionStart());
+
+  if (mode === 'time') return manualStart;
+  if (mode === 'twilight_end_nautical') return events.nauticalDusk || manualStart;
+  if (mode === 'twilight_end_astronomical') return events.astronomicalDusk || manualStart;
+  if (mode === 'sun_set') return events.sunSet || manualStart;
+  if (mode === 'moon_set') return events.moonSet || manualStart;
+
+  return manualStart;
+}
+
+function resolveEndDateForMode(mode, events, nightDate, currentInput) {
+  const morningDate = new Date(nightDate);
+  morningDate.setDate(morningDate.getDate() + 1);
+
+  const manualEnd = buildDateWithInputTime(morningDate, currentInput, defaultSessionEnd());
+
+  if (mode === 'time') return manualEnd;
+  if (mode === 'twilight_start_nautical') return events.nauticalDawn || manualEnd;
+  if (mode === 'twilight_start_astronomical') return events.astronomicalDawn || manualEnd;
+  if (mode === 'sun_rise') return events.sunRise || manualEnd;
+  if (mode === 'moon_rise') return events.moonRise || manualEnd;
+
+  return manualEnd;
 }
 
 function getTimeValueOrDefault(value, fallback) {
@@ -210,6 +276,12 @@ export function useTargetScheduler() {
 
   const sessionStartInput = ref(initialSessionInputs.sessionStartInput);
   const sessionEndInput = ref(initialSessionInputs.sessionEndInput);
+  const sessionStartMode = ref(
+    getValidMode(persisted?.sessionStartMode, SESSION_START_MODE_VALUES, DEFAULT_SESSION_START_MODE)
+  );
+  const sessionEndMode = ref(
+    getValidMode(persisted?.sessionEndMode, SESSION_END_MODE_VALUES, DEFAULT_SESSION_END_MODE)
+  );
 
   const stepMinutes = ref(
     Number.isFinite(Number(persisted?.stepMinutes))
@@ -227,6 +299,8 @@ export function useTargetScheduler() {
       targets: targets.value,
       sessionStartInput: sessionStartInput.value,
       sessionEndInput: sessionEndInput.value,
+      sessionStartMode: sessionStartMode.value,
+      sessionEndMode: sessionEndMode.value,
       stepMinutes: stepMinutes.value,
       maxChunkMinutes: maxChunkMinutes.value,
     });
@@ -309,9 +383,54 @@ export function useTargetScheduler() {
       targets: targets.value,
       sessionStartInput: sessionStartInput.value,
       sessionEndInput: sessionEndInput.value,
+      sessionStartMode: sessionStartMode.value,
+      sessionEndMode: sessionEndMode.value,
       stepMinutes: stepMinutes.value,
       maxChunkMinutes: maxChunkMinutes.value,
     });
+  }
+
+  let isSyncingSessionInputs = false;
+  function syncSessionInputsWithModes() {
+    if (!Number.isFinite(location.value.latitude) || !Number.isFinite(location.value.longitude)) {
+      return;
+    }
+
+    const nightDate = getDateOnlyOrToday(sessionStartInput.value);
+    const events = computeNightSessionEvents({
+      nightDate,
+      location: location.value,
+    });
+
+    const nextStart = resolveStartDateForMode(
+      sessionStartMode.value,
+      events,
+      nightDate,
+      sessionStartInput.value
+    );
+    let nextEnd = resolveEndDateForMode(
+      sessionEndMode.value,
+      events,
+      nightDate,
+      sessionEndInput.value
+    );
+
+    if (nextEnd <= nextStart) {
+      nextEnd = new Date(nextEnd);
+      nextEnd.setDate(nextEnd.getDate() + 1);
+    }
+
+    const nextStartInput = toInputDateTime(nextStart);
+    const nextEndInput = toInputDateTime(nextEnd);
+
+    if (nextStartInput === sessionStartInput.value && nextEndInput === sessionEndInput.value) {
+      return;
+    }
+
+    isSyncingSessionInputs = true;
+    sessionStartInput.value = nextStartInput;
+    sessionEndInput.value = nextEndInput;
+    isSyncingSessionInputs = false;
   }
 
   function addTarget(partial) {
@@ -732,6 +851,22 @@ export function useTargetScheduler() {
 
   let recomputeTimer = null;
   watch(
+    [
+      sessionStartMode,
+      sessionEndMode,
+      () => location.value.latitude,
+      () => location.value.longitude,
+      sessionStartInput,
+    ],
+    () => {
+      if (isSyncingSessionInputs) return;
+      if (sessionStartMode.value === 'time' && sessionEndMode.value === 'time') return;
+      syncSessionInputsWithModes();
+    },
+    { immediate: true }
+  );
+
+  watch(
     [targets, sessionStartInput, sessionEndInput, stepMinutes, maxChunkMinutes, location],
     () => {
       if (recomputeTimer) clearTimeout(recomputeTimer);
@@ -743,7 +878,15 @@ export function useTargetScheduler() {
   );
 
   watch(
-    [targets, sessionStartInput, sessionEndInput, stepMinutes, maxChunkMinutes],
+    [
+      targets,
+      sessionStartInput,
+      sessionEndInput,
+      sessionStartMode,
+      sessionEndMode,
+      stepMinutes,
+      maxChunkMinutes,
+    ],
     () => {
       persistState();
     },
@@ -762,6 +905,8 @@ export function useTargetScheduler() {
     showFavoritesPicker,
     sessionStartInput,
     sessionEndInput,
+    sessionStartMode,
+    sessionEndMode,
     stepMinutes,
     maxChunkMinutes,
     location,

--- a/src/plugins/target-scheduler/services/TargetSchedulerService.js
+++ b/src/plugins/target-scheduler/services/TargetSchedulerService.js
@@ -11,6 +11,7 @@ export const DEFAULT_CONSTRAINTS = Object.freeze({
   minAltitude: 25,
   maxAltitude: 89,
   minMoonSeparation: 0,
+  maxMoonAltitude: 90,
   timeWindowStart: '',
   timeWindowEnd: '',
 });
@@ -302,6 +303,146 @@ function getMoonEquatorial(date) {
   return eclipticToEquatorial(normalizeDeg360(lon), lat, date);
 }
 
+function getBodyEquatorial(body, date) {
+  return body === 'sun' ? getSunEquatorial(date) : getMoonEquatorial(date);
+}
+
+function getBodyAltitudeDeg(body, date, location) {
+  const eq = getBodyEquatorial(body, date);
+  return radecToAltAz(eq.raDeg, eq.decDeg, date, location.latitude, location.longitude).altDeg;
+}
+
+function interpolateCrossingTime(t1, alt1, t2, alt2, thresholdDeg) {
+  if (alt2 === alt1) return new Date((t1 + t2) / 2);
+  const ratio = clamp((thresholdDeg - alt1) / (alt2 - alt1), 0, 1);
+  return new Date(t1 + ratio * (t2 - t1));
+}
+
+function findAltitudeCrossing({
+  body,
+  thresholdDeg,
+  direction,
+  start,
+  end,
+  location,
+  stepMinutes = 5,
+}) {
+  let prevTime = new Date(start);
+  let prevAlt = getBodyAltitudeDeg(body, prevTime, location);
+
+  for (
+    let t = prevTime.getTime() + stepMinutes * 60 * 1000;
+    t <= end.getTime();
+    t += stepMinutes * 60 * 1000
+  ) {
+    const nextTime = new Date(t);
+    const nextAlt = getBodyAltitudeDeg(body, nextTime, location);
+
+    const crossed = (prevAlt - thresholdDeg) * (nextAlt - thresholdDeg) <= 0;
+    const isAscending = nextAlt >= prevAlt;
+    const directionMatches = direction === 'ascending' ? isAscending : !isAscending;
+
+    if (crossed && directionMatches) {
+      return interpolateCrossingTime(
+        prevTime.getTime(),
+        prevAlt,
+        nextTime.getTime(),
+        nextAlt,
+        thresholdDeg
+      );
+    }
+
+    prevTime = nextTime;
+    prevAlt = nextAlt;
+  }
+
+  return null;
+}
+
+export function computeNightSessionEvents({ nightDate, location }) {
+  const base = new Date(nightDate);
+  base.setHours(0, 0, 0, 0);
+
+  const eveningStart = new Date(base);
+  eveningStart.setHours(12, 0, 0, 0);
+
+  const midnight = new Date(base);
+  midnight.setDate(midnight.getDate() + 1);
+  midnight.setHours(0, 0, 0, 0);
+
+  const morningEnd = new Date(midnight);
+  morningEnd.setHours(12, 0, 0, 0);
+
+  const sunThreshold = -0.833;
+
+  return {
+    sunSet: findAltitudeCrossing({
+      body: 'sun',
+      thresholdDeg: sunThreshold,
+      direction: 'descending',
+      start: eveningStart,
+      end: midnight,
+      location,
+    }),
+    nauticalDusk: findAltitudeCrossing({
+      body: 'sun',
+      thresholdDeg: -12,
+      direction: 'descending',
+      start: eveningStart,
+      end: midnight,
+      location,
+    }),
+    astronomicalDusk: findAltitudeCrossing({
+      body: 'sun',
+      thresholdDeg: -18,
+      direction: 'descending',
+      start: eveningStart,
+      end: midnight,
+      location,
+    }),
+    moonSet: findAltitudeCrossing({
+      body: 'moon',
+      thresholdDeg: 0,
+      direction: 'descending',
+      start: eveningStart,
+      end: midnight,
+      location,
+    }),
+    sunRise: findAltitudeCrossing({
+      body: 'sun',
+      thresholdDeg: sunThreshold,
+      direction: 'ascending',
+      start: midnight,
+      end: morningEnd,
+      location,
+    }),
+    nauticalDawn: findAltitudeCrossing({
+      body: 'sun',
+      thresholdDeg: -12,
+      direction: 'ascending',
+      start: midnight,
+      end: morningEnd,
+      location,
+    }),
+    astronomicalDawn: findAltitudeCrossing({
+      body: 'sun',
+      thresholdDeg: -18,
+      direction: 'ascending',
+      start: midnight,
+      end: morningEnd,
+      location,
+    }),
+    moonRise: findAltitudeCrossing({
+      body: 'moon',
+      thresholdDeg: 0,
+      direction: 'ascending',
+      start: midnight,
+      end: morningEnd,
+      location,
+    }),
+  };
+}
+
 function angularSeparationDeg(ra1Deg, dec1Deg, ra2Deg, dec2Deg) {
   const ra1 = toRad(ra1Deg);
   const dec1 = toRad(dec1Deg);
@@ -314,7 +455,7 @@ function angularSeparationDeg(ra1Deg, dec1Deg, ra2Deg, dec2Deg) {
   return toDeg(Math.acos(clamp(cosSep, -1, 1)));
 }
 
-function getMoonDataForTarget(targetRaDeg, targetDecDeg, date) {
+function getMoonDataForTarget(targetRaDeg, targetDecDeg, date, location) {
   const sun = getSunEquatorial(date);
   const moon = getMoonEquatorial(date);
 
@@ -323,9 +464,18 @@ function getMoonDataForTarget(targetRaDeg, targetDecDeg, date) {
 
   const separationDeg = angularSeparationDeg(targetRaDeg, targetDecDeg, moon.raDeg, moon.decDeg);
 
+  const moonAltDeg = radecToAltAz(
+    moon.raDeg,
+    moon.decDeg,
+    date,
+    location.latitude,
+    location.longitude
+  ).altDeg;
+
   return {
     separationDeg,
     illumination,
+    altDeg: moonAltDeg,
   };
 }
 
@@ -406,6 +556,11 @@ function normalizeTarget(target) {
         90
       ),
       minMoonSeparation: clamp(Number(target?.constraints?.minMoonSeparation) || 0, 0, 180),
+      maxMoonAltitude: clamp(
+        Number(target?.constraints?.maxMoonAltitude ?? DEFAULT_CONSTRAINTS.maxMoonAltitude),
+        -30,
+        90
+      ),
     },
   };
 }
@@ -441,15 +596,16 @@ function buildTargetTrack(target, sessionStart, sessionEnd, location, stepMinute
       location.latitude,
       location.longitude
     );
-    const moon = getMoonDataForTarget(target.ra, target.dec, at);
+    const moon = getMoonDataForTarget(target.ra, target.dec, at, location);
 
     const visibleByAltitude =
       altDeg >= target.constraints.minAltitude && altDeg <= target.constraints.maxAltitude;
     const visibleByMoon =
       target.constraints.minMoonSeparation <= 0 ||
       moon.separationDeg >= target.constraints.minMoonSeparation;
+    const visibleByMoonAltitude = moon.altDeg <= Number(target.constraints.maxMoonAltitude ?? 90);
 
-    const visible = inWindow && visibleByAltitude && visibleByMoon;
+    const visible = inWindow && visibleByAltitude && visibleByMoon && visibleByMoonAltitude;
 
     if (visible) {
       visibleMinutes += stepMinutes;
@@ -464,6 +620,7 @@ function buildTargetTrack(target, sessionStart, sessionEnd, location, stepMinute
         azDeg,
         moonSeparationDeg: moon.separationDeg,
         moonIllumination: moon.illumination,
+        moonAltitudeDeg: moon.altDeg,
       };
     }
 
@@ -473,6 +630,7 @@ function buildTargetTrack(target, sessionStart, sessionEnd, location, stepMinute
       azDeg,
       moonSeparationDeg: moon.separationDeg,
       moonIllumination: moon.illumination,
+      moonAltitudeDeg: moon.altDeg,
       visible,
       inWindow,
     });

--- a/src/plugins/target-scheduler/views/TargetSchedulerView.vue
+++ b/src/plugins/target-scheduler/views/TargetSchedulerView.vue
@@ -42,6 +42,18 @@
         <div class="mt-3 grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-4">
           <label class="text-xs text-slate-400">
             {{ t('plugins.targetScheduler.labels.sessionStart') }}
+            <select
+              v-model="sessionStartMode"
+              class="mt-1 w-full rounded border border-slate-600 bg-slate-800 px-2 py-1.5 text-slate-100"
+            >
+              <option
+                v-for="option in sessionStartModeOptions"
+                :key="option.value"
+                :value="option.value"
+              >
+                {{ option.label }}
+              </option>
+            </select>
             <div class="mt-1 grid grid-cols-1 gap-2 sm:grid-cols-2">
               <input
                 v-model="sessionStartDate"
@@ -52,24 +64,42 @@
                 v-model="sessionStartTime"
                 type="time"
                 step="60"
-                class="w-full rounded border border-slate-600 bg-slate-800 px-2 py-1.5 text-slate-100"
+                :disabled="!isSessionStartTimeMode"
+                :readonly="!isSessionStartTimeMode"
+                class="w-full rounded border border-slate-600 bg-slate-800 px-2 py-1.5 text-slate-100 disabled:opacity-60"
               />
             </div>
           </label>
 
           <label class="text-xs text-slate-400">
             {{ t('plugins.targetScheduler.labels.sessionEnd') }}
+            <select
+              v-model="sessionEndMode"
+              class="mt-1 w-full rounded border border-slate-600 bg-slate-800 px-2 py-1.5 text-slate-100"
+            >
+              <option
+                v-for="option in sessionEndModeOptions"
+                :key="option.value"
+                :value="option.value"
+              >
+                {{ option.label }}
+              </option>
+            </select>
             <div class="mt-1 grid grid-cols-1 gap-2 sm:grid-cols-2">
               <input
                 v-model="sessionEndDate"
                 type="date"
-                class="w-full rounded border border-slate-600 bg-slate-800 px-2 py-1.5 text-slate-100"
+                :disabled="!isSessionEndTimeMode"
+                :readonly="!isSessionEndTimeMode"
+                class="w-full rounded border border-slate-600 bg-slate-800 px-2 py-1.5 text-slate-100 disabled:opacity-60"
               />
               <input
                 v-model="sessionEndTime"
                 type="time"
                 step="60"
-                class="w-full rounded border border-slate-600 bg-slate-800 px-2 py-1.5 text-slate-100"
+                :disabled="!isSessionEndTimeMode"
+                :readonly="!isSessionEndTimeMode"
+                class="w-full rounded border border-slate-600 bg-slate-800 px-2 py-1.5 text-slate-100 disabled:opacity-60"
               />
             </div>
           </label>
@@ -314,6 +344,8 @@ const {
   showFavoritesPicker,
   sessionStartInput,
   sessionEndInput,
+  sessionStartMode,
+  sessionEndMode,
   stepMinutes,
   maxChunkMinutes,
   location,
@@ -339,6 +371,37 @@ const {
   recomputeSchedule,
   applyScheduleToSequence,
 } = useTargetScheduler();
+
+const sessionStartModeOptions = computed(() => [
+  { value: 'time', label: t('plugins.targetScheduler.sessionModes.time') },
+  {
+    value: 'twilight_end_nautical',
+    label: t('plugins.targetScheduler.sessionModes.twilightEndNautical'),
+  },
+  {
+    value: 'twilight_end_astronomical',
+    label: t('plugins.targetScheduler.sessionModes.twilightEndAstronomical'),
+  },
+  { value: 'sun_set', label: t('plugins.targetScheduler.sessionModes.sunSet') },
+  { value: 'moon_set', label: t('plugins.targetScheduler.sessionModes.moonSet') },
+]);
+
+const sessionEndModeOptions = computed(() => [
+  { value: 'time', label: t('plugins.targetScheduler.sessionModes.time') },
+  {
+    value: 'twilight_start_nautical',
+    label: t('plugins.targetScheduler.sessionModes.twilightStartNautical'),
+  },
+  {
+    value: 'twilight_start_astronomical',
+    label: t('plugins.targetScheduler.sessionModes.twilightStartAstronomical'),
+  },
+  { value: 'sun_rise', label: t('plugins.targetScheduler.sessionModes.sunRise') },
+  { value: 'moon_rise', label: t('plugins.targetScheduler.sessionModes.moonRise') },
+]);
+
+const isSessionStartTimeMode = computed(() => sessionStartMode.value === 'time');
+const isSessionEndTimeMode = computed(() => sessionEndMode.value === 'time');
 
 function splitDateTimeLocal(value) {
   const raw = String(value || '');


### PR DESCRIPTION
…altitude constraint

add Session Start/End dropdown modes (Time, twilight, sun, moon events) with automatic event-based time resolution add per-target max moon altitude constraint in Advanced conditions and enforce it in schedule visibility add help tooltips for min moon separation, sampling step, and max chunk keep session defaults anchored to today and improve scheduler state handling/persistence for new mode