### PR TITLE
feat: add Korean (ko) locale / 한국어(ko) 로케일 추가

### DIFF
--- a/src/i18n.js
+++ b/src/i18n.js
@@ -11,6 +11,7 @@ import pl from './locales/pl.json';
 import nl from './locales/nl.json';
 import ja from './locales/ja.json';
 import uk from './locales/uk.json';
+import ko from './locales/ko.json';
 
 const languageToBackendCode = {
   en: 'en-GB',
@@ -25,6 +26,7 @@ const languageToBackendCode = {
   pl: 'pl-PL',
   nl: 'nl-NL',
   uk: 'uk-UA',
+  ko: 'ko-KR',
 };
 
 export function getBackendLanguageCode(frontendCode) {
@@ -45,6 +47,7 @@ const availableLanguages = [
   { code: 'pl', name: 'Polski' },
   { code: 'nl', name: 'Nederlands' },
   { code: 'uk', name: 'Українська' },
+  { code: 'ko', name: '한국어' },
 ];
 
 const messages = {
@@ -60,6 +63,7 @@ const messages = {
   nl,
   ja,
   uk,
+  ko,
 };
 
 // Create i18n instance

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -1,0 +1,4232 @@
+{
+  "common": {
+    "name": "이름",
+    "cancel": "취소",
+    "confirm": "확인",
+    "close": "닫기",
+    "select": "선택",
+    "edit": "편집",
+    "delete": "삭제",
+    "enabled": "사용 중",
+    "disabled": "사용 안 함",
+    "enable": "사용",
+    "disable": "사용 안 함",
+    "loading": "로딩 중…",
+    "creating": "생성 중…",
+    "scanning": "검색 중…",
+    "connecting": "연결 중…",
+    "refresh": "새로고침",
+    "help": "도움말",
+    "expand": "펼치기",
+    "collapse": "접기"
+  },
+  "general": {
+    "cancel": "취소",
+    "confirm": "확인",
+    "yes": "예",
+    "no": "아니요",
+    "delete": "삭제",
+    "edit": "편집",
+    "close": "닫기",
+    "save": "저장"
+  },
+  "pages": {
+    "equipment": {
+      "title": "장비 제어",
+      "indiSetup": "INDI 설정"
+    }
+  },
+  "app": {
+    "title": "Touch'N'Stars",
+    "connection_error_toast": {
+      "title": "연결 오류",
+      "message_api": "API 플러그인을 사용할 수 없습니다. NINA에서 설정을 확인하세요",
+      "message_api_version": "API 플러그인이 너무 오래되었습니다. 업데이트를 진행하세요",
+      "message_tns": "Touch'N'Stars 플러그인을 사용할 수 없습니다. NINA에서 설정을 확인하세요",
+      "message_tns_version": "Touch N Stars 플러그인이 너무 오래되었습니다. 업데이트를 진행하세요"
+    }
+  },
+  "whatsnew": {
+    "title": "새로운 기능",
+    "loading": "로딩 중…"
+  },
+  "updates": {
+    "title": "업데이트 사용 가능",
+    "description": "새 앱 번들({version})을 설치할 준비가 되었습니다.",
+    "downgradeTitle": "안정 버전으로 전환",
+    "downgradeDescription": "안정 버전({version})으로 다시 전환합니다. 현재 베타 버전을 대체합니다.",
+    "releaseNotes": "릴리스 노트",
+    "whatsNew": "새로운 기능",
+    "downloading": "업데이트 다운로드 중… {progress}%",
+    "preparing": "업데이트 준비 중… 앱을 계속 열어 두세요.",
+    "error": "업데이트에 실패했습니다. 나중에 다시 시도하세요.",
+    "later": "나중에",
+    "updateNow": "지금 업데이트",
+    "working": "작업 중…"
+  },
+  "setup": {
+    "welcome": "Touch'N'Stars에 오신 것을 환영합니다",
+    "description": "간단한 설정으로 시작해 봅시다",
+    "selectLanguage": "언어를 선택하세요",
+    "gpsConfiguration": "GPS 설정",
+    "currentNinaCoords": "프로필 위치",
+    "currentMountCoords": "마운트 위치",
+    "syncDirection": "위치 동기화 방향",
+    "syncDirectionNosync": "동기화 안 함",
+    "syncDirectionToApplication": "마운트에서 프로필로 동기화",
+    "syncDirectionToTelescope": "프로필에서 마운트로 동기화",
+    "mountNotConnected": "마운트가 연결되지 않음",
+    "coordsNotSupported": "드라이버에서 지원하지 않음",
+    "loadingCoords": "로딩 중…",
+    "coordLat": "위도",
+    "coordLon": "경도",
+    "coordAlt": "고도",
+    "coordUnit": "m",
+    "completeSetup": "설정 완료",
+    "instanceConfiguration": "N.I.N.A 연결 정보",
+    "InfoAppsTitel": "위키",
+    "check_wki": "자세한 안내는 위키에서 확인할 수 있습니다"
+  },
+  "components": {
+    "fitsPlatesolve": {
+      "buttonTitle": "FITS 플레이트 솔브",
+      "browserTitle": "플레이트 솔브할 FITS 파일 선택",
+      "titleLoading": "FITS 파라미터 읽는 중…",
+      "titleConfirm": "플레이트 솔브 파라미터 확인",
+      "titleSolving": "플레이트 솔빙 중…",
+      "titleResult": "플레이트 솔브 결과",
+      "titleError": "플레이트 솔브 실패",
+      "file": "파일",
+      "focalLength": "초점 거리",
+      "pixelSize": "픽셀 크기",
+      "binning": "비닝",
+      "coordinatesHint": "좌표 힌트(블라인드 솔브는 비워 두세요)",
+      "ra": "RA",
+      "dec": "Dec",
+      "raPlaceholder": "HH:MM:SS",
+      "decPlaceholder": "+DD:MM:SS",
+      "plateSolve": "플레이트 솔브",
+      "blindSolve": "블라인드 솔브",
+      "loadingParams": "FITS 헤더 읽는 중…",
+      "solving": "솔빙 중…",
+      "solvingHint": "플레이트 솔빙은 솔버와 검색 반경에 따라 10~60초 정도 걸릴 수 있습니다.",
+      "success": "플레이트 솔브 성공",
+      "rotation": "회전",
+      "pixelScale": "픽셀 스케일",
+      "useAsTarget": "대상으로 사용",
+      "targetApplied": "대상이 적용됨",
+      "error": "플레이트 솔브 실패",
+      "errorLoadParams": "FITS 파라미터를 읽지 못했습니다",
+      "solveFailed": "플레이트 솔브 실패",
+      "tryAgain": "파일 선택"
+    },
+    "instanceSwitcher": {
+      "title": "인스턴스 전환",
+      "active": "활성",
+      "noInstances": "구성된 인스턴스 없음",
+      "manageInstances": "인스턴스 관리",
+      "checking": "인스턴스 확인 중…",
+      "noneOnline": "온라인 인스턴스 없음"
+    },
+    "instanceDetection": {
+      "autoDetectionTitle": "자동 감지",
+      "scanButton": "검색",
+      "scanningButton": "검색 중...",
+      "noInstanceMessage": "Touch-N-Stars 인스턴스를 찾을 수 없습니다. 인스턴스가 실행 중이고 같은 네트워크에 있는지 확인하세요.",
+      "mdnsAvailabilityHint": "mDNS 검색은 Android 및 iOS 앱에서 사용할 수 있습니다. 브라우저에서 실행 중일 때는 수동 구성을 사용하세요.",
+      "manualConfigTitle": "수동 구성",
+      "instanceNameLabel": "인스턴스 이름",
+      "instanceNamePlaceholder": "내 인스턴스",
+      "ipLabel": "IP 주소 / FQDN",
+      "ipPlaceholder": "192.168.x.x",
+      "portLabel": "포트",
+      "portPlaceholder": "5000",
+      "modalTitle": "발견된 인스턴스",
+      "modalSubtitle": "목록에서 Touch-N-Stars 인스턴스를 선택하세요.",
+      "addressUnavailable": "주소를 사용할 수 없음",
+      "otherAddresses": "다른 주소:",
+      "otherAddressesFallback": "해당 없음",
+      "modalEmpty": "이 네트워크에서 Touch-N-Stars 인스턴스를 찾지 못했습니다.",
+      "mdnsRequired": "mDNS 검색은 Android 또는 iOS에서만 실행할 수 있습니다.",
+      "scanningMessage": "Touch-N-Stars 인스턴스 검색 중...",
+      "discoveringMessage": "Touch-N-Stars 인스턴스를 찾는 중...",
+      "noFoundMessage": "mDNS로 Touch-N-Stars 인스턴스를 찾지 못했습니다.",
+      "selectionSuccess": "{label} ({ip}:{port})을(를) 선택했습니다.",
+      "foundSingle": "Touch-N-Stars 인스턴스 1개를 찾았습니다.",
+      "foundMultiple": "Touch-N-Stars 인스턴스 {count}개를 찾았습니다.",
+      "discoveryFailedStatus": "검색 실패: {message}",
+      "discoveryFailedBase": "검색 실패.",
+      "discoveryPermissionHintWrapper": "{message} 시스템 설정에서 앱에 로컬 네트워크/주변 기기 접근 권한이 있는지 확인하세요."
+    },
+    "framing": {
+      "pageTitle": "프레이밍 어시스턴트",
+      "missingEquipmentSettings": "장비 설정 누락: 카메라 시야각(FOV)이 정확히 계산되도록 설정 → 장비에서 초점 거리와 픽셀 크기를 설정하세요.",
+      "confirmSetTargetTitle": "대상 선택 확인",
+      "confirmSetTargetMessage": "이 대상을 시퀀스 대상으로 설정하시겠습니까?",
+      "useNinaCache": "대상 이미지에 NINA 캐시 사용",
+      "setSequnceTarget": "시퀀스 대상으로 설정",
+      "mosaic": {
+        "title": "모자이크 모드",
+        "columns": "열",
+        "rows": "행",
+        "overlap": "겹침 %",
+        "preserveAlignment": "정렬 유지",
+        "preserveAlignmentHelp": "정렬 유지",
+        "preserveAlignmentHelpText": "각 패널의 회전 각도를 개별적으로 보정합니다. 천구는 곡면이므로 큰 모자이크 가장자리의 패널은 중앙 패널과 약간 다른 하늘 방향을 가집니다. 이 옵션을 켜면 로테이터가 각 패널 전에 조정하여 모든 패널이 동일하게 정렬됩니다(예: 북쪽이 위). 로테이터가 없으면 이 옵션을 끄세요 — 패널 이음새의 작은 어긋남은 보통 스택 소프트웨어가 자동으로 보정합니다.",
+        "panels": "패널",
+        "setMosaicTargets": "모자이크 대상 설정",
+        "panelsSet": "시퀀스에 설정된 패널",
+        "willBeSaved": "패널은 개별적으로 저장됩니다"
+      },
+      "search": {
+        "title": "검색",
+        "placeholder": "검색어를 입력하세요...",
+        "objectTypes": {
+          "Planet": "행성",
+          "Comet": "혜성",
+          "StellariumObject": "천체",
+          "Star": "별",
+          "Moon": "달"
+        }
+      },
+      "openFraminingModal": "프레이밍 어시스턴트에서 열기",
+      "fovSettings": {
+        "rotationAngle": "카메라 회전",
+        "fov": "시야각"
+      },
+      "getImageRotation": {
+        "startCapture": "카메라에서 회전 각도 측정",
+        "SolveRun": "플레이트 솔브",
+        "SolveError": "이미지 솔빙 오류"
+      },
+      "moveRotator": "카메라 회전",
+      "infoTargetImage": "이미지가 검게만 표시되면 NINA에서 \"오프라인 스카이맵 캐시\"를 설정하거나 \"NINA 캐시 사용\" 옵션을 꺼야 합니다",
+      "useCenter": "센터링",
+      "useRotate": "회전",
+      "customTarget": "사용자 지정 대상"
+    },
+    "tutorial": {
+      "previous": "이전",
+      "next": "다음",
+      "skip": "튜토리얼 건너뛰기"
+    },
+    "fileBrowser": {
+      "title": "찾아보기",
+      "goUp": "상위 폴더로",
+      "loading": "불러오는 중...",
+      "empty": "빈 디렉터리",
+      "dblClickHint": "더블클릭하여 열기",
+      "deleteDir": "폴더 삭제",
+      "folderPlaceholder": "폴더 이름...",
+      "newFolder": "+ 새 폴더",
+      "create": "만들기",
+      "selectedPath": "선택됨:",
+      "loadError": "디렉터리를 불러올 수 없습니다.",
+      "createError": "폴더를 만들 수 없습니다.",
+      "deleteDirTitle": "폴더 삭제",
+      "deleteDirMessage": "\"{name}\" 및 모든 내용을 정말 삭제하시겠습니까?",
+      "deleteFileTitle": "파일 삭제",
+      "deleteFileMessage": "\"{name}\"을(를) 정말 삭제하시겠습니까?",
+      "deleteFile": "파일 삭제",
+      "deleteError": "삭제할 수 없습니다."
+    },
+    "settings": {
+      "title": "설정",
+      "general": "일반",
+      "add": "추가",
+      "coordinates": "GPS 좌표",
+      "save": "저장",
+      "infoSetLocationSync": "먼저 위치 동기화를 마운트로 설정하세요",
+      "coordsMismatchWarning": "프로필과 마운트 좌표가 다릅니다.",
+      "timeSync": {
+        "title": "시간 동기화",
+        "backendTime": "백엔드 시간",
+        "mountTime": "마운트 시간",
+        "syncLabel": "마운트로 시간 동기화",
+        "syncLabelInfo": "켜면 \"지금 동기화\"를 클릭할 때 마운트를 잠시 끊었다 다시 연결하여 NINA가 현재 시간을 마운트로 전송합니다.",
+        "mountNotConnected": "마운트가 연결되지 않음",
+        "notSupported": "드라이버에서 지원하지 않음",
+        "syncSuccess": "시간을 동기화했습니다.",
+        "syncError": "시간 동기화에 실패했습니다. PINS 기기 연결을 확인하세요.",
+        "loadError": "시간 정보를 불러올 수 없습니다."
+      },
+      "connection": "연결 설정",
+      "language": "언어",
+      "imageSavePath": {
+        "title": "이미지 저장 경로",
+        "placeholder": "선택된 경로 없음",
+        "selectTitle": "저장 위치 선택",
+        "save": "저장",
+        "saving": "...",
+        "savedMsg": "경로 저장됨:",
+        "errorMsg": "경로 저장 오류.",
+        "toastTitle": "경로 저장됨",
+        "toastErrorTitle": "오류",
+        "toastErrorMsg": "경로를 저장할 수 없습니다.",
+        "loading": "불러오는 중...",
+        "loadingDirs": "디렉터리 불러오는 중...",
+        "noSubfolders": "표시할 폴더 없음(비어 있거나 접근할 수 없는 경로)",
+        "dirLoadError": "디렉터리를 불러올 수 없습니다.",
+        "selectedPath": "선택된 경로:",
+        "dblClickHint": "더블클릭하여 열기",
+        "newFolder": "+ 새 폴더",
+        "folderPlaceholder": "폴더 이름...",
+        "create": "만들기"
+      },
+      "horizonFilePath": {
+        "title": "호라이즌 파일",
+        "placeholder": "예: /home/pi/horizon.hrz",
+        "toastTitle": "호라이즌 파일 저장됨"
+      },
+      "image": {
+        "title": "이미지",
+        "quality": "이미지 품질",
+        "maxDimension": "최대 이미지 크기",
+        "strech_factor": "스트레치 계수",
+        "black_clipping": "블랙 클리핑",
+        "debayern": "디베이어 이미지",
+        "DebayeredHFR": "디베이어 HFR",
+        "UnlinkedStretch": "비연동 스트레치",
+        "fileType": "파일 형식"
+      },
+      "imageFile": {
+        "title": "파일 이름 패턴",
+        "pattern": "패턴",
+        "preview": "미리보기",
+        "folder": "폴더",
+        "separator": "구분자",
+        "empty": "아래 토큰을 눌러 패턴을 만드세요",
+        "freeText": "텍스트",
+        "addText": "추가",
+        "editTokens": "토큰 편집",
+        "help": {
+          "title": "파일 이름 패턴",
+          "intro": "촬영한 이미지의 파일 이름 패턴을 만드세요. 저장할 때 각 토큰은 NINA가 실제 값으로 바꿔 줍니다.",
+          "tokensTitle": "토큰",
+          "tokensDesc": "토큰 버튼을 눌러 패턴에 추가하세요. Filter, Date, ExposureTime 같은 토큰은 NINA가 실제 값으로 바꿔 줍니다.",
+          "separatorsTitle": "구분자",
+          "separatorsDesc": "\\로 폴더 구조를 만듭니다. _ 또는 -로 파일 이름의 값을 구분합니다. \"Text\"로 초 단위의 \"s\" 같은 사용자 텍스트를 추가합니다.",
+          "cursorTitle": "삽입 위치",
+          "cursorDesc": "기존 토큰 사이를 눌러 깜빡이는 커서를 옮기세요. 새 토큰은 커서 위치에 삽입됩니다.",
+          "exampleTitle": "예시",
+          "exampleResult": "결과:"
+        },
+        "groups": {
+          "dateTime": "날짜 / 시간",
+          "image": "이미지",
+          "camera": "카메라",
+          "guiding": "가이딩",
+          "equipment": "장비",
+          "other": "기타"
+        },
+        "advancedSettings": "고급 설정",
+        "darks": "다크",
+        "flats": "플랫",
+        "bias": "바이어스",
+        "useLightPattern": "라이트와 동일"
+      },
+      "debug": {
+        "title": "디버그",
+        "activate": "디버그 모드 활성화",
+        "titel": "디버그",
+        "logLevel": "로그 레벨"
+      },
+      "notifications": {
+        "title": "알림",
+        "enable": "사용",
+        "sequence": "시퀀스",
+        "phd2": "PHD2"
+      },
+      "keepAwake": {
+        "title": "화면 켜짐 유지",
+        "description": "앱이 열려 있는 동안 기기가 어두워지거나 잠기지 않게 합니다."
+      },
+      "input": {
+        "title": "입력 최적화",
+        "touchOptimized": "터치 최적화 선택기"
+      },
+      "beta": {
+        "title": "베타 업데이트 채널"
+      },
+      "showTutorial": "튜토리얼 보기",
+      "plugins": {
+        "title": "플러그인 관리",
+        "description": "설치된 플러그인 관리",
+        "author": "제작자"
+      },
+      "system": {
+        "title": "시스템 제어",
+        "description": "시스템 재시작 및 종료 제어",
+        "info": "이 작업은 시스템 전체에 영향을 줍니다",
+        "confirmation": "작업 확인",
+        "confirmShutdown": "시스템을 종료하시겠습니까?",
+        "confirmRestart": "시스템을 재시작하시겠습니까?",
+        "restartInfoTitle": "시스템 재시작 중",
+        "restartInfoMessage": "시스템을 재시작하고 있습니다.",
+        "shutdownInfoTitle": "시스템 종료 중",
+        "shutdownInfoMessage": "시스템을 종료하고 있습니다. 이 페이지에는 더 이상 접속할 수 없습니다."
+      },
+      "plate_solver": {
+        "title": "플레이트 솔버",
+        "basic": "기본 설정",
+        "search": "검색 설정",
+        "retry": "재시도 설정",
+        "ExposureTime": "노출 시간 (s)",
+        "Gain": "게인",
+        "SearchRadius": "검색 반경 (°)",
+        "Threshold": "임계값",
+        "RotationTolerance": "회전 허용 오차 (°)",
+        "MaxObjects": "최대 객체 수",
+        "NumberOfAttempts": "시도 횟수",
+        "ReattemptDelay": "재시도 간격 (min)",
+        "BlindFailoverEnabled": "블라인드 폴백 사용",
+        "ASTAPLocation": "ASTAP 경로",
+        "Filter": "플레이트 솔빙 필터",
+        "FilterCurrent": "현재",
+        "FilterHint": "플레이트 솔빙 중 사용할 필터(현재 필터를 덮어씁니다)"
+      },
+      "equipment": {
+        "title": "장비",
+        "description": "장비 설정 관리"
+      },
+      "navbarCustomization": {
+        "title": "내비게이션 바 사용자 지정",
+        "hint": "드래그하여 순서를 바꾸세요. 설정 외에 최소 한 개의 페이지는 표시되어야 합니다.",
+        "alwaysVisible": "항상 표시",
+        "minOneRequired": "최소 한 개의 페이지는 표시되어야 합니다"
+      },
+      "update": "업데이트",
+      "errors": {
+        "instanceNameRequired": "인스턴스 이름을 입력하세요",
+        "invalidIPFormat": "잘못된 IP 형식",
+        "invalidPortRange": "잘못된 포트 범위",
+        "invalidInstance": "잘못된 인스턴스",
+        "emptyFields": "빈 항목이 있습니다"
+      },
+      "telescope": {
+        "titel": "망원경 설정",
+        "name": "망원경 이름",
+        "focal_ratio": "초점비"
+      },
+      "mount": {
+        "titel": "마운트 설정",
+        "max_slew_rate": "최대 슬루 속도 (°/s)"
+      }
+    },
+    "alpacaDirect": {
+      "title": "Alpaca 직접 설정",
+      "ipAddress": "IP 주소",
+      "port": "포트",
+      "deviceNumber": "장치 번호",
+      "serviceType": "서비스 유형",
+      "save": "저장",
+      "connect": "연결",
+      "disconnect": "연결 해제",
+      "sharedGuidWarning": "로테이터와 안전 모니터는 NINA에서 하나의 저장 슬롯을 공유합니다 — 하나를 바꾸면 다른 하나도 바뀝니다.",
+      "noReconnectHint": "새 설정은 다음 연결 시 적용됩니다.",
+      "cameraNoSettings": "이 카메라는 설정할 항목이 없습니다."
+    },
+    "connectEquipment": {
+      "camera": {
+        "name": "카메라"
+      },
+      "connectAll": "모두 연결",
+      "disconnectAll": "모두 연결 해제",
+      "connectAllError": "모든 장치 연결 오류",
+      "disconnectAllError": "모든 장치 연결 해제 오류",
+      "filter": {
+        "name": "필터휠"
+      },
+      "mount": {
+        "name": "마운트"
+      },
+      "focuser": {
+        "name": "포커서"
+      },
+      "rotator": {
+        "name": "로테이터"
+      },
+      "guider": {
+        "name": "가이더",
+        "mountRequired": "가이더를 연결하려면 먼저 마운트를 연결해야 합니다.",
+        "guideCamRequired": "유효한 가이드 카메라를 선택해야 합니다."
+      },
+      "guiderCam": {
+        "name": "가이드 카메라"
+      },
+      "safety": {
+        "name": "안전 모니터"
+      },
+      "flat": {
+        "name": "플랫 장치"
+      },
+      "dome": {
+        "name": "돔"
+      },
+      "switch": {
+        "name": "스위치"
+      },
+      "weather": {
+        "name": "날씨"
+      },
+      "info": {
+        "title": "정보",
+        "message": "수동 필터휠과 수동 로테이터는 현재 NINA를 통해서만 제어할 수 있습니다. 필터휠은 API의 “Networked Filter Wheel”을 사용하세요"
+      }
+    },
+    "lastLogs": {
+      "timestamp": "타임스탬프",
+      "level": "레벨",
+      "message": "메시지",
+      "download": "다운로드"
+    },
+    "sequence": {
+      "stats": "통계",
+      "noSequenceLoaded": "불러온 시퀀스 없음",
+      "noSequenceData": "아직 사용 가능한 데이터가 없습니다",
+      "startSequence": "시퀀스 시작",
+      "stopSequence": "시퀀스 정지",
+      "pauseSequence": "일시정지",
+      "resetSequence": "시퀀스 초기화",
+      "skipToEnd": "끝으로 건너뛰기",
+      "skipCurrentItem": "현재 항목 건너뛰기",
+      "lockControls": "잠금",
+      "unlockControls": "잠금 해제",
+      "controlsLockedMessage": "시퀀스 실행 중에는 시퀀스 컨트롤이 잠깁니다.",
+      "manageSequences": "시퀀스 불러오기 / 저장",
+      "saveSequenceAs": "현재 시퀀스를 다른 이름으로 저장",
+      "sequenceFileName": "파일명",
+      "sequenceSave": "저장",
+      "sequenceLoad": "불러오기",
+      "sequenceNoFiles": "파일이 없습니다",
+      "sequenceLoading": "불러오는 중...",
+      "sequenceClose": "닫기",
+      "deleteConfirmationTitle": "파일 삭제",
+      "deleteConfirmationMessage": "이 파일을 삭제하시겠습니까?",
+      "overwriteConfirmationTitle": "파일 덮어쓰기",
+      "overwriteConfirmationMessage": "이 파일을 덮어쓰시겠습니까?",
+      "resetConfirmationTitle": "초기화 확인",
+      "resetConfirmationMessage": "시퀀스를 초기화하시겠습니까? 이 작업은 되돌릴 수 없습니다.",
+      "clearSequence": "모두 지우기",
+      "clearConfirmationTitle": "지우기 확인",
+      "clearConfirmationMessage": "전체 시퀀스를 지우시겠습니까? 이 작업은 되돌릴 수 없습니다.",
+      "load_sequence": "디렉터리에서 시퀀스 불러오기",
+      "choose_sequence": "시퀀스 선택",
+      "saved_sequences": "TNS 시퀀스 생성기",
+      "no_sequences_found": "시퀀스를 찾을 수 없습니다",
+      "error_loading_sequences": "시퀀스 불러오기 오류",
+      "error_loading_sequence": "시퀀스 불러오기 오류",
+      "filter": "필터",
+      "triggers": "트리거",
+      "expandAll": "모두 펼치기",
+      "collapseAll": "모두 접기",
+      "addTypeButton": {
+        "searchPlaceholder": "검색…",
+        "noResults": "결과 없음",
+        "addItem": "항목 추가",
+        "addTrigger": "트리거 추가",
+        "addCondition": "조건 추가",
+        "add": "추가",
+        "item": "항목",
+        "trigger": "트리거",
+        "condition": "조건"
+      },
+      "details": {},
+      "hfr": "HFR",
+      "mean": "평균",
+      "median": "중앙값",
+      "stDev": "표준편차",
+      "rmsText": "RMS",
+      "gain": "게인",
+      "offset": "오프셋",
+      "monitor": {
+        "settings": {
+          "title": "보기 설정",
+          "showImage": "마지막 이미지 표시",
+          "showImageStats": "마지막 이미지 통계 표시",
+          "showImgStatsGraph": "HFR 차트 표시",
+          "showGuiderAfGraph": "오토포커스 차트 표시",
+          "imageRotation": "이미지 회전",
+          "display_status_under_image": "이미지 아래에 상태 표시",
+          "sequenceCurrentState": "시퀀스 상태 표시"
+        }
+      },
+      "graphControls": {
+        "title": "그래프 컨트롤",
+        "dataSources": "데이터 소스",
+        "source1": "소스 1",
+        "source2": "소스 2",
+        "reset": "초기화",
+        "noDataAvailable": "사용 가능한 데이터 없음",
+        "timeDisplay": "시간 범위"
+      },
+      "running": "실행 중",
+      "imageHistory": "이미지 기록",
+      "duration": "지속 시간",
+      "temperatureShort": "온도",
+      "targetName": "타깃",
+      "conditions": "조건",
+      "info": {
+        "header": "정보",
+        "message": "안타깝게도 시퀀스를 편집할 수 없습니다. 현재 모든 시퀀스 플러그인이 지원되지는 않습니다. 도움을 주고 싶으시면 사용 중인 플러그인을 GitHub에 알려주세요."
+      },
+      "info_general": {},
+      "sort": {
+        "sort": "정렬",
+        "oldest": "오래된 순",
+        "newest": "최신 순"
+      },
+      "time": "시간",
+      "noRunningItems": "시퀀스 정지됨",
+      "status": "시퀀스 상태",
+      "instructions": "지침",
+      "noItemsInContainer": "이 컨테이너에 항목이 없습니다",
+      "Min": "최소",
+      "Max": "최대",
+      "HFRStDev": "HFR 표준편차",
+      "totalExposureTime": {
+        "title": "총 노출 시간",
+        "Pictures": "사진",
+        "AllFilters": "모든 필터",
+        "noFilter": "필터 없음",
+        "total": "합계"
+      },
+      "imageFilter": {
+        "allTargets": "모든 타깃",
+        "allFilters": "모든 필터",
+        "allNights": "모든 밤",
+        "allImageTypes": "모든 유형",
+        "reset": "필터 초기화"
+      },
+      "items": {
+        "saving": "저장 중…",
+        "generic": "일반",
+        "on": "켜짐",
+        "off": "꺼짐",
+        "takeExposure": {
+          "exposureTime": "노출 시간 (s)",
+          "gain": "게인",
+          "offset": "오프셋",
+          "binning": "비닝",
+          "imageType": "이미지 유형"
+        },
+        "takeManyExposures": {
+          "iterations": "노출 횟수"
+        },
+        "smartExposure": {
+          "ditherAfter": "디더링 간격 (노출)"
+        },
+        "takeSubframeExposure": {
+          "roiPct": "ROI (%)"
+        },
+        "switchFilter": {
+          "filter": "필터",
+          "noFilter": "필터 없음"
+        },
+        "switchProfile": {
+          "profile": "프로필",
+          "reconnect": "재연결"
+        },
+        "loopCondition": {
+          "iterations": "반복 횟수"
+        },
+        "moonIllumination": {
+          "illumination": "조도 (%)"
+        },
+        "reconnect": {
+          "device": "장치"
+        },
+        "autofocus": {
+          "afterExposures": "노출 후",
+          "afterExposuresCount": "노출",
+          "everyN": "{n}회마다",
+          "hfrIncrease": "HFR 증가 (%)",
+          "sampleSize": "샘플 크기",
+          "samples": "샘플 {n}개",
+          "trendPerFilter": "필터별 추세",
+          "deltaT": "온도 변화 (°)",
+          "minutes": "분"
+        },
+        "centerAfterDrift": {
+          "distance": "거리 (분각)"
+        },
+        "meridianFlip": {
+          "minutesAfter": "자오선 통과 후 분",
+          "maxMinutesAfter": "자오선 통과 후 최대 분",
+          "pauseBefore": "자오선 통과 전 대기 (분)",
+          "useSideOfPier": "피어 방향 사용"
+        },
+        "altitudeCondition": {
+          "altitude": "고도 (°)",
+          "horizonOffset": "지평선 오프셋 (°)"
+        },
+        "sunAltitudeCondition": {
+          "altitude": "태양 고도 (°)"
+        },
+        "timeCondition": {
+          "provider": "공급자"
+        },
+        "timeSpan": {
+          "hours": "시",
+          "minutes": "분",
+          "seconds": "초",
+          "minutesOffset": "분 오프셋"
+        },
+        "moonAltitude": {
+          "comparator": "비교 연산자",
+          "below": "이하",
+          "above": "이상",
+          "altitude": "달 고도 (°)"
+        },
+        "dither": {
+          "afterExposures": "노출 후"
+        },
+        "center": {
+          "ra": "RA",
+          "dec": "Dec",
+          "inherited": "대상에서 상속된 좌표"
+        },
+        "coolCamera": {
+          "temperature": "온도 (°C)",
+          "duration": "지속 시간 (분)"
+        },
+        "dewHeater": {
+          "onOff": "이슬 방지 히터"
+        },
+        "setUSBLimit": {
+          "limit": "USB 제한"
+        },
+        "setBrightness": {
+          "brightness": "밝기"
+        },
+        "autoExposureFlat": {
+          "minExposure": "최소 노출 (s)",
+          "maxExposure": "최대 노출 (s)"
+        },
+        "autoBrightnessFlat": {
+          "minBrightness": "최소 밝기",
+          "maxBrightness": "최대 밝기",
+          "histogramTarget": "히스토그램 목표 (%)",
+          "histogramTolerance": "히스토그램 허용 오차 (%)",
+          "iterations": "개수",
+          "keepPanelClosed": "패널 닫힌 상태 유지"
+        },
+        "polarAlignment": {
+          "searchRadius": "검색 반경 (°)",
+          "alignmentTolerance": "정렬 허용 오차 (arcsec)",
+          "moveRate": "이동 속도 (°/s)",
+          "targetDistance": "목표 거리 (°)",
+          "eastDirection": "동쪽 방향",
+          "manualMode": "수동 모드",
+          "manual": "수동",
+          "startFromCurrentPosition": "현재 위치에서 시작"
+        },
+        "skyFlat": {
+          "shouldDither": "디더링",
+          "ditherPixels": "디더 픽셀",
+          "ditherSettleTime": "디더 안정화 시간 (s)"
+        },
+        "moveRotatorMechanical": {
+          "mechanicalPosition": "기계적 위치 (°)"
+        },
+        "solveAndRotate": {
+          "positionAngle": "포지션 앵글 (°)"
+        },
+        "setSwitchValue": {
+          "switch": "스위치",
+          "value": "값"
+        },
+        "setTracking": {
+          "trackingMode": "추적 모드",
+          "sidereal": "항성시",
+          "lunar": "달",
+          "solar": "태양",
+          "king": "King",
+          "custom": "사용자 지정",
+          "stopped": "정지됨"
+        },
+        "expressionVariable": {
+          "identifier": "이름",
+          "expression": "값",
+          "value": "값",
+          "initially": "초기값",
+          "newValue": "새 값",
+          "time": "시간",
+          "minutesOffset": "오프셋 (분)"
+        },
+        "annotation": {
+          "text": "텍스트"
+        },
+        "waitUntil": {
+          "predicate": "조건"
+        },
+        "waitForTimeSpan": {
+          "time": "지속 시간 (s)"
+        },
+        "slewDomeAzimuth": {
+          "azimuth": "방위각 (°)"
+        },
+        "stackFlats": {
+          "waitForStack": "스택 대기"
+        },
+        "interruptWhenRMSAbove": {
+          "rmsThreshold": "RMS 임계값 (\")",
+          "mode": "모드",
+          "modeRMS": "RMS",
+          "modePeak": "피크",
+          "minimumPoints": "최소 포인트 수"
+        },
+        "changePHD2Parameters": {
+          "parameter": "매개변수",
+          "exposureTime": "노출 시간 (s)",
+          "ditherPixels": "디더 (px)",
+          "ditherRAOnly": "RA만 디더",
+          "settlePixels": "안정화 (px)",
+          "settleTime": "안정화 시간 (s)",
+          "settleTimeout": "안정화 시간 초과 (s)",
+          "roiPct": "ROI (%)"
+        },
+        "dso": {
+          "targetName": "대상 이름",
+          "positionAngle": "포지션 앵글 (°)",
+          "loadFromFavorites": "즐겨찾기에서 불러오기"
+        },
+        "warmCamera": {
+          "duration": "지속 시간 (분)"
+        },
+        "orbuculum": {
+          "hourAngle": "시간각 (h)",
+          "nextTarget": "다음 대상:",
+          "current": "현재:"
+        },
+        "autoBalancingExposure": {
+          "timeSeconds": "시간 (s)",
+          "noEntries": "항목 없음",
+          "addRow": "행 추가",
+          "progress": "진행률",
+          "ratio": "비율",
+          "bin": "비닝"
+        },
+        "setReadoutMode": {
+          "mode": "모드"
+        },
+        "loopWhile": {
+          "expression": "수식"
+        },
+        "slewScopeToAltAz": {
+          "azimuth": "Az",
+          "altitude": "Alt"
+        },
+        "moveFocuserAbsolute": {
+          "position": "위치"
+        },
+        "moveFocuserRelative": {
+          "relativePosition": "상대 위치"
+        },
+        "moveFocuserByTemperature": {
+          "slope": "기울기",
+          "intercept": "절편",
+          "absolute": "절대값"
+        }
+      },
+      "emptyContainer": "비어 있음 — +를 눌러 항목 추가",
+      "move": "이동",
+      "more": "더 보기",
+      "duplicate": "복제",
+      "enable": "사용",
+      "disable": "사용 안 함",
+      "resetStatus": "상태 초기화",
+      "delete": "삭제"
+    },
+    "mount": {
+      "title": "마운트",
+      "slew": "슬루",
+      "location_sync": {
+        "title": "위치 동기화 설정",
+        "confirmationMessage": "NINA의 'Location Sync'가 'Prompt'로 설정되어 있으면 좌표를 망원경으로 보내기 전에 확인 창이 나타날 수 있습니다. 이를 피하고 TNS가 좌표를 자동으로 설정하도록 하려면 'Sync to Telescope'로 변경하는 것을 권장합니다",
+        "toTelescope": {
+          "label": "망원경으로 동기화"
+        },
+        "toApplication": {
+          "label": "애플리케이션으로 동기화"
+        },
+        "noSync": {
+          "label": "동기화 안 함"
+        }
+      },
+      "control": {
+        "park": "파킹",
+        "unpark": "파킹 해제",
+        "home": "홈",
+        "set_as_park": "파킹 위치로 설정",
+        "trackingMode": "추적 모드",
+        "manuellControl": "수동 제어",
+        "slewRate": "슬루 속도",
+        "siderial": "항성시(Sidereal)",
+        "sync_coordinates_to_mount": "마운트와 좌표 동기화",
+        "errors": {
+          "unpark": "마운트 파킹 해제 오류",
+          "tracking": "추적 모드 설정 오류"
+        },
+        "setLocationSyncToMount": "\"망원경으로 동기화\" 설정",
+        "slewRateINDI": "슬루 속도",
+        "reverse_axis": "축 방향"
+      },
+      "info": {
+        "notConnected": "마운트를 연결하세요",
+        "parked": "파킹됨",
+        "unparked": "파킹 해제됨",
+        "trackingActive": "추적 중",
+        "trackingDisabled": "추적 비활성화됨",
+        "slewing": "마운트 슬루 중",
+        "notSlewing": "슬루 중 아님",
+        "timeToMeridianFlip": "자오선 반전까지 시간",
+        "declination": "Dec",
+        "rightAscension": "Ra",
+        "Alt": "Alt",
+        "Az": "Az",
+        "SideOfPier": "피어 방향"
+      },
+      "settings": {
+        "meridian_flip_settings": "자오선 반전(meridian flip)",
+        "telescope_settle_time": "슬루 후 안정화 시간 (s)",
+        "meridian_flip": {
+          "basic": "기본 설정",
+          "behavior": "동작",
+          "post_flip_actions": "반전 후 작업",
+          "MinutesAfterMeridian": "자오선 통과 후 시간(분)",
+          "MaxMinutesAfterMeridian": "자오선 통과 후 최대 시간(분)",
+          "PauseTimeBeforeMeridian": "자오선 통과 전 일시정지 시간",
+          "SettleTime": "안정화 시간 (s)",
+          "Recenter": "재중심 정렬",
+          "UseSideOfPier": "피어 방향 사용",
+          "AutoFocusAfterFlip": "반전 후 오토포커스",
+          "RotateImageAfterFlip": "반전 후 이미지 회전"
+        },
+        "reverse_primary_axis": "주축 반전",
+        "reverse_secondary_axis": "보조축 반전"
+      },
+      "indi": {
+        "settings": "마운트 설정"
+      }
+    },
+    "guider": {
+      "notConnected": "가이더를 연결하세요",
+      "start": "시작",
+      "startWithCal": "캘리브레이션부터 시작",
+      "stop": "정지",
+      "rms_error": "RMS 오차",
+      "title": "가이더",
+      "running": "실행 중",
+      "statusLabel": "상태",
+      "settings": "가이더 설정",
+      "phd2Path": "PHD2 경로",
+      "phd2ServerHost": "PHD2 서버 호스트명",
+      "phd2ServerPort": "PHD2 서버 포트",
+      "ditherPixels": "디더 픽셀 (px)",
+      "ditherRAOnly": "RA 방향만 디더링",
+      "settlePixels": "안정화 픽셀 허용 오차 (px)",
+      "settleTime": "최소 안정화 시간 (s)",
+      "settleTimeout": "안정화 타임아웃 (s)",
+      "guidingStartRetry": "가이딩 시작 재시도",
+      "guidingStartTimeout": "가이딩 시작 타임아웃 (s)",
+      "roiPercentage": "가이드 별 탐색 ROI 비율 (%)",
+      "status": {
+        "looping": "루핑",
+        "lostLock": "락 손실",
+        "guiding": "가이딩 중",
+        "stopped": "정지됨",
+        "calibrating": "캘리브레이션 중",
+        "unknown": "알 수 없음"
+      },
+      "calibrationAssistant": {
+        "title": "캘리브레이션 도우미",
+        "info": "캘리브레이션 도우미는 캘리브레이션을 위해 마운트를 최적의 위치에 배치하고 정확한 캘리브레이션을 수행하도록 도와줍니다.",
+        "positionSettings": "위치 설정",
+        "decOffset": "Dec",
+        "meridianOffset": "자오선 오프셋",
+        "direction": "방향",
+        "west": "서",
+        "east": "동",
+        "slewToPosition": "위치로 슬루",
+        "startCalibration": "캘리브레이션 시작",
+        "stopCalibration": "캘리브레이션 정지",
+        "positionCalculated": "최적 위치 계산됨",
+        "slewing": "목표 위치로 슬루 중...",
+        "slewComplete": "슬루 완료",
+        "slewError": "슬루 중 오류",
+        "stopSlew": "슬루 정지",
+        "slewStopped": "슬루 정지됨",
+        "calibrating": "캘리브레이션 진행 중...",
+        "calibrationComplete": "캘리브레이션 완료",
+        "calibrationFailed": "캘리브레이션 실패",
+        "calibrationStopped": "캘리브레이션 정지됨",
+        "calibrationError": "캘리브레이션 중 오류",
+        "calibrationResult": "캘리브레이션 결과",
+        "quality": "품질",
+        "goodCalibration": "우수한 캘리브레이션 달성",
+        "poorCalibration": "캘리브레이션을 개선할 수 있습니다. 다른 위치를 시도하거나 장비를 점검하세요."
+      },
+      "phd2": {
+        "Exposuretime": "노출 시간",
+        "profile": "프로필",
+        "forceCalibration": "캘리브레이션 강제 실행",
+        "calibration": "캘리브레이션",
+        "exposure": "노출",
+        "raAlgorithm": "RA 알고리즘",
+        "decAlgorithm": "DEC 알고리즘",
+        "equipment": "장비",
+        "optical": "광학 설정",
+        "focalLength": "초점 거리",
+        "calibrationStep": "캘리브레이션 스텝",
+        "calibStepCalc": "스텝 크기 계산기",
+        "optimal": "최적",
+        "pixelSize": "픽셀 크기",
+        "guideSpeed": "가이드 속도",
+        "desiredSteps": "목표 스텝",
+        "declination": "적위",
+        "imageScale": "이미지 스케일",
+        "calibDistance": "거리",
+        "calculatedStep": "계산된 스텝",
+        "applyStep": "적용",
+        "reverseDecAfterFlip": "반전 후 DEC 방향 반대로",
+        "useMultipleStars": "다중 별 사용",
+        "shared_prarmeters": "공유 파라미터",
+        "guideAlgorithm": "가이드 알고리즘",
+        "guideAlgorithmRA": "RA 가이드 알고리즘",
+        "guideAlgorithmDEC": "DEC 가이드 알고리즘",
+        "camera": "카메라",
+        "cameraGain": "게인",
+        "cameraBinning": "비닝",
+        "restoreCalibration": "캘리브레이션 복원",
+        "mountSettings": "마운트",
+        "guideRate": "가이드 레이트",
+        "guideRateReadOnly": "읽기 전용",
+        "guiderScale": "가이더 스케일",
+        "maxY": "최대 Y",
+        "historySize": "히스토리 크기",
+        "ra": {
+          "aggression": "RA: 적극성",
+          "hysteresis": "RA: 히스테리시스",
+          "MinMove": "RA: 최소 이동",
+          "MaxMove": "RA: 최대 이동",
+          "predictive_weight": "RA: 예측 가중치",
+          "reactive_weight": "RA: 반응 가중치",
+          "slope_weight": "RA: 기울기 가중치",
+          "exp_factor": "RA: 노출 계수"
+        },
+        "dec": {
+          "aggression": "DEC: 적극성",
+          "hysteresis": "DEC: 히스테리시스",
+          "MinMove": "DEC: 최소 이동",
+          "MaxMove": "DEC: 최대 이동",
+          "predictive_weight": "DEC: 예측 가중치",
+          "reactive_weight": "DEC: 반응 가중치",
+          "slope_weight": "DEC: 기울기 가중치",
+          "exp_factor": "DEC: 노출 계수"
+        },
+        "error": {
+          "title": "PHD2 오류",
+          "star-lost-message": "별 추적 실패"
+        },
+        "profileManagement": {
+          "title": "프로파일 관리",
+          "createNew": "새 프로파일 만들기",
+          "profileName": "프로파일 이름",
+          "profileNamePlaceholder": "프로파일 이름 입력",
+          "profilesList": "프로파일",
+          "create": "만들기",
+          "rename": "이름 변경",
+          "delete": "삭제",
+          "cancel": "취소",
+          "confirmDelete": "삭제하시겠습니까?",
+          "lastProfileWarning": "마지막 프로파일은 삭제할 수 없습니다",
+          "success": {
+            "created": "프로파일이 생성되었습니다",
+            "renamed": "프로파일 이름이 변경되었습니다",
+            "deleted": "프로파일이 삭제되었습니다"
+          },
+          "errors": {
+            "emptyName": "프로파일 이름은 비워둘 수 없습니다",
+            "duplicateName": "이미 존재하는 프로파일 이름입니다",
+            "createFailed": "프로파일 생성 실패",
+            "renameFailed": "프로파일 이름 변경 실패",
+            "deleteFailed": "프로파일 삭제 실패"
+          }
+        },
+        "starComponents": {
+          "show": "별 구성요소 표시",
+          "hide": "별 구성요소 숨기기"
+        },
+        "autoSelectStar": "가이드 별 자동 선택",
+        "reviewCalibration": "캘리브레이션 검토",
+        "calibrationData": {
+          "title": "캘리브레이션 검토",
+          "notCalibrated": "캘리브레이션 안 됨",
+          "lastMountCalibration": "마지막 마운트 캘리브레이션",
+          "cameraAngle": "카메라 각도:",
+          "orthogonalityError": "직교성 오차:",
+          "raRate": "RA 레이트:",
+          "decRate": "Dec 레이트:",
+          "raParity": "RA 패리티:",
+          "decParity": "Dec 패리티:",
+          "declination": "적위:",
+          "estimated": "(추정)",
+          "clearing": "지우는 중...",
+          "clearCalibration": "캘리브레이션 지우기",
+          "rightAscension": "적경",
+          "declinationAxis": "적위"
+        },
+        "darkLibrary": {
+          "title": "다크 라이브러리",
+          "manage": "다크 라이브러리 관리",
+          "info": "다양한 노출 시간으로 다크 프레임을 촬영해 다크 라이브러리를 만듭니다. PHD2는 이를 사용해 가이드 프레임에서 센서 노이즈를 제거합니다.",
+          "warning": "빌드 중에는 PHD2가 차단됩니다 — 빌드가 실행되는 동안 다른 모든 PHD2 동작이 비활성화됩니다.",
+          "status": "상태",
+          "exists": "라이브러리 있음",
+          "loaded": "로드됨",
+          "notLoaded": "로드 안 됨",
+          "noLibrary": "다크 라이브러리가 없습니다",
+          "numDarks": "다크 개수",
+          "range": "노출 범위",
+          "minExposure": "최소 노출 (s)",
+          "maxExposure": "최대 노출 (s)",
+          "frameCount": "노출당 프레임 수",
+          "previewExposures": "노출 시간",
+          "totalFrames": "전체 프레임",
+          "build": "빌드",
+          "cancel": "빌드 취소",
+          "building": "빌드 중",
+          "buildProgress": "프레임 {frame} / {total} – {exposure} s",
+          "load": "로드",
+          "unload": "언로드",
+          "delete": "삭제",
+          "confirmDelete": "삭제하려면 다시 클릭",
+          "buildSuccess": "다크 라이브러리가 생성되었습니다",
+          "buildFailed": "다크 라이브러리 빌드 실패",
+          "buildCancelled": "빌드가 취소되었습니다",
+          "invalidRange": "최소 노출은 최대 노출보다 작거나 같아야 합니다",
+          "buildActive": "다크 라이브러리 빌드 진행 중",
+          "buildActiveMessage": "빌드가 완료될 때까지 PHD2 동작이 차단됩니다."
+        }
+      }
+    },
+    "focuser": {
+      "title": "포커서",
+      "focus": "포커스",
+      "new_position": "새 위치:",
+      "move": "이동",
+      "start_autofocus": "오토포커스 시작",
+      "cancel_autofocus": "오토포커스 취소",
+      "autofocus_graph": "오토포커스 그래프",
+      "autofocus_error": "오토포커스 오류",
+      "please_connect_focuser": "포커서를 연결해 주세요",
+      "current_position": "현재 위치:",
+      "temperature": "온도:",
+      "moving": "이동 중",
+      "stopped": "정지됨",
+      "autofocus_active": "오토포커스 진행 중",
+      "autofocus": "오토포커스",
+      "last_autofocus": "마지막 오토포커스",
+      "graph": {
+        "measurePoints": "측정 점",
+        "quadraticTrendline": "2차 추세선",
+        "hyperbolicTrendline": "쌍곡선 추세선",
+        "quadraticMin": "2차 최소",
+        "hyperbolicMin": "쌍곡선 최소",
+        "value": "값",
+        "invalidDate": "잘못된 날짜"
+      },
+      "hfr": "HFR",
+      "focuser_position": "위치",
+      "IsStalled": "멈춤",
+      "HeatingPower": "가열 출력:",
+      "BoardTemperature": "보드 온도:",
+      "DcPower": "DC 전원",
+      "StepSize": "스텝 크기",
+      "duration_seconds": "시간",
+      "filter": "필터",
+      "estimated": "추정",
+      "settings": {
+        "AutoFocusInitialOffsetSteps": "초기 오프셋 스텝",
+        "AutoFocusStepSize": "스텝 크기",
+        "FocuserSettleTime": "포커서 안정 시간",
+        "AutoFocusTotalNumberOfAttempts": "총 시도 횟수",
+        "AutoFocusNumberOfFramesPerPoint": "점당 프레임 수",
+        "AutoFocusInnerCropRatio": "내부 크롭 비율",
+        "AutoFocusOuterCropRatio": "외부 크롭 비율",
+        "AutoFocusUseBrightestStars": "가장 밝은 별 사용",
+        "BacklashIn": "백래시 인",
+        "BacklashOut": "백래시 아웃",
+        "AutoFocusBinning": "오토포커스 비닝",
+        "AutoFocusTimeoutSeconds": "오토포커스 타임아웃(초)",
+        "RSquaredThreshold": "R제곱 임계값",
+        "AutoFocusFitFunction": "곡선 피팅 방식",
+        "AutoFocusDisableGuiding": "오토포커스 중 가이딩 비활성화",
+        "TRENDLINES": "추세선",
+        "PARABOLIC": "포물선",
+        "TRENDPARABOLIC": "추세 포물선",
+        "HYPERBOLIC": "쌍곡선",
+        "TRENDHYPERBOLIC": "추세 쌍곡선",
+        "BacklashCompensationModel": "백래시 보정 모델",
+        "OVERSHOOT": "오버슈트",
+        "ABSOLUTE": "절대",
+        "title": "설정",
+        "general": "일반 설정",
+        "autofocus": "오토포커스 설정",
+        "crop_and_stars": "크롭 및 별",
+        "backlash": "백래시",
+        "advanced": "고급",
+        "Reverse": "역방향",
+        "UseFilterWheelOffsets": "필터휠 오프셋 사용",
+        "MaxStep": "최대 스텝",
+        "AutoFocusFilter": "오토포커스 필터",
+        "AutoFocusFilterNone": "없음",
+        "AutoFocusExposureTime": "기본 노출 시간",
+        "MotorSpeedControl": "모터 속도 제어",
+        "BeepOnMove": "이동 시 비프음",
+        "BeepOnStartup": "시작 시 비프음",
+        "StallDetection": "멈춤 감지",
+        "Heating": "가열",
+        "HeatingTemperature": "가열 온도",
+        "USBCapacity": "USB 용량",
+        "ClearStall": "멈춤 해제",
+        "ResetPosition": "위치를 0으로 설정",
+        "commandFailed": "이 장치에서 지원하지 않는 명령",
+        "FocuserAlias": "포커서 별칭",
+        "deviceSpecific": "장치 설정"
+      },
+      "indi": {
+        "settings": "포커서 설정"
+      }
+    },
+    "dome": {
+      "title": "돔",
+      "azimuth": "방위각",
+      "slewing": "슬루 중",
+      "slewing_stopped": "슬루 정지됨",
+      "following": "추적 중",
+      "following_stopped": "추적 정지됨",
+      "at_home": "홈",
+      "not_at_home": "홈 아님",
+      "park": "파킹",
+      "unpark": "파킹 해제",
+      "shutter_close": "셔터 닫힘",
+      "shutter_open": "셔터 열림",
+      "control": {
+        "open": "셔터 열기",
+        "close": "셔터 닫기",
+        "stop": "셔터 움직임 정지",
+        "errors": {
+          "open": "셔터 열기 오류",
+          "close": "셔터 닫기 오류",
+          "stop": "셔터 정지 오류",
+          "park": "파킹 오류",
+          "sync": "동기화 오류",
+          "stop_slew": "슬루 정지 오류",
+          "home": "홈 오류",
+          "follow": "망원경 추적 오류"
+        },
+        "slew": "슬루",
+        "slew_label": "각도로 슬루",
+        "follow": "돔 망원경 추적",
+        "sync": "망원경과 동기화",
+        "park": "파킹",
+        "home": "홈"
+      },
+      "please_connect_dome": "돔을 연결하세요",
+      "is_sync": "동기화",
+      "not_sync": "동기화 안 됨",
+      "indi": {
+        "settings": "돔 설정"
+      }
+    },
+    "safetyMonitor": {
+      "indi": {
+        "settings": "안전 모니터 설정"
+      }
+    },
+    "camera": {
+      "connect": "카메라를 연결하세요",
+      "settings": "설정",
+      "capture_running": "촬영 진행 중",
+      "exposure_time": "노출 시간(s):",
+      "gain_iso": "게인 / ISO:",
+      "name": "카메라 이름",
+      "gain": "게인",
+      "offset": "오프셋",
+      "temperature": "온도(°C)",
+      "standby": "대기",
+      "cooler_on": "냉각 켜짐",
+      "cooler_off": "냉각 꺼짐",
+      "dew_heater": "결로 방지 히터",
+      "dew_heater_on": "결로 방지 히터 켜기",
+      "dew_heater_off": "결로 방지 히터 끄기",
+      "dewHeaterStrength": "결로 방지 히터 세기",
+      "camera_cooling": "카메라 쿨다운",
+      "target_temperature": "목표 온도 (°C)",
+      "warm_up_time": "예열 시간 (분)",
+      "cooling_time": "냉각 시간 (분)",
+      "binning_mode": "비닝",
+      "readout_mode": "리드아웃 모드",
+      "usb_limit": "USB 제한",
+      "set_use_platesolve": "플레이트 솔브 사용",
+      "chip_settings": {
+        "title": "카메라 칩 설정",
+        "pixel_size": "픽셀 크기 (μm)",
+        "width": "너비 (px)",
+        "height": "높이 (px)",
+        "focal_length": "초점 거리 (mm)"
+      },
+      "at_target_temp": "목표 온도 도달",
+      "temperature_setpoint": "온도 설정값 (°C)",
+      "cooler_power": "쿨러 출력 (%)",
+      "camera_warming": "카메라 예열",
+      "cooler_status": "쿨러 상태",
+      "cooler_status_off": "꺼짐",
+      "cooler_status_cooling": "작동 중 - 냉각 목표",
+      "cooler_status_holding": "작동 중 - 목표 온도 도달",
+      "cooler_status_warming": "작동 중 - 예열 목표",
+      "set_save_snapshot": "스냅샷 저장",
+      "snapshotTargetName": "대상 이름",
+      "set_use_solve_sync_to_mount": "마운트에 동기화",
+      "readout_mode_image": "리드아웃 모드 (시퀀스)",
+      "readout_mode_snap": "리드아웃 모드 (스냅샷)",
+      "LowNoiseMode": "울트라 모드",
+      "BadPixelCorrection": "불량 픽셀 보정",
+      "BadPixelCorrectionThreshold": "불량 픽셀 임계값",
+      "HighFullwellMode": "고풀웰 모드",
+      "BinAverageEnabled": "비닝 픽셀 평균화",
+      "LEDLights": "LED",
+      "FanSpeed": "팬 속도",
+      "tab_camera": "카메라",
+      "tab_cooler": "쿨러",
+      "tab_filter": "필터",
+      "tab_snapshot": "저장 및 솔브"
+    },
+    "tppa": {
+      "title": "삼점 극축 정렬",
+      "camera_mount_required": "카메라가 연결되어 있어야 합니다",
+      "start_alignment": "정렬 시작",
+      "stop_alignment": "정렬 중지",
+      "altitude_error": "고도 오차:",
+      "azimuth_error": "방위 오차:",
+      "total_error": "전체 오차:",
+      "error_values_missing": "오차 값 누락",
+      "unknown_response_format": "알 수 없는 응답 형식",
+      "east": "동",
+      "west": "서",
+      "down": "아래",
+      "up": "위",
+      "not_available": "사용 불가",
+      "running": "실행 중",
+      "plate_solve_start": "플레이트 솔빙 시작",
+      "plate_solve_ok": "플레이트 솔빙 성공",
+      "plate_solve_error": "플레이트 솔빙 오류",
+      "slewing_first_position": "첫 번째 위치로 이동 중",
+      "slewing_next_position": "다음 위치로 이동 중",
+      "capture_running": "노출 진행 중",
+      "last_messages": "최근 메시지",
+      "settings": {
+        "title": "TPPA 설정",
+        "StartFromCurrentPosition": "현재 위치에서 시작할까요?",
+        "DirectionEast": "동쪽 방향",
+        "camera_settings": "카메라 설정",
+        "camera_settings_hint": "NINA 기본값을 사용하려면 비워 두세요",
+        "exposure_time": "노출 시간 (초)",
+        "gain": "게인",
+        "nina_default": "NINA 기본값",
+        "ManualMode": "수동 모드"
+      },
+      "pins_settings": {
+        "title": "PINS TPPA 설정",
+        "movement": "이동",
+        "offsets": "오프셋",
+        "behavior": "동작",
+        "default_move_rate": "최대 이동 속도 (°/s)",
+        "default_east_direction": "기본 동쪽 방향",
+        "move_timeout_factor": "이동 타임아웃 계수",
+        "default_target_distance": "기본 목표 거리 (°)",
+        "default_search_radius": "기본 검색 반경 (°)",
+        "default_azimuth_offset": "방위 오프셋 (°)",
+        "default_altitude_offset": "고도 오프셋 (°)",
+        "alignment_tolerance": "정렬 허용 오차",
+        "refraction_adjustment": "대기굴절 보정",
+        "stop_tracking_when_done": "완료 시 추적 중지",
+        "settle_time": "안정화 시간 (초)",
+        "auto_pause": "자동 일시정지",
+        "log_error": "오차 로그 기록",
+        "reset": "기본값으로 재설정",
+        "help_default_move_rate": "마운트의 최대 슬루 속도(초당 도)입니다. TPPA는 이 값을 사용해 측정 지점 간 이동 속도를 계산합니다. 마운트의 실제 최대 속도와 일치하는 것이 중요합니다. 일부 마운트 제조사는 이동 속도를 다르게 구현합니다 - 마운트가 예상한 거리만큼 이동하지 않으면 이동 타임아웃 계수를 조정하세요.",
+        "help_default_east_direction": "두 번째와 세 번째 측정 지점의 방향을 RA 축을 따라 동쪽 또는 서쪽으로 이동해 정할지 설정합니다. 일부 마운트 드라이버는 망원경 탭 설정에서 이 방향을 반대로 해야 할 수도 있습니다.",
+        "help_move_timeout_factor": "(목표 거리 / 이동 속도 × 타임아웃 계수) 초가 지나면 안전장치로 마운트가 이동을 멈춥니다. 목표 거리에 도달하지 못했다는 경고가 표시될 때만 값을 늘리세요.",
+        "help_default_target_distance": "극축 정렬 과정에서 측정 지점 사이의 거리(도)입니다.",
+        "help_default_search_radius": "TPPA 중 플레이트 솔버의 검색 반경(도)입니다. 초기 극축 정렬 오차보다 커야 하지만, 빠른 솔빙을 위해 너무 크지 않아야 합니다.",
+        "help_default_azimuth_offset": "첫 번째 측정 지점을 시작할 극점 위치로부터의 방위 오프셋(도)입니다.",
+        "help_default_altitude_offset": "첫 번째 측정 지점을 시작할 극점 위치로부터의 고도 오프셋(도)입니다.",
+        "help_alignment_tolerance": "0이 아닌 값으로 설정하면, 오차가 이 허용 오차(분각) 미만이 될 때 극축 정렬 루틴이 자동으로 완료됩니다.",
+        "help_refraction_adjustment": "활성화하면 위치, 고도, 현재 기상 조건을 바탕으로 대기굴절을 반영합니다. 기상 소스가 연결되어 있지 않으면 표준 대기 매개변수를 사용합니다.",
+        "help_stop_tracking_when_done": "활성화하면 극축 정렬이 끝난 후 마운트가 추적을 중지합니다. 마운트가 계속 추적하길 원하면 비활성화하세요.",
+        "help_settle_time": "자동 조정을 사용할 때, 각 이동 후 대기할 시간(초)을 지정합니다.",
+        "help_auto_pause": "극축 정렬 과정의 자동 일시정지 설정입니다.",
+        "help_log_error": "활성화하면 극축 정렬 오차 조정 내역과 각 조정 후의 연속 오차가 기록된 로그 파일이 생성됩니다."
+      },
+      "error_modal": {},
+      "tppa": "TPPA"
+    },
+    "slewAndCenter": {
+      "title": "슬루 및 센터링",
+      "LastSelectedImageSource_wrong": "NINA / 프레이밍에서 이미지 소스로 오프라인 천체 지도를 선택하세요",
+      "ra": "RA:",
+      "dec": "Dec:",
+      "ra_placeholder": "RA 03:47:28.2",
+      "dec_placeholder": "Dec +24:06:19",
+      "slew": "슬루",
+      "slew_and_center": "슬루 및 센터링",
+      "errors": {
+        "invalidRAInput": "잘못된 RA 입력입니다.",
+        "invalidDECInput": "잘못된 DEC 입력입니다.",
+        "apiResponseError": "API 응답 오류:",
+        "mountInfoError": "마운트 정보를 가져오는 중 오류:",
+        "invalidAltInput": "잘못된 alt 입력입니다.",
+        "invalidAzInput": "잘못된 az 입력입니다."
+      },
+      "visibleStars": "보이는 별 검색",
+      "alt": "Alt:",
+      "az": "Az:",
+      "slew_modal": {
+        "deviation_target": "목표와의 편차:"
+      }
+    },
+    "filterwheel": {
+      "title": "필터휠",
+      "filter": "필터:",
+      "unknown": "알 수 없음",
+      "nofilteravailable": "사용 가능한 필터 없음",
+      "please_connect_filterwheel": "필터휠을 연결하세요",
+      "currentFilter": "현재 필터",
+      "position": "위치",
+      "availableFilters": "사용 가능한 필터",
+      "settings": {
+        "title": "필터 설정",
+        "FilterWheelFilters": {
+          "FocusOffset": "포커스 오프셋",
+          "Position": "위치",
+          "AutoFocusExposureTime": "오토포커스 노출 시간",
+          "Name": "이름"
+        },
+        "deviceSpecific": "장치 설정",
+        "FilterWheelAlias": "필터휠 별칭",
+        "Speed": "속도",
+        "TurboMode": "터보 모드",
+        "Autorun": "자동 실행",
+        "Calibrate": "보정",
+        "commandFailed": "이 장치에서 지원하지 않는 명령",
+        "SlotNum": "슬롯 수",
+        "slotNumDefault": "기본값"
+      },
+      "indi": {
+        "settings": "필터휠 설정"
+      },
+      "Unidirectional": "필터휠 단방향",
+      "BoardTemperature": "보드 온도",
+      "State": "상태",
+      "Counter": "카운터"
+    },
+    "RemoveFilter": {
+      "confirmTitle": "필터 제거",
+      "confirmMessage": "이 필터를 제거하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+    },
+    "rotator": {
+      "title": "로테이터",
+      "label": "로테이터",
+      "move": "이동",
+      "control": "제어",
+      "please_connect_rotator": "로테이터를 연결하세요",
+      "connected": "연결됨",
+      "disconnected": "연결 끊김",
+      "currentPosition": "현재 위치",
+      "moving": "이동 중",
+      "stationary": "정지",
+      "stepSize": "스텝 크기",
+      "settings": {
+        "title": "설정",
+        "basic": "기본 설정",
+        "QUARTER": "90°",
+        "HALF": "180°",
+        "FULL": "360°",
+        "RangeType": "기계적 범위",
+        "RangeStartMechanicalPosition": "기계적 범위 시작",
+        "Overshoot": "오버슛",
+        "OvershootDirection": "오버슛 방향",
+        "OvershootAngle": "오버슛 각도",
+        "Backlash": "백래시",
+        "ResetPosition": "영점 위치 초기화"
+      },
+      "indi": {
+        "settings": "로테이터 설정"
+      }
+    },
+    "flat": {
+      "please_connect_flatDevice": "플랫 장치를 연결하세요",
+      "device_name": "이름:",
+      "cover_state": "커버 상태:",
+      "light_state": "조명 상태:",
+      "brightness": "밝기:",
+      "toggle_light": "조명:",
+      "cover": {
+        "close": "커버 닫기",
+        "open": "커버 열기"
+      },
+      "title": "플랫 패널",
+      "settings": {
+        "title": "설정",
+        "heater": "히터 출력 (0-3)",
+        "openPosition": "열림 위치 (°)",
+        "closedPosition": "닫힘 위치 (°)",
+        "currentPosition": "현재 위치",
+        "trainedSettings": {
+          "title": "학습된 플랫 노출 설정",
+          "filter": "필터",
+          "noFilter": "필터 없음",
+          "binning": "비닝",
+          "gain": "게인",
+          "offset": "오프셋",
+          "brightness": "밝기",
+          "time": "시간 (s)",
+          "confirmTitle": "설정 제거",
+          "confirmMessage": "이 학습된 플랫 노출 설정을 제거하시겠습니까?"
+        }
+      },
+      "indi": {
+        "settings": "플랫 장치 설정"
+      }
+    },
+    "flatassistant": {
+      "title": "플랫 어시스턴트",
+      "count": "촬영할 플랫 수",
+      "darks_to_take": "촬영할 다크플랫 수",
+      "exposure_time": "노출 시간",
+      "min_exposure_time": "최소 노출 시간",
+      "max_exposure_time": "최대 노출 시간",
+      "brightness": "밝기",
+      "min_brightness": "최소 밝기",
+      "max_brightness": "최대 밝기",
+      "histogram_mean_target": "히스토그램 평균 목표",
+      "mean_tolerance": "평균 허용 오차",
+      "completed_recordings": "완료된 촬영:",
+      "status_running_flats": "진행 중: {completed} / {total} 플랫",
+      "status_running_darks": "진행 중: {completed} / {total} 다크",
+      "status_running_unknown": "결정 중…",
+      "filter_label": "필터",
+      "status_success_flats": "완료 - 플랫 {count}장 촬영됨",
+      "status_success_darks": "완료 - 다크 {count}장 촬영됨",
+      "status_completed_flats": "완료됨",
+      "status_stopped_flats": "조기 중지됨 - 플랫 {total}장 중 {completed}장 촬영됨",
+      "status_stopped_darks": "조기 중지됨 - 다크 {total}장 중 {completed}장 촬영됨",
+      "status_failed_flats": "유효한 노출을 결정할 수 없음",
+      "status_failed_flats_multi": "모든 필터에서 유효한 노출을 결정하지 못함",
+      "status_partial_flats_multi": "실패한 필터: {filters}",
+      "result_dim": "너무 어두움",
+      "result_bright": "너무 밝음",
+      "status_failed_darks": "다크 촬영 없음 - 유효한 노출을 결정할 수 없음",
+      "status_adu_live": "마지막 측정 ADU: {adu}",
+      "target": "목표",
+      "cover_scope_title": "지금 망원경을 덮으세요",
+      "cover_scope_message": "지금 망원경을 덮고 OK를 눌러 다크 촬영을 시작하세요.",
+      "cover_scope_confirm": "OK",
+      "operation_failed": "작업 실패",
+      "start_auto_exposure": "자동 노출 시작",
+      "start_auto_brightness": "자동 밝기 시작",
+      "start_sky_flat": "스카이 플랫 시작",
+      "stop": "중지",
+      "auto_exposure": "자동 노출",
+      "auto_brightness": "자동 밝기",
+      "skyflat": "스카이 플랫",
+      "button_slew_to_zenith": "천정으로 슬루",
+      "keep_closed": "플랫 패널 닫힌 상태 유지",
+      "mode": "모드",
+      "single_mode": "싱글 모드",
+      "multi_mode": "멀티 모드",
+      "start_multi_mode": "멀티 모드 시작",
+      "multi_mode_no_filters": "필터휠이 연결되지 않음",
+      "status_filter_progress": "필터: {completed} / {total}",
+      "status_failed": "실패",
+      "status_running": "실행 중",
+      "status_stopped": "정지됨",
+      "status_success": "성공"
+    },
+    "weatherModal": {
+      "weatherInformation": "날씨 정보",
+      "metric": "미터법",
+      "imperial": "야드파운드법",
+      "temperature": "온도",
+      "cloudCover": "구름량",
+      "wind": "바람",
+      "humidity": "습도",
+      "pressure": "기압",
+      "skyTemperature": "하늘 온도",
+      "skyQuality": "하늘 상태",
+      "rainRate": "강우량",
+      "dewPoint": "이슬점",
+      "indi": {
+        "settings": "날씨 설정"
+      },
+      "settings": {
+        "apiKey": "API 키",
+        "apiKeyPlaceholder": "API 키 입력",
+        "stationId": "측정소 ID",
+        "stationIdPlaceholder": "측정소 ID 입력"
+      }
+    },
+    "switch": {
+      "gauges": "게이지",
+      "switch": "스위치",
+      "indi": {
+        "settings": "스위치 설정"
+      },
+      "sv241pro": {
+        "preConnectDelay": "연결 전 대기 시간 (ms)"
+      }
+    },
+    "stellarium": {
+      "selected_object": {
+        "title": "선택한 천체",
+        "ra": "RA",
+        "dec": "DEC",
+        "button_framing": "프레이밍으로 이동"
+      },
+      "datetime": {
+        "title": "날짜 및 시간",
+        "date": "날짜",
+        "time": "시간",
+        "now": "지금",
+        "speed": "속도"
+      },
+      "mount_position": {},
+      "settings": {
+        "constellations_lines_visible": "별자리 표시",
+        "azimuthal_lines_visible": "방위 좌표선 표시",
+        "equatorial_lines_visible": "적도 좌표선 표시",
+        "meridian_lines_visible": "자오선 표시",
+        "ecliptic_lines_visible": "황도 표시",
+        "atmosphere_visible": "대기 표시",
+        "landscapes_visible": "지형 표시",
+        "dsos_visible": "심원천체 (메시에, NGC)",
+        "title": "설정"
+      }
+    },
+    "profile": {
+      "label": "프로필:",
+      "manage": "프로필 관리",
+      "add": "프로필 추가",
+      "switchTo": "이 프로필로 전환",
+      "rename": "이름 변경",
+      "clone": "복제",
+      "cloneOf": "복사",
+      "remove": "삭제",
+      "namePlaceholder": "프로필 이름",
+      "nameExists": "이미 존재하는 이름입니다",
+      "cannotSwitchConnected": "장치가 연결된 상태에서는 프로필을 전환할 수 없습니다",
+      "cannotRemoveActive": "활성 프로필은 삭제할 수 없습니다",
+      "cannotRemoveLast": "마지막 프로필은 삭제할 수 없습니다",
+      "noProfiles": "사용 가능한 프로필이 없습니다"
+    },
+    "notifications": {
+      "modal": {
+        "title": "알림 설정",
+        "description": "시퀀스 이벤트 알림을 받으려면 권한을 허용해 주세요."
+      }
+    },
+    "fav_target": {
+      "table": {
+        "name": "이름",
+        "ra": "RA",
+        "dec": "DEC",
+        "load": "불러오기",
+        "remove": "삭제",
+        "rotation": "회전"
+      },
+      "modal_sequence": {
+        "titel": "시퀀스"
+      },
+      "modal_sequence_ok": {
+        "message": "대상 설정됨"
+      },
+      "modal_sequence_error": {
+        "message": "불러온 시퀀스가 없습니다"
+      },
+      "enter_name": "이름 입력",
+      "save_to_favorites": "즐겨찾는 대상에 저장",
+      "no_fav": "저장된 즐겨찾기가 없습니다",
+      "titel": "즐겨찾기"
+    },
+    "helpers": {
+      "imageModal": {
+        "no_image": "이미지 데이터가 없습니다"
+      },
+      "histogram": {
+        "blackPoint": "블랙 포인트",
+        "whitePoint": "화이트 포인트",
+        "gamma": "감마",
+        "mean": "평균",
+        "median": "중앙값",
+        "stdDev": "표준편차",
+        "min": "최소",
+        "max": "최대",
+        "stars": "별",
+        "hfr": "HFR",
+        "reset": "초기화",
+        "noSaveHint": "통계는 저장된 이미지에만 계산됩니다",
+        "enableSave": "저장 활성화"
+      },
+      "zoomableImage": {
+        "toggleCrosshair": "십자선 표시 전환",
+        "toggleLoupe": "루페 전환",
+        "loupeZoom": "루페 확대"
+      }
+    },
+    "platesolve": {
+      "solve_successful": "솔브 성공",
+      "solve_failed": "솔브 실패",
+      "solving": "솔빙 중...",
+      "solve_time": "솔브 시간",
+      "orientation": "방향",
+      "flipped": "반전됨",
+      "ra": "RA",
+      "dec": "Dec",
+      "pixel_scale": "픽셀 스케일",
+      "focal_length": "초점거리"
+    }
+  },
+  "plugins": {
+    "common": {
+      "initializing": "초기화 중...",
+      "outdated": {
+        "title": "플러그인 구버전",
+        "message": "NINA의 TouchNStars 플러그인이 구버전이라 업데이트가 필요합니다.",
+        "required": "필요 버전",
+        "current": "현재 버전"
+      }
+    },
+    "pins": {
+      "title": "PINS 관리",
+      "notAvailable": "PINS 환경이 감지되지 않았습니다. 이 플러그인은 비활성화됩니다.",
+      "dryRun": "드라이 런 모드",
+      "sambaTitle": "Samba 공유",
+      "sambaDescription": "네트워크 파일 공유 활성화 또는 비활성화",
+      "phd2Title": "PHD2 자동 시작",
+      "phd2Running": "서비스가 실행 중입니다",
+      "phd2Stopped": "서비스가 정지되어 있습니다",
+      "tabs": {
+        "network": "네트워크",
+        "services": "서비스",
+        "software": "소프트웨어",
+        "upgrade": "업그레이드"
+      },
+      "wifiTitle": "WiFi 설정",
+      "wifiAdaptersTitle": "WiFi 어댑터 할당",
+      "wifiAdaptersDescription": "홈 WiFi를 담당할 어댑터와 핫스팟 모드를 호스팅할 어댑터를 선택하세요.",
+      "wifiClientInterface": "홈 WiFi 어댑터",
+      "wifiHotspotInterface": "핫스팟 어댑터",
+      "wifiAdapterRefresh": "어댑터 목록 새로고침",
+      "wifiAdapterSave": "어댑터 선택 저장",
+      "wifiAdapterSaving": "어댑터 선택 저장 중...",
+      "wifiNoAdapters": "WiFi 어댑터를 찾을 수 없습니다.",
+      "wifiAutoInterface": "자동 (데몬 기본값)",
+      "stationaryMode": "고정 모드",
+      "stationaryDescription": "로컬 WiFi 네트워크를 검색하고 연결하려면 활성화하세요",
+      "noNetworks": "네트워크를 찾을 수 없습니다",
+      "wifiSelect": "네트워크 선택",
+      "wifiBand": "WiFi 대역",
+      "bandAuto": "자동",
+      "band24": "2.4 GHz",
+      "band5": "5 GHz",
+      "rescan": "WiFi 네트워크 재검색",
+      "wifiPassword": "비밀번호",
+      "autoConnect": "부팅 후 선택한 WiFi에 자동 연결",
+      "wifiConnect": "연결",
+      "scanning": "검색 중...",
+      "hotspotPasswordTitle": "핫스팟 비밀번호",
+      "hotspotConfigured": "사용자 지정 핫스팟 비밀번호가 설정되어 있습니다.",
+      "hotspotNotConfigured": "현재 기본 핫스팟 비밀번호를 사용 중입니다.",
+      "hotspotRefresh": "핫스팟 비밀번호 상태 새로고침",
+      "hotspotMetaLine": "출처: {source} | 인터페이스: {iface} | 대역: {band} | 채널: {channel}",
+      "hotspotBandLabel": "핫스팟 대역",
+      "hotspotBandAuto": "자동 / 미설정",
+      "hotspotChannelLabel": "핫스팟 채널",
+      "hotspotChannelPlaceholder": "자동으로 설정하려면 비워 두세요",
+      "hotspotAppliedStatus": "활성 핫스팟에 적용됨: {applied} | 대역: {band} | 채널: {channel}",
+      "hotspotCapabilitiesUnavailable": "어댑터 지원 목록을 사용할 수 없습니다. 수동 채널 설정이 허용됩니다.",
+      "hotspotNewPassword": "새 핫스팟 비밀번호",
+      "hotspotPasswordHint": "세션마다 또는 비밀번호 변경 시 한 번 필요합니다. 8~63자를 사용하세요.",
+      "hotspotSave": "핫스팟 비밀번호 저장",
+      "hotspotSaving": "핫스팟 비밀번호 저장 중...",
+      "systemTime": "시스템 시간",
+      "deviceTime": "기기 시간",
+      "loadingTime": "시간 불러오는 중...",
+      "autoSync": "자동 동기화",
+      "syncNow": "지금 동기화",
+      "timeWarning": {
+        "title": "시간 불일치 감지됨",
+        "message": "기기 시간({deviceTime})이 클라이언트 시간({clientTime})과 1분 이상 차이가 납니다. 이로 인해 문제가 발생할 수 있습니다.",
+        "setTime": "기기 시간을 클라이언트 시간으로 설정",
+        "suppress": "이 경고를 다시 표시하지 않기",
+        "dismiss": "닫기",
+        "reenable": "시간 불일치 경고 다시 활성화"
+      },
+      "startUpgrade": "업그레이드 시작",
+      "upgrading": "업그레이드 중...",
+      "upgradeOverlay": {
+        "title": "시스템 업데이트 진행 중",
+        "running": "Raspberry Pi 패키지를 업데이트하고 있습니다. 작업이 완료될 때까지 기다려 주세요.",
+        "waitingForApi": "업데이트 완료. NINA API에 다시 연결될 때까지 기다리는 중...",
+        "keepOpen": "이 앱을 열어 두세요. 상태 불일치를 방지하기 위해 컨트롤이 일시적으로 차단됩니다.",
+        "jobId": "작업 ID: {jobId}",
+        "close": "닫기"
+      },
+      "terminalOutput": "터미널 출력",
+      "clearOutput": "출력 지우기",
+      "waiting": "제어 인계 중... 명령 대기 중...",
+      "status": {
+        "idle": "대기 중",
+        "running": "실행 중",
+        "success": "성공",
+        "failed": "실패"
+      },
+      "logs": {
+        "syncingTime": "시간 차이 감지됨: {diff}s. 시간 동기화 중...",
+        "forcingSync": "수동으로 시간 동기화 중...",
+        "timeInSync": "시간이 동기화되어 있습니다 (차이: {diff}s).",
+        "timeSynced": "시스템 시간이 성공적으로 동기화되었습니다.",
+        "noIp": "오류: 설정에서 IP 주소를 찾을 수 없습니다. 먼저 인스턴스에 연결하세요.",
+        "init": "호스트에서 업그레이드 시퀀스 초기화 중: {ip}",
+        "config": "구성: 모의 실행 = {dryRun}",
+        "sambaAction": "동작: Samba 공유 {action}",
+        "sambaEnable": "활성화",
+        "sambaDisable": "비활성화",
+        "phd2Action": "PHD2 서비스 {action}...",
+        "phd2Enabling": "활성화",
+        "phd2Disabling": "비활성화",
+        "phd2Success": "PHD2 서비스 업데이트 성공.",
+        "phd2Failed": "PHD2 서비스 업데이트 실패: {message}",
+        "connectingToWifi": "WiFi 네트워크에 연결 중: {ssid}",
+        "wifiResponse": "WiFi 응답: {response}",
+        "wifiAdaptersLoadFailed": "WiFi 어댑터 불러오기 실패: {message}",
+        "wifiInterfacesLoadFailed": "선택된 WiFi 인터페이스 불러오기 실패: {message}",
+        "wifiInterfacesSaved": "WiFi 인터페이스 저장됨. 클라이언트: {clientInterface}, 핫스팟: {hotspotInterface}",
+        "wifiInterfacesSaveFailed": "WiFi 인터페이스 저장 실패: {message}",
+        "hotspotFetched": "핫스팟 설정 불러옴 (configured={configured}, source={source}, band={band}, channel={channel}).",
+        "hotspotFetchFailed": "핫스팟 설정 불러오기 실패: {message}",
+        "hotspotSaving": "핫스팟 비밀번호 업데이트 중...",
+        "hotspotSaved": "핫스팟 설정이 성공적으로 업데이트되었습니다: {message} (활성 핫스팟에 적용됨: {applied}).",
+        "hotspotSaveFailed": "핫스팟 설정 저장 실패: {message}",
+        "hotspotPasswordInvalidLength": "핫스팟 비밀번호는 필수이며 8~63자여야 합니다.",
+        "hotspotChannelInvalid": "핫스팟 채널을 입력할 경우 양의 정수여야 합니다.",
+        "jobCreated": "작업이 성공적으로 생성되었습니다. ID: {jobId}",
+        "daemonCheck": "{ip}:{port}에서 PINS 데몬이 실행 중인지 확인하세요",
+        "serverError": "서버 오류 ({status}): {data}",
+        "corsHint": "힌트: 서버가 요청 방식을 거부했습니다. 서버의 CORS 설정을 확인하세요.",
+        "networkError": "네트워크 오류: 요청이 실패했습니다.",
+        "noResponse": "네트워크 오류: 서버로부터 응답이 없습니다.",
+        "error": "오류: {message}",
+        "wsConnecting": "{wsUrl}로 WebSocket 연결 협상 중...",
+        "wsConnected": "연결되었습니다. 로그를 스트리밍하는 중...",
+        "wsCreationFailed": "WebSocket 생성 실패: {message}",
+        "wsClosed": "연결이 종료되었습니다. (코드: {code})",
+        "wsError": "WebSocket 오류가 발생했습니다.",
+        "verifyingStatus": "최종 작업 상태 확인 중...",
+        "jobReport": "작업 보고서: {report}",
+        "upgradeSuccess": "업그레이드가 성공적으로 완료되었습니다.",
+        "upgradeFailed": "업그레이드 실패. 종료 코드: {exitCode}",
+        "jobStatus": "작업 상태: {status}",
+        "statusFetchFailed": "최종 상태 가져오기 실패: {message}",
+        "wifiDisabling": "WiFi 연결 해제 및 핫스팟 활성화 중...",
+        "wifiDisabled": "WiFi 연결이 해제되고 핫스팟이 활성화되었습니다.",
+        "updateCheckFailed": "업데이트 확인 실패: {message}",
+        "indi3rdpartyLoadFailed": "INDI 서드파티 패키지 불러오기 실패: {message}",
+        "indi3rdpartyInstallStart": "INDI 패키지 설치 중: {assetName}",
+        "indi3rdpartyInstallSuccess": "INDI 패키지 설치 완료: {message}",
+        "indi3rdpartyInstallFailed": "INDI 패키지 설치 실패: {message}",
+        "pluginsLoadFailed": "PINS 플러그인 불러오기 실패: {message}",
+        "pluginsLoadMetadataFailed": "플러그인 메타데이터 저장소를 현재 사용할 수 없어 PINS 플러그인을 불러올 수 없습니다 (HTTP 502).",
+        "pluginsPackageNotAllowed": "API 정책에서 허용하지 않는 패키지입니다: {packageName}",
+        "pluginInstallStart": "플러그인 설치 중: {packageName}",
+        "pluginUninstallStart": "플러그인 제거 중: {packageName}",
+        "pluginActionSuccess": "플러그인 작업 완료: {packageName}",
+        "pluginActionFailed": "{packageName} 플러그인 작업 실패. 상태: {status}"
+      },
+      "wifiDisconnect": "WiFi 연결 해제",
+      "disconnectConfirmTitle": "WiFi 연결을 해제할까요?",
+      "disconnectConfirmMessage": "현재 WiFi 연결을 끊고 핫스팟을 다시 활성화합니다. 계속할까요?",
+      "updatesAvailable": "사용 가능한 업데이트 ({count})",
+      "updatesModalTitle": "사용 가능한 업데이트",
+      "updatesCheckedAt": "확인 시각",
+      "checkUpdates": "다시 확인",
+      "checkingUpdates": "확인 중...",
+      "noUpdatesAvailable": "사용 가능한 업데이트 없음",
+      "updatesPackage": "패키지",
+      "updatesInstalled": "설치됨",
+      "updatesLatest": "최신",
+      "indi3rdpartyTitle": "INDI 서드파티 드라이버",
+      "indi3rdpartyDescription": "현재 설치되지 않은 INDI 드라이버를 추가로 설치합니다.",
+      "indi3rdpartySearch": "검색",
+      "indi3rdpartySearchPlaceholder": "드라이버 검색 (예: asi)",
+      "indi3rdpartyRefresh": "목록 새로고침",
+      "indi3rdpartySelect": "드라이버 패키지 선택",
+      "indi3rdpartyInstall": "드라이버 설치",
+      "indi3rdpartyInstalling": "설치 중...",
+      "indi3rdpartyNoDrivers": "설치되지 않은 드라이버가 없습니다.",
+      "indiInstallModalTitle": "INDI 드라이버 설치",
+      "indiInstallModalDriverPackage": "드라이버/패키지",
+      "indiInstallModalAssetName": "에셋 이름",
+      "indiInstallModalType": "유형",
+      "indiInstallModalLabel": "라벨",
+      "indiInstallModalInstall": "설치",
+      "indiInstallModalInstalling": "설치 중...",
+      "indiInstallModalSuccessStarted": "{label} 설치를 시작했습니다.",
+      "indiInstallModalSuccessCompleted": "{label} 설치를 완료했습니다.",
+      "pluginsTitle": "PINS 플러그인",
+      "pluginsDescription": "선택형 PINS 플러그인을 관리합니다 (설치 또는 제거).",
+      "pluginsRefresh": "플러그인 목록 새로고침",
+      "pluginsCheckedAt": "확인 시각",
+      "pluginsEmpty": "사용 가능한 플러그인이 없습니다.",
+      "pluginsPackage": "패키지",
+      "pluginsInstalled": "설치됨",
+      "pluginsVersion": "버전",
+      "pluginsAction": "작업",
+      "pluginsInstalledYes": "예",
+      "pluginsInstalledNo": "아니오",
+      "pluginsInstall": "설치",
+      "pluginsInstalling": "설치 중...",
+      "pluginsUninstall": "제거",
+      "pluginsUninstalling": "제거 중...",
+      "dhcpClientsTitle": "연결된 클라이언트",
+      "dhcpClientsDescription": "핫스팟에서 DHCP 임대가 활성화된 기기입니다.",
+      "dhcpClientsRefresh": "클라이언트 목록 새로고침",
+      "dhcpClientsLoading": "클라이언트 불러오는 중...",
+      "dhcpClientsEmpty": "활성 DHCP 클라이언트가 없습니다.",
+      "dhcpClientsIp": "IP 주소",
+      "dhcpClientsMac": "MAC 주소",
+      "dhcpClientsHostname": "호스트명",
+      "dhcpClientsExpires": "임대 만료"
+    },
+    "bahtifocus": {
+      "title": "바티노프 마스크 분석기",
+      "subtitle": "이미지를 촬영하거나 불러와 바티노프 마스크로 초점 품질을 측정합니다.",
+      "sections": {
+        "imageSource": "이미지 소스",
+        "imageSourceHint": "새 프레임을 촬영하거나, 파일을 업로드하거나, 예시 이미지를 선택해 시작하세요.",
+        "parameters": "광학 파라미터",
+        "parametersHint": "정확한 측정값을 위해 이번 노출에 사용한 광학 및 카메라 정보를 입력하세요."
+      },
+      "image": {
+        "selectFile": "이미지 선택",
+        "loadingCapture": "촬영 불러오는 중…",
+        "useLatestCapture": "최근 촬영 사용",
+        "examplePlaceholder": "예시 이미지 불러오기…",
+        "clearSelection": "선택 해제",
+        "source": "소스",
+        "size": "파일 크기",
+        "originalSize": "원본 {size}",
+        "mime": "포맷",
+        "transport": "업로드 방식",
+        "transportBinary": "바이너리 스트림",
+        "transportLegacy": "레거시 JSON 폴백",
+        "previewUnavailable": "미리보기를 사용할 수 없습니다. 분석은 이 포맷을 지원합니다.",
+        "capturedName": "최근 촬영",
+        "sourceCaptured": "현재 촬영",
+        "sourceExample": "예시 이미지",
+        "sourceUpload": "업로드한 이미지",
+        "resizedTitle": "이미지 최적화됨",
+        "resizedMessage": "{width}×{height} (약 {size})로 크기 조정됨. 원본 크기는 {originalSize}였습니다."
+      },
+      "inputs": {
+        "focalLength": "초점 거리 (mm)",
+        "pixelSize": "픽셀 크기 (µm)",
+        "focalRatio": "초점비 (f/)",
+        "apertureDiameter": "조리개 지름 (mm)",
+        "resizeFactor": "크기 조정 배율"
+      },
+      "crop": {
+        "enable": "처리 영역 자르기",
+        "x": "자르기 X",
+        "y": "자르기 Y",
+        "width": "자르기 너비",
+        "height": "자르기 높이"
+      },
+      "previousAngles": {
+        "label": "이전 각도",
+        "savedLabel": "마지막으로 저장한 각도",
+        "reset": "마지막 각도 복원",
+        "input": "각도 {index} (°)"
+      },
+      "analysis": {
+        "lastDuration": "마지막 실행: {seconds}s"
+      },
+      "actions": {
+        "resetForm": "양식 초기화",
+        "submitting": "분석 중…",
+        "runAnalysis": "분석 실행",
+        "toggleParametersShow": "광학 파라미터 표시",
+        "toggleParametersHide": "광학 파라미터 숨기기"
+      },
+      "camera": {
+        "capture": "프레임 촬영",
+        "capturing": "촬영 중…",
+        "captureFailed": "새 프레임을 촬영할 수 없습니다.",
+        "abort": "촬영 중단",
+        "abortFailed": "진행 중인 촬영을 중단할 수 없습니다.",
+        "exposureLabel": "노출 시간",
+        "exposureUnit": "초",
+        "statusDisconnected": "프레임을 촬영하려면 카메라를 연결하세요.",
+        "statusExposing": "노출 진행 중…",
+        "statusExposingCountdown": "노출 진행 중 – {seconds}s 남음.",
+        "statusLoading": "이미지 데이터 수신 중…",
+        "statusLooping": "노출 반복 중. 중지할 때까지 촬영이 반복됩니다."
+      },
+      "overlay": {
+        "title": "오버레이 미리보기",
+        "processedSize": "처리된 크기: {width} x {height} px",
+        "noImage": "오버레이를 보려면 이미지를 선택하거나 촬영하세요."
+      },
+      "results": {
+        "title": "분석 결과",
+        "focusErrorPixels": "초점 오차 (px)",
+        "absoluteFocusError": "초점 오차 (mm)",
+        "criticalFocusThreshold": "임계 초점 임계값 (mm)",
+        "isWithinCriticalFocus": "임계 초점 상태",
+        "focusOk": "임계 초점 범위 내",
+        "focusNotOk": "임계 초점 범위 밖",
+        "maskAngle": "마스크 각도 (°)",
+        "effectiveResizeFactor": "유효 리사이즈 계수",
+        "lineAngles": "마스크 선 각도",
+        "updatedAngles": "각도 업데이트됨",
+        "cropApplied": "처리된 크롭",
+        "noCrop": "적용된 크롭 없음",
+        "failure": "분석 실패. 자세한 내용은 백엔드 응답을 확인하세요.",
+        "placeholder": "분석기를 실행하면 초점 지표가 여기에 표시됩니다.",
+        "successTitle": "분석 완료",
+        "successMessage": "바티노프 지표가 업데이트되었습니다."
+      },
+      "tips": {
+        "title": "팁",
+        "tip1": "대상 근처의 밝은 별을 사용해 선명한 회절 패턴을 만드세요.",
+        "tip2": "이미지를 촬영하기 전에 바티노프 마스크가 정렬되었는지 확인하세요.",
+        "tip3": "제안된 각도를 재사용하면 이후 측정이 안정화됩니다."
+      },
+      "errors": {
+        "title": "바티노프 분석",
+        "readFile": "선택한 파일을 읽을 수 없습니다.",
+        "captureLoad": "N.I.N.A.에서 최신 촬영본을 불러오지 못했습니다.",
+        "exampleLoad": "예제 이미지를 불러올 수 없습니다.",
+        "analysisFailed": "분석 요청에 실패했습니다.",
+        "badRequest": "서버가 요청을 거부했습니다. 매개변수를 확인하세요.",
+        "mockMode": "모의 API가 활성화된 동안에는 바티노프 분석을 사용할 수 없습니다.",
+        "missingServer": "백엔드 주소를 확인할 수 없습니다. 연결 설정을 확인하세요."
+      },
+      "validation": {
+        "title": "검증 오류",
+        "fixErrors": "분석을 실행하기 전에 표시된 오류를 수정하세요.",
+        "requiredPositive": "양수 값을 입력하세요.",
+        "invalidPositive": "값은 양수여야 합니다.",
+        "ratioOrAperture": "초점비 또는 조리개 직경 중 하나를 입력하세요.",
+        "invalidNonNegative": "0 이상의 값을 입력하세요.",
+        "allAnglesRequired": "세 각도를 모두 입력하거나 필드를 비우세요.",
+        "invalidNumber": "유효한 숫자를 입력하세요.",
+        "imageRequired": "분석을 실행하기 전에 이미지를 선택하세요."
+      }
+    },
+    "logfileCollector": {
+      "title": "로그파일 수집기",
+      "intro": "최신 TNS 로그(디버그 포함)를 수집해 설정된 엔드포인트로 업로드합니다.",
+      "descriptionLabel": "설명 (선택)",
+      "descriptionPlaceholder": "조사할 문제를 설명하세요...",
+      "lastToken": "생성된 토큰",
+      "submissionHistory": "제출 기록",
+      "confirmClearAll": "모든 제출 기록을 지우시겠습니까?",
+      "diagnostics": {
+        "title": "진단 지원 (PINS)",
+        "intro": "진단 섹션을 선택하고 아카이브 수집을 시작한 뒤, 준비되면 ZIP을 다운로드/업로드하세요.",
+        "sectionsTitle": "섹션",
+        "journalLines": "저널 줄 수",
+        "dmesgLines": "dmesg 줄 수",
+        "start": "수집 시작",
+        "running": "수집 중...",
+        "download": "ZIP 다운로드",
+        "downloadBusy": "다운로드 중...",
+        "refreshOptions": "옵션 새로고침",
+        "loadingOptions": "옵션 불러오는 중...",
+        "statusLabel": "상태",
+        "archiveId": "아카이브 ID",
+        "statusIdle": "대기",
+        "statusQueued": "대기열에 있음",
+        "statusRunning": "실행 중",
+        "statusSuccess": "성공",
+        "statusFailed": "실패",
+        "statusTimeout": "시간 초과",
+        "started": "진단 아카이브를 시작했습니다.",
+        "optionsLoaded": "진단 옵션을 불러왔습니다.",
+        "optionsLoadFailed": "진단 옵션을 불러오지 못했습니다. 기본값을 사용합니다.",
+        "startFailed": "진단 아카이브를 시작하지 못했습니다.",
+        "pollFailed": "진단 상태를 조회하지 못했습니다.",
+        "stillPreparing": "아카이브가 아직 준비 중입니다. 잠시 후 다시 다운로드해 주세요.",
+        "downloadFailed": "진단 아카이브를 다운로드하지 못했습니다.",
+        "uploaded": "진단 ZIP을 지원 엔드포인트로 업로드했습니다.",
+        "validationSections": "섹션을 하나 이상 선택하세요.",
+        "validationJournalLines": "저널 줄 수는 100에서 50000 사이여야 합니다.",
+        "validationDmesgLines": "dmesg 줄 수는 100에서 50000 사이여야 합니다.",
+        "autoDownloaded": "아카이브가 자동으로 다운로드되었고 업로드를 시도했습니다."
+      },
+      "actions": {
+        "collectUpload": "수집 및 업로드",
+        "uploading": "업로드 중…",
+        "copyToken": "복사",
+        "remove": "제거",
+        "clearAll": "모두 지우기"
+      },
+      "submissionFields": {
+        "date": "날짜",
+        "filename": "파일명",
+        "token": "토큰"
+      },
+      "result": {
+        "success": "업로드 성공",
+        "failed": "업로드 실패",
+        "failedWithStatus": "업로드 실패 ({status})",
+        "tokenCopied": "토큰을 클립보드에 복사했습니다",
+        "tokenCopyFailed": "토큰 복사 실패",
+        "submissionRemoved": "제출 항목 제거됨",
+        "allSubmissionsCleared": "모든 제출 항목이 지워졌습니다"
+      }
+    },
+    "telescopius": {
+      "title": "Telescopius",
+      "offlineInfo": "telescopius.com에서 개인 대상 목록을 불러와 오프라인에서 사용할 수 있도록 로컬에 저장합니다.",
+      "landing": {
+        "title": "Telescopius 플러그인",
+        "subtitle": "Telescopius.com의 대상 천체를 Touch'N'Stars로 바로 가져오세요",
+        "whatIsPlugin": {
+          "title": "이 플러그인은 무엇인가요?",
+          "description": "Telescopius.com에 저장한 대상 천체를 Touch'N'Stars로 바로 불러와 내비게이션과 프레이밍에 사용하세요.",
+          "features": {
+            "loadLists": "Telescopius.com에서 대상 목록 불러오기",
+            "navigate": "천체로 바로 이동",
+            "framingAssistant": "프레이밍 도우미 사용",
+            "offlineCache": "빠른 접근을 위한 오프라인 캐시"
+          }
+        },
+        "whatIsTelecopius": {
+          "title": "Telescopius란?",
+          "description": "Telescopius는 천체 관측을 발견하고 계획하기 위한 종합 천문 플랫폼입니다.",
+          "features": {
+            "database": "방대한 천체 데이터베이스",
+            "lists": "개인 맞춤 대상 목록",
+            "planning": "관측 계획",
+            "community": "커뮤니티 및 공유"
+          },
+          "visitWebsite": "Telescopius.com 방문"
+        },
+        "mainFeatures": {
+          "title": "주요 기능",
+          "description": "Telescopius와 Touch'N'Stars의 매끄러운 통합:",
+          "features": {
+            "autoImport": "자동 가져오기: 모든 대상 목록을 한 번에",
+            "smartCache": "스마트 캐시: 빠른 오프라인 접근",
+            "directNavigation": "바로 내비게이션: 한 번의 클릭으로 슬루",
+            "framingIntegration": "프레이밍 통합: 기존 도구 사용",
+            "locationBased": "위치 기반: 사용자 위치를 고려"
+          }
+        },
+        "apiSetup": {
+          "title": "API 키 설정",
+          "description": "다음 간단한 단계를 따라 플러그인을 설정하세요:",
+          "step1": {
+            "title": "Telescopius 계정 만들기",
+            "description": "아직 계정이 없다면 무료로 가입하세요:",
+            "button": "무료로 가입"
+          },
+          "step2": {
+            "title": "API 키 요청",
+            "description": "로그인 후 설정 → API에서 개인 키를 발급받으세요:",
+            "button": "API 키 요청"
+          },
+          "step3": {
+            "title": "API 키 설정",
+            "description": "API 키를 생성할 때 다음 설정을 사용하세요:",
+            "config": {
+              "name": "이름",
+              "nameValue": "원하는 이름 (예: Touch N Stars)",
+              "description": "설명",
+              "descriptionValue": "원하는 설명 (예: TNS용 API)",
+              "accessType": "접근 유형",
+              "accessTypeValue": "Select Server",
+              "ipLimit": "이 IP 주소로만 접근 제한",
+              "ipLimitValue": "비워 두기"
+            }
+          },
+          "step4": {
+            "title": "API 키 입력",
+            "description": "아래 \"API 키 설정\"을 클릭하고 키를 입력하세요:",
+            "button": "API 키 설정"
+          },
+          "security": {
+            "title": "보안",
+            "description": "API 키는 이 기기에만 로컬로 저장되며 다른 사람과 공유되지 않습니다. 언제든지 삭제할 수 있습니다."
+          }
+        }
+      },
+      "apiKey": {
+        "title": "Telescopius API 키",
+        "description": "Telescopius를 사용하려면 API 키가 필요합니다. Telescopius 웹사이트에서 발급받을 수 있습니다:",
+        "linkText": "→ Telescopius API 키 요청",
+        "securityNote": "API 키는 서버에 저장되며 Telescopius 요청에만 사용됩니다.",
+        "placeholder": "Telescopius API 키를 입력하세요...",
+        "configured": "API 키가 이미 설정되어 있습니다",
+        "save": "저장",
+        "delete": "삭제",
+        "cancel": "취소",
+        "configure": "API 키 설정",
+        "required": "API 키 필요",
+        "errors": {
+          "saveFailed": "API 키를 저장할 수 없습니다.",
+          "deleteFailed": "API 키를 삭제할 수 없습니다."
+        },
+        "loadFromTelescopius": "새로고침"
+      },
+      "targetLists": {
+        "noListsTitle": "저장된 대상 목록 없음",
+        "noListsDescription": "Telescopius 계정에서 아직 대상 목록을 찾을 수 없습니다.",
+        "noListsHint": "telescopius.com에서 대상 목록을 만든 뒤 여기서 다시 불러오세요.",
+        "editOnTelescopius": "Telescopius에서 목록 편집",
+        "dataFrom": "데이터 출처",
+        "connectionError": "Telescopius 연결에 실패했습니다. NINA PC에 인터넷 연결이 필요하며 Telescopius에 대상 목록이 하나 이상 있어야 합니다."
+      }
+    },
+    "webcam": {
+      "title": "웹캠 설정",
+      "snapshotUrl": "스냅샷 URL",
+      "snapshotUrlDescription": "스냅샷 URL은 웹캠/IP 카메라의 단일 이미지로 바로 연결되는 링크입니다. 이 URL은 HTML 페이지나 스트림이 아니라 JPEG/PNG 이미지를 직접 반환해야 합니다.",
+      "snapshotUrlExamples": "예시:",
+      "refreshInterval": "새로고침 간격",
+      "displayOptions": "표시 옵션",
+      "autoRefresh": "자동 새로고침",
+      "status": "상태",
+      "connected": "연결됨",
+      "disconnected": "연결 끊김",
+      "error": "오류",
+      "lastUpdate": "마지막 업데이트",
+      "startAuto": "자동 시작",
+      "stopAuto": "자동 중지",
+      "settings": "설정",
+      "reset": "초기화",
+      "close": "닫기",
+      "resetConfirm": "모든 웹캠 설정을 초기화하시겠습니까?",
+      "liveView": "라이브 보기",
+      "noImageAvailable": "사용 가능한 이미지 없음",
+      "configureUrl": "스냅샷 URL을 설정하고 이미지를 가져오세요",
+      "loadingImage": "이미지 불러오는 중...",
+      "errors": {}
+    },
+    "multiImageMonitor": {
+      "addCamera": "카메라",
+      "addCameraTitle": "카메라 추가",
+      "editCameraTitle": "카메라 편집",
+      "refreshNow": "지금 새로고침",
+      "settings": "설정",
+      "noCameras": "설정된 카메라 없음",
+      "noCamerasHint": "탭 바에서 '+ 카메라'를 클릭하세요.",
+      "cameraName": "카메라 이름",
+      "cameraNamePlaceholder": "예: 남쪽 하늘, Allsky...",
+      "snapshotUrl": "스냅샷 URL",
+      "autoRefresh": "자동 새로고침",
+      "autoRefreshHint": "이미지 자동 새로고침",
+      "refreshInterval": "새로고침 간격",
+      "seconds": "초",
+      "intervalMin": "최소: 1초",
+      "delete": "삭제",
+      "cancel": "취소",
+      "save": "저장",
+      "add": "추가",
+      "useProxy": "프록시 사용",
+      "useProxyHint": "NINA 백엔드를 통해 이미지를 전달합니다. 인증 정보가 필요하거나 CORS 제한이 있는 카메라에 필요합니다. 인터넷에 직접 연결된 카메라는 비활성화하세요.",
+      "deleteConfirm": "카메라 \"{name}\"을(를) 정말 삭제하시겠습니까?",
+      "loadingImage": "이미지 불러오는 중…",
+      "unknownCamera": "알 수 없는 카메라",
+      "noUrlConfigured": "설정에서 스냅샷 URL을 지정하세요.",
+      "help": {
+        "title": "스냅샷 URL 도움말",
+        "what": "스냅샷 URL은 IP 카메라의 단일 이미지로 바로 연결되는 링크입니다. URL은 HTML 페이지나 동영상 스트림이 아니라 JPEG 또는 PNG 이미지를 직접 반환해야 합니다.",
+        "examplesTitle": "예시",
+        "exampleLabels": ["일반 IP 카메라", "ONVIF 카메라", "Axis 카메라", "Hikvision 카메라"],
+        "credentialsTitle": "비밀번호로 보호된 카메라",
+        "credentials": "카메라에 사용자 이름과 비밀번호가 필요한 경우, 인증 정보를 URL에 직접 포함하세요:",
+        "credentialsNote": "백엔드 프록시가 인증을 자동으로 처리합니다 — URL의 인증 정보는 Basic 및 Digest 인증 모두에서 동작합니다 (예: Hikvision).",
+        "proxyTitle": "프록시 vs. 직접 연결",
+        "proxyText": "각 카메라는 두 가지 방식으로 가져올 수 있습니다:",
+        "proxyOptions": [
+          "프록시 (기본값): NINA 백엔드가 이미지를 가져와 브라우저로 전달합니다. 인증 정보가 필요하거나 CORS 제한이 있는 로컬 네트워크 카메라에 필요합니다. VPN으로 접속할 때는 약간 느립니다.",
+          "직접 연결: 브라우저가 이미지를 직접 가져옵니다. 공용 인터넷 카메라(예: 공개 allsky 캠)에 더 빠릅니다. Chrome/Edge에서는 URL의 인증 정보를 지원하지 않습니다."
+        ],
+        "close": "닫기"
+      }
+    },
+    "filebrowser": {
+      "title": "파일 브라우저",
+      "subtitle": "이미지 폴더를 탐색하고 촬영한 파일을 관리합니다.",
+      "jumpToImagePath": "이미지 저장 경로",
+      "goUp": "위로",
+      "refresh": "새로고침",
+      "imagesOnly": "이미지/FITS만",
+      "currentPath": "현재 경로",
+      "directoriesCount": "디렉터리: {count}",
+      "filesCount": "파일: {count}",
+      "newFolderPlaceholder": "새 폴더 이름",
+      "createFolder": "폴더 만들기",
+      "loading": "파일 불러오는 중...",
+      "empty": "이 폴더는 비어 있습니다.",
+      "openFolder": "열기",
+      "details": "선택 정보",
+      "type": "유형",
+      "directory": "디렉터리",
+      "file": "파일",
+      "size": "크기",
+      "modified": "수정일",
+      "isImage": "이미지/FITS",
+      "selectEntryHint": "파일이나 디렉터리를 선택하면 상세 정보가 표시됩니다.",
+      "onHoldTitle": "보류 중",
+      "onHoldMessage": "이름 변경 및 파일 열기 동작은 현재 의도적으로 보류 중입니다.",
+      "loadError": "디렉터리 내용을 불러오지 못했습니다.",
+      "createError": "디렉터리를 생성하지 못했습니다.",
+      "deleteError": "항목을 삭제하지 못했습니다.",
+      "deleteDirectoryTitle": "디렉터리 삭제",
+      "deleteDirectoryMessage": "디렉터리 \"{name}\"을(를) 하위 항목까지 모두 삭제하시겠습니까?",
+      "deleteFileTitle": "파일 삭제",
+      "deleteFileMessage": "파일 \"{name}\"을(를) 삭제하시겠습니까?"
+    },
+    "sequenceCreator": {
+      "title": "시퀀스 작성기",
+      "subtitle": "전문 천체사진 시퀀스를 만듭니다",
+      "toolbar": {
+        "undo": "실행 취소",
+        "redo": "다시 실행",
+        "loadBasicSequence": "기본 시퀀스 불러오기",
+        "clearSequence": "시퀀스 지우기",
+        "saveAsDefault": "기본값으로 저장",
+        "saveAsDefaultSuccess": "기본 시퀀스로 저장했습니다!",
+        "sendToNina": "시퀀스 채택",
+        "sending": "전송 중...",
+        "sent": "전송 완료!",
+        "sendErrorTitle": "N.I.N.A로 전송하는 중 오류가 발생했습니다",
+        "sendSuccessMessage": "시퀀스를 N.I.N.A로 전송했습니다!",
+        "validSequence": "시퀀스가 유효하며 채택할 수 있습니다",
+        "invalidSequence": "유효한 시퀀스를 만들려면 타깃 설정과 스마트 노출을 추가하세요",
+        "saveNamed": "다른 이름으로 시퀀스 저장...",
+        "saveNamedSuccess": "시퀀스를 저장했습니다!",
+        "openLibrary": "시퀀스 라이브러리",
+        "loadNamed": "불러오기",
+        "loadNamedSuccess": "시퀀스를 불러왔습니다!"
+      },
+      "library": {
+        "isDefault": "기본값",
+        "setAsDefault": "기본값으로 설정",
+        "setAsDefaultSuccess": "기본 시퀀스로 설정했습니다!"
+      },
+      "confirmations": {
+        "title": "확인",
+        "clearSequence": "전체 시퀀스를 지우시겠습니까? 이 작업은 되돌릴 수 없습니다.",
+        "saveAsDefault": "현재 시퀀스를 기본값으로 저장하시겠습니까? 기존 기본 시퀀스를 덮어씁니다.",
+        "loadBasicSequence": "기본 시퀀스를 불러오시겠습니까? 현재 시퀀스를 덮어씁니다.",
+        "removeAction": "\"{actionName}\" 동작을 제거하시겠습니까?",
+        "navigateToSequence": "지금 시퀀스 페이지로 전환하시겠습니까?",
+        "saveNamed": "시퀀스 이름을 입력하세요:",
+        "saveNamedPlaceholder": "시퀀스 이름...",
+        "libraryTitle": "저장된 시퀀스",
+        "libraryEmpty": "저장된 시퀀스가 없습니다."
+      },
+      "containers": {
+        "startSequence": {
+          "title": "시작 시퀀스",
+          "description": "세션 시작 시 실행되는 동작",
+          "emptyTitle": "시작 동작 없음",
+          "emptyDescription": "촬영을 위해 장비를 준비하는 동작을 추가하세요"
+        },
+        "targetSequence": {
+          "title": "타깃 시퀀스",
+          "description": "타깃을 위한 주 촬영 시퀀스",
+          "emptyTitle": "타깃 동작 없음",
+          "emptyDescription": "타깃 촬영 동작을 추가하세요"
+        },
+        "endSequence": {
+          "title": "종료 시퀀스",
+          "description": "세션 종료 시 실행되는 동작",
+          "emptyTitle": "종료 동작 없음",
+          "emptyDescription": "장비를 안전하게 종료하는 동작을 추가하세요"
+        },
+        "noActions": "동작 없음",
+        "addActionsToContainer": "이 컨테이너에 동작을 추가하세요",
+        "addAction": "동작 추가"
+      },
+      "actions": {
+        "disabled": "비활성화됨",
+        "enabled": "활성화됨",
+        "closeEditor": "편집기 닫기",
+        "editParameters": "매개변수 편집",
+        "moveUp": "위로 이동",
+        "moveDown": "아래로 이동",
+        "duplicateAction": "동작 복제",
+        "removeAction": "동작 제거",
+        "clickToRename": "클릭하여 이름 변경",
+        "actionParameters": "동작 매개변수",
+        "changesSaveAutomatically": "변경 사항은 자동으로 저장됩니다",
+        "min": "최소:",
+        "max": "최대:",
+        "yes": "예",
+        "no": "아니요",
+        "notSet": "설정 안 됨",
+        "noConfigurableParameters": "이 동작에는 설정 가능한 매개변수가 없습니다.",
+        "actionId": "동작 ID",
+        "category": "카테고리",
+        "parameters": "매개변수",
+        "unparkTelescope": {
+          "name": "망원경 파킹 해제",
+          "description": "망원경 마운트 파킹을 해제합니다"
+        },
+        "coolCamera": {
+          "name": "카메라 냉각",
+          "description": "카메라를 지정한 온도로 냉각합니다",
+          "temperatureLabel": "온도 (°C)",
+          "temperatureTooltip": "카메라 냉각 목표 온도",
+          "durationLabel": "냉각 시간 (분)",
+          "durationTooltip": "카메라를 적극적으로 냉각하는 시간 (0 = 목표 온도에 도달할 때까지 냉각)"
+        },
+        "dewHeater": {
+          "name": "결로 방지 히터",
+          "description": "카메라 결로 방지 히터 상태를 설정합니다",
+          "onOffLabel": "활성화됨",
+          "onOffTooltip": "카메라 결로 방지 히터를 켜거나 끕니다"
+        },
+        "targetSettings": {
+          "name": "타깃 설정",
+          "description": "타깃 좌표와 설정을 정의합니다",
+          "targetNameLabel": "타깃 이름",
+          "targetNameTooltip": "천체의 이름",
+          "raLabel": "적경(Right Ascension)",
+          "raTooltip": "HH:MM:SS 형식의 RA",
+          "decLabel": "적위(Declination)",
+          "decTooltip": "DD:MM:SS 형식의 Dec",
+          "positionAngleLabel": "위치각 (°)",
+          "positionAngleTooltip": "카메라 회전 각도"
+        },
+        "slewToTarget": {
+          "name": "타깃으로 슬루",
+          "description": "다양한 옵션으로 타깃으로 이동합니다",
+          "slewModeLabel": "슬루 모드",
+          "slewModeTooltip": "타깃으로 이동하는 방식을 선택하세요"
+        },
+        "runAutofocus": {
+          "name": "오토포커스 실행",
+          "description": "자동 초점 루틴을 수행합니다"
+        },
+        "startGuiding": {
+          "name": "가이딩 시작",
+          "description": "자동 가이딩 시스템을 시작합니다",
+          "forceCalibrationLabel": "캘리브레이션 강제 실행",
+          "forceCalibrationTooltip": "가이더 캘리브레이션을 강제로 새로 수행합니다"
+        },
+        "smartExposure": {
+          "name": "스마트 노출 (촬영)",
+          "description": "디더링과 트리거가 포함된 지능형 노출 시퀀스",
+          "exposureTimeLabel": "노출 시간 (s)",
+          "exposureTimeTooltip": "각 노출의 지속 시간",
+          "gainLabel": "게인",
+          "gainTooltip": "카메라 게인 설정",
+          "offsetLabel": "오프셋",
+          "offsetTooltip": "카메라 오프셋 설정",
+          "binningLabel": "비닝",
+          "binningTooltip": "픽셀 비닝 모드",
+          "filterLabel": "필터",
+          "filterTooltip": "필터휠 선택",
+          "imageTypeLabel": "이미지 유형",
+          "imageTypeTooltip": "촬영할 노출 유형",
+          "countLabel": "이미지 수",
+          "countTooltip": "촬영할 노출 횟수",
+          "ditherAfterLabel": "N회 노출 후 디더링",
+          "ditherAfterTooltip": "디더링 빈도"
+        },
+        "stopGuiding": {
+          "name": "가이딩 중지",
+          "description": "자동 가이딩 시스템 중지"
+        },
+        "warmCamera": {
+          "name": "카메라 워밍",
+          "description": "카메라 워밍업",
+          "durationLabel": "워밍 시간(분)",
+          "durationTooltip": "카메라를 능동적으로 워밍업할 시간 (0 = 주변 온도까지 워밍)"
+        },
+        "findHome": {
+          "name": "홈 찾기",
+          "description": "망원경을 홈 위치로 이동"
+        },
+        "parkTelescope": {
+          "name": "망원경 파킹",
+          "description": "망원경 마운트 파킹"
+        }
+      },
+      "actionLibrary": {
+        "title": "액션 라이브러리",
+        "description": "클릭하여 컨테이너에 액션 추가",
+        "startActions": "🚀 시작 액션",
+        "targetActions": "🎯 타깃 액션",
+        "endActions": "🏁 종료 액션"
+      },
+      "exportModal": {
+        "buttons": {},
+        "messages": {},
+        "jsonPreview": {
+          "sequenceJsonExport": "시퀀스 JSON 내보내기",
+          "previewDescription": "시퀀스를 JSON 파일로 미리보기 및 다운로드",
+          "totalActions": "전체 액션",
+          "enabled": "활성화됨",
+          "categories": "카테고리",
+          "estimatedDuration": "예상 소요 시간",
+          "filenamePrompt": "파일명 입력...",
+          "copyJson": "JSON 복사",
+          "copied": "복사됨!",
+          "downloadJson": "JSON 다운로드"
+        },
+        "howToUse": {}
+      },
+      "targetSearch": {
+        "searchLabel": "타깃 검색",
+        "searchDescription": "딥스카이 천체, 행성 또는 항성을 검색해 좌표를 자동으로 적용",
+        "placeholder": "천체 이름 입력 (예: M31, NGC 1234, 화성)...",
+        "objectTypes": {
+          "DSO": "딥스카이 천체",
+          "Planet": "행성",
+          "Star": "항성",
+          "Moon": "달",
+          "Comet": "혜성"
+        }
+      },
+      "settings": {
+        "title": "자오선 반전(meridian flip)",
+        "enableMeridianFlip": "자오선 반전(meridian flip) 활성화"
+      }
+    },
+    "platesolveplus": {
+      "title": "PlateSolvePlus",
+      "subtitle": "대체 플레이트솔브 카메라 V2용 원격 PlateSolvePlus 콘솔",
+      "ws": {
+        "label": "WS",
+        "connected": "연결됨",
+        "disconnected": "연결 끊김"
+      },
+      "tabs": {
+        "control": "제어",
+        "config": "설정"
+      },
+      "sections": {
+        "status": "상태",
+        "preview": "미리보기",
+        "actions": "액션",
+        "secondary_camera": "보조 카메라 (ASCOM)",
+        "offset": "오프셋",
+        "current_settings": "현재 설정",
+        "event_log": "이벤트 로그",
+        "connection": "연결",
+        "websocket": "WebSocket",
+        "offsets": "오프셋"
+      },
+      "buttons": {
+        "refresh": "새로고침",
+        "refreshing": "새로고침 중…",
+        "capture": "캡처",
+        "solve_sync": "솔브 + 동기화",
+        "center_solve": "센터링 + 솔브",
+        "target_solve": "타깃 + 솔브",
+        "clear": "지우기",
+        "sync": "동기화",
+        "setup": "설정…",
+        "save_config": "설정 저장",
+        "reload_from_storage": "저장소에서 다시 불러오기",
+        "test_connection": "연결 테스트",
+        "reconnect_ws": "WS 재연결",
+        "disconnect_ws": "WS 연결 끊기",
+        "reset_offsets": "오프셋 초기화",
+        "calibrate_offsets": "오프셋 보정"
+      },
+      "status_labels": {
+        "busy": "사용 중",
+        "service_ready": "서비스 준비됨",
+        "mount_connected": "마운트 연결됨",
+        "camera_connected": "카메라 연결됨",
+        "last_update": "마지막 업데이트",
+        "task_status": "작업 상태",
+        "used_parameters": "사용된 파라미터",
+        "validation": "검증",
+        "raw_solve": "원본 솔브 (가이더 카메라)",
+        "corrected_coordinates": "보정된 좌표 (오프셋 적용)",
+        "last_solve_summary": "lastSolveSummary"
+      },
+      "preview": {
+        "preview_title": "미리보기 이미지",
+        "auto_refresh": "자동 새로고침",
+        "alt_latest_preview": "최신 미리보기",
+        "unavailable_title": "미리보기 사용 불가",
+        "load_error": "로드 오류 — 새로고침해 주세요.",
+        "no_preview_loaded": "아직 불러온 미리보기가 없습니다.",
+        "cache_hint": "캐시 무효화 활성화됨 (?t=). 서버도 Cache-Control: no-store를 전송합니다.",
+        "no_preview_yet": "(아직) 사용 가능한 미리보기가 없습니다."
+      },
+      "actions_help": {
+        "capture": "플레이트 솔브만 수행 (검증), 동기화/슬루 없음.",
+        "solve_sync": "플레이트 솔브 후 마운트 동기화 (마운트 연결 필요).",
+        "center_solve": "플레이트 솔브 후 타깃 센터링 (마운트 연결 + 보정된 오프셋 필요).",
+        "capture_label": "캡처",
+        "capture_text": "플레이트 솔브만 수행 (검증), 동기화/슬루 없음.",
+        "solve_sync_label": "솔브 + 동기화",
+        "solve_sync_text": "플레이트 솔브 후 마운트 동기화 (마운트 연결 필요).",
+        "center_solve_label": "센터링 + 솔브",
+        "center_solve_text": "플레이트 솔브 후 타깃 센터링 (마운트 연결 + 보정된 오프셋 필요).",
+        "target_solve_label": "타깃 + 솔브",
+        "target_solve_text": "타깃으로 슬루 + 센터링 (마운트 연결 + 프레이밍 어시스턴트의 Stellarium에 타깃 설정 필요)."
+      },
+      "progress": {
+        "title": "솔브 진행",
+        "job": "작업",
+        "action": "액션",
+        "stage": "단계",
+        "message": "메시지",
+        "process_progress": "프로세스 진행 상황.",
+        "pill": {
+          "capturing": "캡처 중",
+          "validating": "검증 중",
+          "platesolving": "플레이트 솔빙 중",
+          "syncing": "동기화 중",
+          "centering": "센터링 중",
+          "finishing": "마무리 중",
+          "calibrating": "보정 중",
+          "running": "실행 중",
+          "slewing_to_target": "대상으로 슬루 중"
+        },
+        "messages": {
+          "working": "작업 중…",
+          "capturing_validating": "촬영 + 검증 중…",
+          "solving_syncing": "솔빙 + 동기화 중…",
+          "solving_centering": "솔빙 + 센터링 중…",
+          "solving": "솔빙 중…",
+          "capture_accepted": "촬영 수락됨 (이벤트 대기 중)",
+          "capture_started": "촬영 시작",
+          "capture_finished": "촬영 완료",
+          "solve_started": "솔브 시작",
+          "solve_finished": "솔브 완료",
+          "solve_sync_accepted": "솔브+동기화 수락됨 (이벤트 대기 중)",
+          "solve_sync_started": "솔브+동기화 시작",
+          "solve_sync_finished": "솔브+동기화 완료",
+          "center_solve_accepted": "센터+솔브 수락됨 (이벤트 대기 중)",
+          "center_solve_started": "센터+솔브 시작",
+          "center_solve_finished": "센터+솔브 완료",
+          "offset_calibrate_started": "오프셋 보정 시작",
+          "offset_calibrate_finished": "오프셋 보정 완료"
+        }
+      },
+      "secondary": {
+        "status": "상태",
+        "connected": "연결됨",
+        "disconnected": "연결 끊김",
+        "current_camera": "현재 카메라",
+        "not_connected": "연결 안 됨",
+        "no_drivers_returned": "반환된 드라이버가 없습니다.",
+        "log": {
+          "state_synced": "보조 카메라 상태 동기화됨",
+          "sync_failed": "보조 카메라 동기화 실패",
+          "selection_applied": "보조 선택 적용됨",
+          "selection_failed": "보조 선택 실패",
+          "connect": "보조 연결",
+          "connect_failed": "보조 연결 실패",
+          "disconnect": "보조 연결 해제",
+          "disconnect_failed": "보조 연결 해제 실패",
+          "setup_dialog": "보조 설정 대화상자",
+          "setup_dialog_failed": "보조 설정 대화상자 실패"
+        }
+      },
+      "offset_fields": {
+        "offset_enabled": "offsetEnabled",
+        "offset_mode": "offsetMode",
+        "dra_arcsec": "ΔRA (arcsec):",
+        "ddec_arcsec": "ΔDec (arcsec):",
+        "rotation_quat": "rotation (quat):"
+      },
+      "settings": {
+        "camera": "카메라",
+        "scope": "망원경",
+        "platesolve": "플레이트솔브",
+        "exposure": "노출:",
+        "gain": "게인:",
+        "binning": "비닝:",
+        "focal_length": "초점 거리:",
+        "focal_scale": "초점 스케일:",
+        "pixel_size": "픽셀 크기:",
+        "search_radius": "검색 반경:",
+        "downsample": "다운샘플:",
+        "timeout_sec": "타임아웃 (초):",
+        "threshold": "임계값:",
+        "max_attempts": "최대 시도 횟수:",
+        "auto_gain": "자동",
+        "values_from_backend": "이 값들은 백엔드 설정 엔드포인트에서 가져옵니다."
+      },
+      "event_log": {
+        "empty": "—"
+      },
+      "config": {
+        "host": "호스트",
+        "port": "포트",
+        "base_path": "기본 경로",
+        "base_path_default": "기본값: /api/platesolveplus",
+        "use_token_optional": "토큰 사용 (선택)",
+        "token": "토큰",
+        "token_placeholder": "token…",
+        "token_hint": "X-PSP-Token 헤더로 전송됩니다 (PlateSolvePlus API 호스트와 일치).",
+        "active_url": "활성 URL:"
+      },
+      "websocket": {
+        "endpoint": "엔드포인트:",
+        "auto_reconnect": "자동 재연결 활성화됨 (백오프)."
+      },
+      "offsets_help": {
+        "text": "보정은 가이더-메인 오프셋 모델을 생성/업데이트합니다. 리셋은 모든 오프셋을 지웁니다."
+      },
+      "footer": {
+        "rest": "REST:"
+      },
+      "common": {
+        "empty": "—",
+        "true": "true",
+        "false": "false"
+      },
+      "log": {
+        "preview_refreshed": "미리보기 새로고침됨",
+        "config_load_failed": "설정 불러오기 실패"
+      },
+      "secondary_setup": {
+        "title": "보조 카메라 설정",
+        "subtitle": "드라이버 선택, 연결 및 네이티브 ASCOM 설정 대화상자",
+        "pills": {
+          "connected": "연결됨",
+          "disconnected": "연결 끊김",
+          "busy": "사용 중",
+          "idle": "대기 중",
+          "active": "활성"
+        },
+        "driver": {
+          "title": "드라이버",
+          "description": "보조 카메라로 사용할 ASCOM 드라이버를 선택하세요.",
+          "label": "드라이버",
+          "select_placeholder": "— 선택 —",
+          "fallback_name": "드라이버",
+          "selected": "선택됨"
+        },
+        "buttons": {
+          "close": "닫기",
+          "refresh": "새로고침",
+          "refresh_title": "드라이버 목록 새로고침",
+          "sync": "동기화",
+          "sync_title": "현재 선택/연결 동기화",
+          "apply": "적용",
+          "apply_title": "선택 적용",
+          "connect": "연결",
+          "disconnect": "연결 해제",
+          "driver_setup": "드라이버 설정...",
+          "driver_setup_title": "호스트에서 네이티브 ASCOM 설정 대화상자 열기"
+        },
+        "tip": {
+          "prefix": "팁: 드라이버 설정 대화상자에서 설정을 변경했다면, 그 후에",
+          "suffix": "클릭하세요."
+        }
+      }
+    },
+    "livestack": {
+      "not_available": "Livestack을 찾을 수 없습니다. 먼저 NINA에 Livestack 플러그인을 설치하세요.",
+      "beta_note": "이 플러그인은 아직 개발 중이며 일부 오류가 있을 수 있습니다!",
+      "target": "대상",
+      "available_filters": "사용 가능한 필터",
+      "no_image_available": "사용 가능한 이미지 없음",
+      "start_and_select_filter": "라이브스택을 시작하고 필터를 선택하면 이미지가 표시됩니다",
+      "no_filter": "필터 없음",
+      "no_filters_available": "이 대상에 사용 가능한 필터가 없습니다",
+      "no_target": "대상 없음",
+      "configuration_title": "라이브스택 설정",
+      "drag_hint": "드래그",
+      "show_rgb_only": "RGB 합성만 표시",
+      "track_stack_updates": "항상 최신 스택 표시",
+      "empty_option": "비어 있음",
+      "image_alt": "라이브스택 이미지 - {filter}",
+      "loading_image": "라이브스택 이미지 불러오는 중...",
+      "reset": "스택 리셋",
+      "errors": {
+        "start_failed": "라이브스택 시작 실패",
+        "start_exception": "라이브스택 시작 오류: {message}",
+        "stop_failed": "라이브스택 중지 실패",
+        "stop_exception": "라이브스택 중지 중 오류: {message}",
+        "reset_failed": "라이브스택 초기화 실패",
+        "reset_exception": "라이브스택 초기화 중 오류: {message}",
+        "loading_image": "이미지 로드 중 오류: {message}",
+        "failed_to_load": "라이브스택 이미지 로드 실패",
+        "api_version_required": "API 버전 {version} 이상이 필요합니다"
+      }
+    },
+    "narrowband": {
+      "title": "필터 계산기",
+      "subtitle": "협대역 필터 투과 특성 계산",
+      "sections": {
+        "optical": "광학 파라미터",
+        "bandpass": "대역폭 특성",
+        "chart": "대역폭 곡선",
+        "results": "투과 결과"
+      },
+      "aperture": "구경 (mm)",
+      "focalLength": "초점 거리 (mm)",
+      "peakTransmittance": "최대 투과율",
+      "refractiveIndex": "굴절률",
+      "obstructionDiameter": "중앙 차폐 (mm)",
+      "bandpassCenter": "대역 중심 (nm)",
+      "fwhm": "FWHM (nm)",
+      "flatTop": "플랫 탑 (nm)",
+      "populerFilters": "주요 필터",
+      "selectManufacturer": "제조사 선택...",
+      "clearSelection": "선택 해제",
+      "customCurve": "사용자 지정 대역폭 곡선",
+      "csvInfo": {
+        "title": "예상 파일 형식",
+        "description": "한 줄에 공백으로 구분된 두 개의 열이 있는 일반 텍스트 파일: 파장 (nm)과 투과율 (%). 두 개의 숫자로 해석할 수 없는 줄은 자동으로 건너뜁니다 (주석이나 헤더로 사용하세요).",
+        "example": "# wavelength  transmission\n500.0   0.10\n656.3  98.50\n672.4  99.00\n700.0   0.05",
+        "note": "투과율 값은 0 – 100 (퍼센트) 범위여야 합니다. 쉼표로 구분된 파일은 지원되지 않습니다."
+      },
+      "clearCurve": "곡선 지우기",
+      "loaded": "불러옴:",
+      "dataPoints": "데이터 점",
+      "targetWavelength": "목표 파장 (nm)",
+      "filterTransmission": "필터 투과율",
+      "wavelengthLabel": "파장 (nm)",
+      "transmissionLabel": "투과율",
+      "transmissionPercent": "투과율: {percent}%",
+      "wavelengthRange": "파장 범위",
+      "flatTopRange": "플랫 탑 범위",
+      "fRatio": "f/비",
+      "resetDefaults": "기본값으로 초기화",
+      "status": {
+        "success": "투과율이 계산되었습니다",
+        "invalidCsv": "CSV에서 유효한 파장/투과율 데이터를 찾을 수 없습니다",
+        "csvError": "CSV 파싱 오류: {error}"
+      }
+    },
+    "pinsDevices": {
+      "title": "PI'N'Stars 장치",
+      "powerBox": "PINS.PowerBox",
+      "meteoStation": "PINS.MeteoStation",
+      "wifiTab": "WiFi",
+      "settings": {
+        "general": "일반",
+        "generalDescription": "일반 장치 설정 및 정보",
+        "powerPorts": "전원 포트",
+        "powerPortsDescription": "전원 포트 출력 구성 및 관리",
+        "usbPorts": "USB 포트",
+        "usbPortsDescription": "USB 포트 연결 구성 및 관리",
+        "dewPorts": "결로 방지 포트",
+        "dewPortsDescription": "결로 방지 히터 포트 구성 및 관리",
+        "adjustablePower": "조절형 전원 포트",
+        "adjustablePowerDescription": "조절형 전원 포트 구성 및 관리",
+        "configuration": "구성",
+        "configurationDescription": "장치 설정 및 센서 보정 구성",
+        "ports": "PowerBox",
+        "wifi": "WiFi",
+        "weather": "MeteoStation",
+        "temperature": "온도",
+        "humidity": "습도",
+        "dewPoint": "이슬점",
+        "placeholders": {
+          "networkName": "네트워크 이름",
+          "password": "비밀번호",
+          "passwordHint": "최소 8자"
+        },
+        "validation": {
+          "passwordRequired": "비밀번호는 최소 8자 이상이어야 합니다"
+        }
+      },
+      "config": {
+        "title": "구성",
+        "temperatureOffset": "온도 오프셋",
+        "temperatureOffsetDesc": "온도 센서 보정 오프셋",
+        "humidityOffset": "습도 오프셋",
+        "humidityOffsetDesc": "습도 센서 보정 오프셋",
+        "envUpdateRate": "환경 갱신 주기",
+        "envUpdateRateDesc": "온도 및 습도 측정값 새로고침 간격",
+        "updateRate": "장치 갱신 주기",
+        "updateRateDesc": "장치 상태 업데이트 새로고침 간격",
+        "factoryReset": "공장 초기화",
+        "factoryResetDesc": "PINS 장치를 공장 기본 설정으로 초기화",
+        "factoryResetConfirm": "공장 초기화를 진행하시겠습니까? 모든 설정이 기본값으로 초기화됩니다.",
+        "notifications": {
+          "title": "알림",
+          "beepOnWarning": "경고 시 비프음",
+          "beepOnWarningDesc": "NINA 경고 수신 시 PowerBox에서 비프음 울림",
+          "beepOnError": "오류 시 비프음",
+          "beepOnErrorDesc": "NINA 오류 수신 시 PowerBox에서 비프음 울림",
+          "beepVolume": "비프음 볼륨",
+          "volumeLow": "낮음",
+          "volumeMedium": "중간",
+          "volumeLoud": "높음",
+          "beepLength": "비프음 길이",
+          "beepLengthDesc": "각 비프음 길이 (밀리초, 100–10000)",
+          "beepRepeatDuration": "반복 시간",
+          "beepRepeatDurationDesc": "비프음 패턴을 반복할 총 시간 (1–60s)",
+          "powerboxRequired": "비프음 알림이 작동하려면 PowerBox가 연결되어 있어야 합니다",
+          "testBeep": "비프음 테스트",
+          "testBeepRunning": "비프음 울리는 중..."
+        }
+      },
+      "info": {
+        "coreTemp": "CPU 온도",
+        "deviceId": "장치 ID",
+        "firmware": "펌웨어",
+        "driverVersion": "드라이버 버전",
+        "ports": "사용 가능한 포트",
+        "powerPorts": "전원 포트",
+        "usbPorts": "USB 포트",
+        "dewPorts": "결로 방지 포트",
+        "adjPorts": "조절형 전원 포트",
+        "powerStatus": "전원 상태",
+        "meteoStation": "Meteo Station",
+        "rail12v": "12V 레일",
+        "rail5v": "5V 레일",
+        "averageAmps": "평균 전류",
+        "totalAmps": "총 전류",
+        "totalWatts": "총 전력"
+      },
+      "status": {
+        "notConnected": "연결 안 됨"
+      },
+      "ports": {
+        "status": "상태",
+        "current": "전류",
+        "voltage": "전압",
+        "maxCurrent": "최대 전류",
+        "overcurrent": "과전류",
+        "readOnly": "읽기 전용 (제어 불가)",
+        "noPorts": "사용 가능한 포트 없음",
+        "bootState": "전원 켜짐 상태",
+        "bootStateEnabled": "시작 시 활성화",
+        "bootStateDisabled": "시작 시 비활성화"
+      },
+      "wifi": {
+        "currentStatus": "현재 WiFi 상태",
+        "notConnected": "현재 연결된 네트워크 없음",
+        "availableNetworks": "사용 가능한 네트워크",
+        "scanNetworks": "네트워크 검색",
+        "scanning": "WiFi 네트워크 검색 중...",
+        "noNetworksFound": "WiFi 네트워크를 찾을 수 없음",
+        "channel": "채널",
+        "connect": "연결",
+        "connectTo": "연결 대상",
+        "connectToNetwork": "WiFi 네트워크 연결",
+        "ssid": "네트워크 SSID",
+        "password": "비밀번호",
+        "enterPassword": "WiFi 비밀번호 입력",
+        "min8chars": "최소 8자",
+        "passwordTooShort": "비밀번호는 최소 8자 이상이어야 합니다",
+        "connectAsClient": "클라이언트로 연결",
+        "createHotspot": "핫스팟 만들기",
+        "hotspotName": "핫스팟 이름",
+        "hotspotPassword": "핫스팟 비밀번호",
+        "hotspotDesc": "다른 기기가 연결할 수 있는 WiFi 액세스 포인트 생성"
+      },
+      "weather": {
+        "deviceInfo": "기기 정보",
+        "name": "이름",
+        "id": "기기 ID",
+        "firmware": "펌웨어",
+        "uptime": "가동 시간",
+        "disconnected": "MeteoStation이 현재 연결되어 있지 않음",
+        "currentWeather": "현재 기상 상태",
+        "temperature": "온도",
+        "humidity": "습도",
+        "dewPoint": "이슬점",
+        "cloudCover": "구름량",
+        "skyQuality": "하늘 품질",
+        "skyBrightness": "하늘 밝기",
+        "skyTemp": "하늘 온도",
+        "noData": "기상 데이터 없음",
+        "conditions": "기상 평가",
+        "cloudAssessment": "구름량",
+        "temperatureStatus": "온도 상태",
+        "dewSpread": "이슬 여유 (T-Td)"
+      }
+    },
+    "shortcuts": {
+      "title": "시퀀스 단축키",
+      "description": "N.I.N.A 시퀀스를 빠르게 불러오고 시작",
+      "addNew": "새 단축키",
+      "newShortcut": "새 단축키",
+      "createFirst": "첫 단축키 만들기",
+      "menu": "메뉴",
+      "edit": "편집",
+      "editShortcut": "단축키 편집",
+      "deleteShortcut": "단축키 삭제",
+      "noShortcuts": "아직 생성된 단축키 없음",
+      "noShortcutsDescription": "즐겨 쓰는 시퀀스를 빠르게 불러올 단축키 만들기",
+      "phrase": "단축키 이름",
+      "phrasePlaceholder": "예: M31 세션",
+      "shortcutName": "단축키 이름",
+      "shortcutNamePlaceholder": "예: M31 세션",
+      "sequenceFile": "시퀀스 파일",
+      "selectSequence": "시퀀스 선택...",
+      "autoStart": "시퀀스 자동 시작",
+      "autoStartDescription": "불러온 후 시퀀스를 자동으로 시작",
+      "autoStartEnabled": "자동 시작 켜짐",
+      "manualExecution": "수동 실행",
+      "icon": "아이콘",
+      "selectIcon": "아이콘 선택",
+      "color": "색상",
+      "selectColor": "색상 선택",
+      "create": "만들기",
+      "update": "업데이트",
+      "cancel": "취소",
+      "delete": "삭제",
+      "execute": "실행",
+      "refreshSequences": "목록 새로고침",
+      "loadingSequences": "시퀀스 불러오는 중...",
+      "noSequencesAvailable": "사용 가능한 시퀀스 없음",
+      "confirmDelete": "단축키를 삭제할까요?",
+      "confirmDeleteMessage": "\"{phrase}\"을(를) 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.",
+      "confirmDeleteTitle": "단축키 삭제",
+      "errors": {
+        "nameRequired": "단축키 이름이 필요합니다",
+        "sequenceRequired": "시퀀스를 선택하세요",
+        "loadFailed": "단축키 불러오기 실패",
+        "saveFailed": "단축키 저장 실패",
+        "deleteFailed": "단축키 삭제 실패",
+        "executeFailed": "단축키 실행 실패",
+        "sequenceLoadFailed": "시퀀스 불러오기 실패"
+      },
+      "success": {
+        "created": "단축키를 생성했습니다",
+        "updated": "단축키를 업데이트했습니다",
+        "deleted": "단축키를 삭제했습니다"
+      }
+    },
+    "hocusfocus": {
+      "title": "HocusFocus",
+      "tabs": {
+        "aberration": "수차 검사기",
+        "aberrationOptions": "수차 검사기 옵션",
+        "autoFocusOptions": "오토포커스 옵션",
+        "starDetection": "별 검출",
+        "tilter": "틸터 (베타)"
+      },
+      "modal": {
+        "selectDirectory": "다시 실행할 오토포커스 디렉터리 선택",
+        "loading": "오토포커스 디렉터리 불러오는 중...",
+        "placeholder": "오토포커스 디렉터리 선택...",
+        "proceed": "진행",
+        "cancel": "취소"
+      },
+      "aberrationInspector": {
+        "title": "오토포커스 작업",
+        "runButton": "상세 오토포커스 실행",
+        "cancelButton": "오토포커스 취소",
+        "loadSaved": "저장된 AF 불러오기",
+        "clearAnalyses": "분석 지우기",
+        "focusCurveAnalysis": "포커스 곡선 분석",
+        "finalFocusDataSummary": "최종 포커스 데이터 요약",
+        "backfocusError": "백포커스 오차:",
+        "hfrDifference": "HFR 차이:",
+        "innerHFR": "내측 HFR:",
+        "outerHFR": "외측 HFR:",
+        "moveSensor": "(센서 이동",
+        "flattener": "플래트너)",
+        "tiltCornerMeasurements": "틸트 코너 측정값",
+        "sensorSide": "센서 측면",
+        "focuserPosition": "포커서 위치",
+        "adjustmentSteps": "조정 단계",
+        "adjustmentMicrons": "조정 마이크론",
+        "rSquared": "R²",
+        "unitMicrons": "µm",
+        "unitSteps": "steps"
+      },
+      "aberrationInspectorOptions": {
+        "loading": "수차 검사기 옵션을 불러오는 중...",
+        "noOptions": "아직 사용할 수 있는 수차 검사기 옵션이 없습니다.",
+        "error": "오류:",
+        "inspectorSettings": "검사기 설정",
+        "micronsPerFocuserStep": "포커서 스텝당 마이크론",
+        "retry": "다시 시도",
+        "resetToDefaults": "기본값으로 초기화",
+        "resetting": "초기화 중..."
+      },
+      "autoFocusOptions": {
+        "loading": "오토포커스 옵션을 불러오는 중...",
+        "error": "오류:",
+        "retry": "다시 시도",
+        "basicSettings": "기본 설정",
+        "hfrValidation": "HFR 검증"
+      },
+      "directoryBrowser": {
+        "browse": "찾아보기...",
+        "error": "디렉터리 선택 창을 열지 못했습니다"
+      },
+      "starDetection": {
+        "loading": "별 검출 옵션을 불러오는 중...",
+        "error": "오류:",
+        "retry": "다시 시도",
+        "generalSettings": "일반 설정",
+        "advancedMode": "고급 모드",
+        "useHotpixelThresholding": "핫픽셀 임계값 사용",
+        "useAutoFocusCrop": "오토포커스 크롭 사용",
+        "fitPSF": "PSF 피팅",
+        "hotpixelFiltering": "핫픽셀 필터링",
+        "noiseReducedStarMeasurement": "노이즈 감소 별 측정",
+        "debugMode": "디버그 모드",
+        "simpleModeSettings": "간단 모드 설정",
+        "noiseLevel": "노이즈 레벨"
+      },
+      "tilter": {
+        "device": "장치",
+        "selectDevice": "장치 선택",
+        "scanTooltip": "장치 검색",
+        "connect": "연결",
+        "disconnect": "연결 해제",
+        "deviceInfo": "장치 정보 (베타 - 주의해서 사용)",
+        "status": "상태",
+        "connected": "연결됨",
+        "moving": "이동 중",
+        "idle": "대기 중",
+        "currentPositions": "현재 위치",
+        "noDeviceSelected": "먼저 장치를 선택하세요",
+        "deviceNotConnected": "컨트롤을 보려면 장치에 연결하세요",
+        "configuration": "구성",
+        "sensorWidth": "센서 폭",
+        "sensorHeight": "센서 높이",
+        "sensorRotation": "센서 회전",
+        "sensorRotationDescription": "카메라 뒷면을 바라볼 때 시계 방향",
+        "manualTilterConfiguration": "수동 3점 틸터 구성 (베타 - 주의해서 사용)",
+        "tilterOuterRadius": "틸터 외경 반지름",
+        "tilterThreadPitch": "틸터 나사 피치",
+        "applyTiltPlane": "틸트 평면 적용",
+        "fetchFromAberrationInspector": "수차 검사기에서 가져오기",
+        "calculateActuatorPositions": "액추에이터 위치 계산",
+        "calculatedPositions": "계산된 위치",
+        "applyThesePositionsToDevice": "이 위치를 장치에 적용",
+        "actuatorVisualizationLabel": "반지름 {radius} mm의 액추에이터 • 센서 회전 {rotation}° • 위에서 본 모습",
+        "calculatingPositions": "계산 중...",
+        "applyingPositions": "적용 중...",
+        "savingConfiguration": "저장 중..."
+      },
+      "common": {
+        "error": "오류:",
+        "loading": "불러오는 중..."
+      }
+    },
+    "tenmicron": {
+      "title": "10micron 모델 빌더",
+      "subtitle": "10micron 마운트의 포인팅 모델을 구축하고 관리합니다",
+      "notLoaded": "TenMicron 플러그인이 로드되지 않았습니다. NINA.Joko.Plugin.TenMicron 플러그인을 설치하고 활성화하세요.",
+      "mountNotConnected": "마운트가 연결되어 있지 않습니다.",
+      "cancel": "취소",
+      "mountStatus": "마운트 상태",
+      "dualAxisTracking": "양축 추적",
+      "refractionCorrection": "대기 굴절 보정",
+      "tabs": {
+        "builder": "모델 빌더",
+        "model": "정렬 모델",
+        "library": "모델 라이브러리",
+        "mount": "마운트 정보"
+      },
+      "builder": {
+        "pointGeneration": "포인트 생성",
+        "buildControl": "빌드 제어",
+        "starCount": "별 개수",
+        "generatePoints": "골든 스파이럴 생성",
+        "generateSidereal": "항성 경로 생성",
+        "clear": "포인트 지우기",
+        "buildModel": "모델 빌드",
+        "stop": "정지",
+        "cancel": "취소",
+        "buildRunning": "모델 빌드가 진행 중입니다…",
+        "pointCount": "포인트: 사용 가능 {valid}개 / 전체 {total}개",
+        "pointFilters": "포인트 필터",
+        "altRange": "고도 범위",
+        "azRange": "방위각 범위",
+        "min": "최소",
+        "max": "최대",
+        "maxRMS": "최대 RMS (0 = 끔)",
+        "numRetries": "포인트당 재시도",
+        "showExcluded": "제외된 포인트 표시",
+        "minimizeMeridian": "자오선 반전(meridian flip) 최소화",
+        "removeHighRMS": "빌드 후 높은 RMS 제거",
+        "buildOptions": "빌드 옵션",
+        "logCommands": "명령 로깅",
+        "maxConcurrency": "최대 동시 실행",
+        "allowBlindSolves": "블라인드 솔브 허용",
+        "optimizeDome": "돔 최적화",
+        "westToEast": "서쪽에서 동쪽으로",
+        "plateSolveSubframe": "플레이트 솔브 서브프레임",
+        "alternateDirection": "방향 교대",
+        "disableRefractionCorrection": "대기 굴절 보정 비활성화",
+        "decJitter": "Dec 지터 (σ°)",
+        "disableDAT": "모델링 중 DAT 비활성화",
+        "resetOptions": "기본값으로 초기화",
+        "noCameraConnected": "카메라가 연결되어 있지 않습니다 — 모델을 빌드하려면 카메라가 필요합니다.",
+        "generatorType": "생성기",
+        "goldenSpiral": "골든 스파이럴",
+        "siderealPath": "항성 경로",
+        "target": "대상",
+        "raHours": "RA (h)",
+        "decDegrees": "Dec (°)",
+        "raDelta": "RA 간격 (°)",
+        "startTime": "시작 시간",
+        "endTime": "종료 시간",
+        "offsetMin": "오프셋 (분)",
+        "fromScope": "망원경에서",
+        "fromSequence": "시퀀스에서",
+        "timeWindow": "시간 범위",
+        "noPoints": "모델 포인트가 없습니다. 시작하려면 포인트를 생성하세요.",
+        "scatterChart": "모델 포인트 (Az/Alt)",
+        "axisAz": "방위각 (도)",
+        "axisAlt": "고도 (도)",
+        "refresh": "새로고침"
+      },
+      "model": {
+        "alignmentInfo": "정렬 정보",
+        "stars": "별",
+        "rmsError": "RMS 오차",
+        "modelTerms": "모델 항",
+        "polarAlt": "극축 고도",
+        "polarAz": "극축 방위각",
+        "polarError": "극축 정렬 오차",
+        "paAltError": "PA Alt 오차",
+        "paAzError": "PA Az 오차",
+        "paAngle": "PA 오차 각도",
+        "coneError": "콘 오차",
+        "azTurns": "Az 조정 회전수",
+        "altTurns": "Alt 조정 회전수",
+        "starsChart": "정렬 별 (극축 보기)",
+        "deleteWorstStar": "최악의 별 삭제",
+        "clearAlignment": "정렬 초기화",
+        "clearConfirmTitle": "정렬 모델을 초기화할까요?",
+        "clearConfirmMsg": "마운트에서 현재 정렬 모델을 영구적으로 삭제합니다. 계속할까요?",
+        "refresh": "새로고침",
+        "noModel": "로드된 정렬 모델이 없습니다."
+      },
+      "library": {
+        "savedModels": "저장된 모델",
+        "namePlaceholder": "새 모델 이름…",
+        "save": "저장",
+        "load": "불러오기",
+        "delete": "삭제",
+        "noModels": "저장된 모델이 없습니다.",
+        "refresh": "새로고침"
+      },
+      "mount": {
+        "info": "마운트 정보",
+        "product": "마운트",
+        "firmware": "펌웨어",
+        "firmwareDate": "펌웨어 날짜",
+        "ip": "IP 주소",
+        "mac": "MAC 주소",
+        "statusTitle": "마운트 상태",
+        "gpsSync": "GPS 시간 동기화",
+        "trackingRate": "추적 속도",
+        "slewSettle": "슬루 정착",
+        "meridianLimit": "자오선 한계",
+        "unattendedFlip": "무인 반전",
+        "disable": "비활성화",
+        "refractionTemp": "굴절 온도",
+        "refractionPressure": "굴절 기압",
+        "reset": "초기화",
+        "set": "설정",
+        "arcsecPerSec": "arcsec/sec",
+        "seconds": "s",
+        "degrees": "°",
+        "celsius": "°C",
+        "hPa": "hPa",
+        "slewRate": "슬루 속도",
+        "horizonHigh": "지평선 상한",
+        "horizonLow": "지평선 하한",
+        "connectionType": "연결 방식",
+        "deltaTExpiration": "DeltaT 만료",
+        "localTime": "현지 시간",
+        "localDate": "현지 날짜",
+        "siderealTime": "항성시"
+      }
+    },
+    "pinsAllSky": {
+      "title": "AllSky 캡처",
+      "common": {
+        "ok": "확인",
+        "cancel": "취소",
+        "close": "닫기",
+        "and": "및",
+        "download": "다운로드",
+        "saving": "저장 중…",
+        "auto": "자동",
+        "unlimited": "무제한",
+        "notGenerated": "생성되지 않음",
+        "notAvailable": "—"
+      },
+      "buttons": {
+        "automation": "자동화",
+        "camera": "카메라",
+        "outputs": "출력",
+        "showStatus": "상태 표시",
+        "updateBackend": "백엔드 업데이트",
+        "startingUpdate": "업데이트 시작 중…",
+        "startCapture": "캡처 시작",
+        "renderProgress": "렌더링 진행률",
+        "renderingProgress": "렌더링 진행 중…",
+        "stopAndRender": "중지 후 렌더링",
+        "refreshPreview": "미리보기 새로고침",
+        "refreshingPreview": "미리보기 새로고침 중…",
+        "regenerate": "재생성",
+        "files": "파일",
+        "showStoredFiles": "저장된 파일 표시",
+        "hideStoredFiles": "저장된 파일 숨기기",
+        "refreshFiles": "파일 새로고침",
+        "deleteAllSessions": "저장된 모든 세션, 프레임, 생성된 결과물 삭제",
+        "deleteSession": "이 세션 삭제",
+        "downloadTimelapse": "타임랩스 다운로드",
+        "deleteTimelapse": "타임랩스 삭제",
+        "downloadKeogram": "케오그램 다운로드",
+        "deleteKeogram": "케오그램 삭제",
+        "downloadStartrails": "스타트레일 다운로드",
+        "deleteStartrails": "스타트레일 삭제",
+        "downloadItem": "{name} 다운로드",
+        "deleteItem": "{name} 삭제"
+      },
+      "statusModal": {
+        "title": "AllSky 상태",
+        "close": "상태 대화상자 닫기",
+        "updateBackendTooltip": "최신 백엔드 저장소를 받아오고, PINS AllSky 백엔드 플러그인을 재설치한 뒤 PINS를 재시작합니다."
+      },
+      "banners": {
+        "missingRuntimeDependencies": "런타임 종속성 누락: {dependencies}",
+        "backendUnavailableTitle": "AllSky 백엔드에 연결할 수 없음",
+        "backendUnavailableBody": "AllSky 백엔드에 연결할 수 없습니다. Raspberry Pi에 PINS AllSky 백엔드를 설치하고 PINS를 재시작한 뒤 이 페이지를 새로고침하세요.",
+        "backendUnavailableInstallLabel": "SSH로 Pi에 설치:"
+      },
+      "sections": {
+        "sessionControl": "세션 제어",
+        "sessionEstimate": "세션 예상치",
+        "recentSessions": "최근 세션",
+        "recentSessionsDescription": "생성된 결과물은 백엔드에서 직접 제공되며 새 탭에서 열립니다.",
+        "livePreview": "라이브 미리보기",
+        "storedFrames": "저장된 프레임"
+      },
+      "preview": {
+        "noFrameYet": "아직 캡처된 프레임이 없습니다. 세션을 시작하거나 다음 자동 캡처를 기다리세요.",
+        "session": "세션",
+        "noActiveSession": "활성 세션 없음",
+        "lastCapture": "마지막 캡처:",
+        "frameCount": "프레임 수:",
+        "captureInterval": "캡처 간격:",
+        "exposure": "노출:",
+        "gain": "게인:",
+        "mean": "평균:"
+      },
+      "statusRows": {
+        "backend": "백엔드",
+        "session": "세션",
+        "sequence": "시퀀스",
+        "capture": "캡처",
+        "rendering": "렌더링",
+        "piUsed": "사용 중인 Pi",
+        "piAvailable": "사용 가능한 Pi",
+        "pluginUsed": "플러그인 사용량",
+        "pluginLimit": "플러그인 한도",
+        "pluginAvailable": "플러그인 사용 가능량",
+        "online": "온라인",
+        "offline": "오프라인",
+        "running": "실행 중",
+        "idle": "대기 중",
+        "active": "활성",
+        "stopped": "정지됨",
+        "inProgress": "진행 중",
+        "available": "사용 가능",
+        "missing": "없음"
+      },
+      "dependencies": {
+        "rpiCamStill": "rpicam-still",
+        "ffmpeg": "ffmpeg",
+        "keogram": "AllSky 케오그램",
+        "startrails": "AllSky 스타트레일"
+      },
+      "estimate": {
+        "sessionLabelTitle": "다음 수동 캡처에 사용할 세션 라벨. 기본값은 {label}.",
+        "sessionLabelPlaceholder": "세션 라벨",
+        "start": "시작",
+        "end": "종료",
+        "expectedDuration": "예상 소요 시간",
+        "expectedFrames": "예상 프레임 수",
+        "expectedStorage": "예상 저장 용량",
+        "startTooltip": "저장 용량 추정에 사용되는 캡처 시작 예정 시각. 기본값은 현재 로컬 시간.",
+        "endTooltip": "저장 용량 추정에 사용되는 캡처 종료 예정 시각. 기본값은 내일 로컬 시간 08:00.",
+        "invalidWindow": "저장 용량을 추정하려면 올바른 시작/종료 시각을 설정하세요.",
+        "endBeforeStart": "종료 시각은 시작 시각보다 늦어야 합니다.",
+        "noBaseline": "완료된 기준 세션이 아직 없습니다. 저장 용량을 정확히 추정하려면 먼저 세션을 하나 완료하세요.",
+        "piFreeSpace": "Pi 여유 공간 ({size})",
+        "pluginLimitRemaining": "플러그인 한도 잔여량 ({size})",
+        "exceeds": "예상 저장 용량 {size}이(가) {limits}을(를) 초과합니다."
+      },
+      "modals": {
+        "closeDialog": "{title} 대화상자 닫기",
+        "automationInfo": "활성화하면 PINS Advanced API가 활성 시퀀스를 보고하는 즉시 AllSky가 캡처 세션을 시작하고, 시퀀스가 끝나면 캡처를 멈추고 결과물을 자동으로 렌더링합니다.",
+        "cameraRotationInfo": "rpicam-still 회전은 0도 또는 180도로만 제한됩니다.",
+        "startrailMountInfo": "적도의 마운트에서는 카메라가 하늘을 따라 추적할 수 있으므로 스타트레일 출력은 생성되더라도 전형적인 원형 궤적 효과가 나타나지 않을 수 있습니다.",
+        "automation": {
+          "autoStartWithSequence": "시퀀스와 함께 자동 시작",
+          "sequenceTriggeredCapture": "시퀀스 트리거 캡처",
+          "advancedApiEnabled": "Advanced API 활성화됨",
+          "backendMonitoring": "백엔드 모니터링",
+          "protocol": "프로토콜",
+          "sequencePollIntervalSeconds": "시퀀스 폴링 간격 (s)",
+          "sequencePollIntervalHelp": "시퀀스 상태만 폴링합니다. 카메라 프레임 주기는 변경하지 않습니다.",
+          "advancedApiHost": "Advanced API 호스트",
+          "port": "포트",
+          "timeoutSeconds": "타임아웃 (s)",
+          "advancedApiBasePath": "Advanced API 기본 경로",
+          "maxPluginStorageGb": "최대 플러그인 저장 용량 (GB)",
+          "maxPluginStorageHelp": "제한 없음은 0으로 설정하세요.",
+          "protocolTooltip": "PINS가 노출하는 로컬 Advanced API에 접속할 때 사용하는 프로토콜.",
+          "sequencePollTooltip": "AllSky가 PINS/NINA 시퀀스의 시작/정지 여부를 확인하는 주기.",
+          "advancedApiHostTooltip": "PINS Advanced API 서비스의 호스트명 또는 IP 주소.",
+          "portTooltip": "PINS Advanced API 서비스가 사용하는 TCP 포트.",
+          "timeoutTooltip": "Advanced API 요청 하나를 사용 불가로 표시하기 전까지 대기하는 최대 시간.",
+          "advancedApiBasePathTooltip": "Advanced API 엔드포인트를 호출할 때 사용하는 기본 경로 접두사.",
+          "maxPluginStorageTooltip": "PINS AllSky가 플러그인 데이터 디렉터리에서 사용할 수 있는 최대 저장 용량. 제한 없음은 0으로 설정하세요. 한도를 초과하면 백엔드가 완료된 세션 중 가장 오래된 것부터 정리합니다."
+        },
+        "camera": {
+          "intervalSeconds": "간격 (s)",
+          "timeoutSeconds": "타임아웃 (s)",
+          "width": "너비",
+          "height": "높이",
+          "jpegQuality": "JPEG 품질",
+          "warmupMilliseconds": "워밍업 (ms)",
+          "metering": "측광",
+          "awb": "AWB",
+          "denoise": "노이즈 제거",
+          "evCompensation": "EV 보정",
+          "rotation": "회전",
+          "brightness": "밝기",
+          "contrast": "대비",
+          "saturation": "채도",
+          "sharpness": "선명도",
+          "manualExposure": "수동 노출",
+          "shutterMicroseconds": "셔터 (µs)",
+          "manualExposureHelp": "비활성화하면 PINS AllSky가 AllSky 평균 기반 컨트롤러를 사용합니다. Target Mean이 0이면 rpicam-still 노출은 자동으로 유지됩니다.",
+          "manualGain": "수동 게인",
+          "analogGain": "아날로그 게인",
+          "manualGainHelp": "비활성화하면 PINS AllSky가 AllSky 평균 기반 컨트롤러를 사용합니다. Target Mean이 0이면 rpicam-still 게인은 자동으로 유지됩니다.",
+          "horizontalFlip": "좌우 반전",
+          "mirrorOnXAxis": "X축 미러",
+          "verticalFlip": "상하 반전",
+          "mirrorOnYAxis": "Y축 미러",
+          "extraArguments": "추가 rpicam-still 인수",
+          "intervalTooltip": "캡처 시작 간 시간(초). 실제 AllSky 프레임 주기입니다.",
+          "timeoutTooltip": "rpicam-still 캡처 하나를 실패로 처리하기 전까지 허용되는 최대 시간.",
+          "widthTooltip": "캡처되는 각 프레임의 출력 이미지 너비(픽셀).",
+          "heightTooltip": "캡처되는 각 프레임의 출력 이미지 높이(픽셀).",
+          "jpegQualityTooltip": "캡처 프레임에 사용되는 JPEG 품질. 값이 높을수록 디테일이 더 보존되지만 파일 크기가 커집니다.",
+          "warmupTooltip": "각 프레임을 기록하기 전에 rpicam-still에 전달되는 워밍업 시간.",
+          "meteringTooltip": "rpicam-still이 사용하는 노출 측광 방식.",
+          "awbTooltip": "rpicam-still이 사용하는 자동 화이트 밸런스 모드.",
+          "denoiseTooltip": "rpicam-still이 캡처 프레임마다 사용하는 노이즈 제거 모드.",
+          "evCompensationTooltip": "선택한 노출 모드에 추가로 적용되는 노출 값 보정.",
+          "rotationTooltip": "이미지 회전(도). Pi 카메라 스택은 여기서 0 또는 180만 지원합니다.",
+          "brightnessTooltip": "rpicam-still이 적용하는 밝기 조정.",
+          "contrastTooltip": "rpicam-still이 적용하는 대비 배수.",
+          "saturationTooltip": "rpicam-still이 적용하는 채도 배수.",
+          "sharpnessTooltip": "rpicam-still이 적용하는 선명도 배수.",
+          "shutterTooltip": "수동 셔터 시간(마이크로초). 수동 노출이 활성화된 경우에만 적용됩니다.",
+          "analogGainTooltip": "Pi 카메라에 적용되는 수동 아날로그 게인. 수동 게인이 활성화된 경우에만 사용됩니다.",
+          "extraArgumentsTooltip": "관리되는 카메라 설정 뒤에 추가되는 원시 rpicam-still 인수.",
+          "options": {
+            "centre": "중앙",
+            "spot": "스폿",
+            "average": "평균",
+            "custom": "사용자 지정",
+            "auto": "자동",
+            "incandescent": "백열등",
+            "tungsten": "텅스텐",
+            "fluorescent": "형광등",
+            "indoor": "실내",
+            "daylight": "주광",
+            "cloudy": "흐림",
+            "off": "끄기",
+            "cdnOff": "CDN 끄기",
+            "cdnFast": "CDN 빠름",
+            "cdnHq": "CDN 고품질"
+          },
+          "allSkyAutoExposure": "AllSky 자동 노출 / 게인",
+          "allSkyAutoExposureHelp": "AllSky의 평균 기반 컨트롤러를 적용한 방식입니다. 수동 노출 또는 수동 게인이 비활성화되면, PINS AllSky가 이전 프레임을 측정해 rpicam-still 자동 노출에만 의존하지 않고 다음 셔터와 게인을 계산합니다.",
+          "autoMeanTarget": "목표 평균",
+          "autoMeanThreshold": "평균 임계값",
+          "autoMaxExposureMicroseconds": "자동 최대 셔터 (µs)",
+          "autoMaxGain": "자동 최대 게인",
+          "autoMeanP0": "반응도 P0",
+          "autoMeanP1": "반응도 P1",
+          "autoMeanP2": "반응도 P2",
+          "autoMeanTargetTooltip": "AllSky 자동 노출 컨트롤러가 사용하는 목표 정규화 이미지 평균입니다. 0으로 설정하면 rpicam-still 자동 노출로 되돌아갑니다.",
+          "autoMeanThresholdTooltip": "다음 프레임의 노출 단계가 변경되기 전까지 목표 평균으로부터 허용되는 정규화 거리입니다.",
+          "autoMaxExposureTooltip": "수동 노출이 비활성화되었을 때 AllSky 자동 노출 컨트롤러가 사용할 수 있는 최대 셔터 시간입니다.",
+          "autoMaxGainTooltip": "수동 게인이 비활성화되었을 때 AllSky 자동 노출 컨트롤러가 사용할 수 있는 최대 아날로그 게인입니다.",
+          "autoMeanP0Tooltip": "AllSky 컨트롤러 튜닝 상수 p0. 값이 클수록 밝기 변화에 더 적극적으로 반응합니다.",
+          "autoMeanP1Tooltip": "평균 오차에 대한 선형 반응에 사용되는 AllSky 컨트롤러 튜닝 상수 p1입니다.",
+          "autoMeanP2Tooltip": "큰 밝기 오차에 대한 더 강한 2차 반응에 사용되는 AllSky 컨트롤러 튜닝 상수 p2입니다."
+        },
+        "outputs": {
+          "keepSourceFrames": "원본 프레임 유지",
+          "retainOriginalCaptures": "원본 캡처 유지",
+          "timelapse": "타임랩스",
+          "fps": "FPS",
+          "bitrateKbps": "비트레이트 (kbps)",
+          "width": "너비",
+          "height": "높이",
+          "codec": "코덱",
+          "pixelFormat": "픽셀 포맷",
+          "ffmpegLogLevel": "FFmpeg 로그 레벨",
+          "extraFfmpegArguments": "추가 ffmpeg 인자",
+          "keogram": "케오그램",
+          "expandToFrameWidth": "프레임 너비에 맞춰 확장",
+          "stretchOutput": "출력 스트레치",
+          "showLabels": "라벨 표시",
+          "drawCaptions": "캡션 그리기",
+          "showDate": "날짜 표시",
+          "stampDate": "날짜 스탬프",
+          "rotateDegrees": "회전 (도)",
+          "fontName": "글꼴 이름",
+          "fontColor": "글꼴 색상",
+          "fontSize": "글꼴 크기",
+          "lineThickness": "선 두께",
+          "extraKeogramArguments": "추가 케오그램 인자",
+          "startrails": "스타트레일",
+          "brightnessThreshold": "밝기 임계값",
+          "extraStartrailsArguments": "추가 스타트레일 인자",
+          "fpsTooltip": "타임랩스 영상 조립 시 사용되는 재생 프레임레이트입니다.",
+          "bitrateTooltip": "생성되는 타임랩스의 목표 영상 비트레이트입니다(킬로비트/초).",
+          "timelapseWidthTooltip": "렌더링된 타임랩스 영상의 출력 너비(픽셀)입니다.",
+          "timelapseHeightTooltip": "렌더링된 타임랩스 영상의 출력 높이(픽셀)입니다.",
+          "codecTooltip": "타임랩스 출력 인코딩에 사용되는 ffmpeg 영상 코덱입니다.",
+          "pixelFormatTooltip": "타임랩스 출력에 사용되는 ffmpeg 픽셀 포맷입니다.",
+          "ffmpegLogLevelTooltip": "타임랩스 렌더링 시 사용되는 ffmpeg 로그 상세 수준입니다.",
+          "extraFfmpegArgumentsTooltip": "타임랩스 렌더 명령에 추가되는 ffmpeg 인자입니다.",
+          "rotateTooltip": "완성된 케오그램 이미지에 적용되는 회전입니다.",
+          "fontNameTooltip": "AllSky 케오그램 도구에 라벨용으로 전달되는 글꼴 패밀리 이름입니다.",
+          "fontColorTooltip": "케오그램 도구가 사용하는 글꼴 색상이며, 보통 16진수 색상 값입니다.",
+          "fontSizeTooltip": "생성되는 케오그램에 사용되는 라벨 글꼴 크기입니다.",
+          "lineThicknessTooltip": "케오그램 도구가 라벨이나 마커를 그릴 때 사용하는 선 두께입니다.",
+          "extraKeogramArgumentsTooltip": "AllSky 케오그램 도구에 추가되는 명령줄 인자입니다.",
+          "brightnessThresholdTooltip": "픽셀이 스타트레일 합성에 기여하기 위해 도달해야 하는 최소 정규화 밝기입니다.",
+          "extraStartrailsArgumentsTooltip": "AllSky 스타트레일 도구에 추가되는 명령줄 인자입니다.",
+          "overlayTimestamp": "타임스탬프 오버레이",
+          "stampTimestamp": "캡처 타임스탬프 스탬프",
+          "overlayExposureGain": "노출 + 게인 오버레이",
+          "stampExposureGain": "노출과 게인 스탬프",
+          "overlayTimestampTooltip": "캡처된 타임스탬프를 각 타임랩스 프레임에 렌더링합니다. 다음 타임랩스 렌더 시 또는 기존 세션을 다시 생성할 때 적용됩니다.",
+          "overlayExposureGainTooltip": "각 캡처 프레임에 실제 사용된 노출과 게인을 타임랩스에 렌더링합니다. 다음 타임랩스 렌더 시 또는 기존 세션을 다시 생성할 때 적용됩니다."
+        }
+      },
+      "recentSessions": {
+        "noSessions": "아직 완료된 세션이 기록되지 않았습니다.",
+        "expanded": "펼침",
+        "collapsed": "접힘",
+        "storageWithinLimit": "저장 공간 한도 이내입니다.",
+        "storageLimitExceeded": "저장 공간 한도를 초과했습니다.",
+        "pluginAvailable": "사용 가능한 플러그인:",
+        "piAvailable": "사용 가능한 Pi:",
+        "started": "{date} 시작됨",
+        "stopped": "{date} 중지됨",
+        "framesReason": "프레임: {count} • 사유: {reason}",
+        "storage": "저장 용량: {size}",
+        "timelapse": "타임랩스",
+        "keogram": "케오그램",
+        "startrails": "스타트레일",
+        "retainedFrames": "유지된 프레임 {count}개",
+        "loadingStoredFiles": "저장된 파일 불러오는 중…",
+        "noStoredFrames": "이 세션에 사용 가능한 저장된 프레임이 없습니다.",
+        "reasons": {
+          "manualStart": "수동 시작",
+          "manualStop": "수동 중지",
+          "sequenceStart": "시퀀스 시작",
+          "sequenceStop": "시퀀스 중지",
+          "unknown": "알 수 없음"
+        }
+      },
+      "dialogs": {
+        "deleteSession": "{sessionName} 및 캡처된 모든 프레임/산출물을 삭제하시겠습니까?",
+        "deleteAllSessions": "저장된 모든 AllSky 세션, 프레임, 생성된 산출물을 삭제하시겠습니까?",
+        "deleteArtifact": "{artifactName}을(를) 삭제하시겠습니까?",
+        "deleteFrame": "{frameName}을(를) 삭제하시겠습니까?"
+      },
+      "messages": {
+        "noSessionsDeleted": "삭제된 세션이 없습니다.",
+        "deletedSessions": "세션 {count}개{suffix} 삭제됨, {freed} 확보, 남은 플러그인 사용량 {remaining}.",
+        "deletedArtifact": "산출물을 삭제하고 {freed}를 확보했습니다.",
+        "deletedFrame": "프레임을 삭제하고 {freed}를 확보했습니다.",
+        "backendUpdateStarted": "백엔드 업데이트를 시작했습니다. 설치가 완료되면 PINS가 재시작됩니다."
+      },
+      "errors": {
+        "loadStatus": "백엔드 상태를 불러올 수 없습니다.",
+        "loadConfig": "구성을 불러올 수 없습니다.",
+        "connectBackend": "AllSky 백엔드에 연결할 수 없습니다.",
+        "saveConfig": "구성 저장에 실패했습니다.",
+        "startSession": "세션을 시작할 수 없습니다.",
+        "stopSession": "세션을 중지할 수 없습니다.",
+        "generateArtifacts": "산출물을 생성할 수 없습니다.",
+        "deleteSession": "선택한 세션을 삭제할 수 없습니다.",
+        "deleteAllSessions": "저장된 세션을 삭제할 수 없습니다.",
+        "loadSessionDetails": "세션 상세 정보를 불러올 수 없습니다.",
+        "deleteArtifact": "선택한 산출물을 삭제할 수 없습니다.",
+        "deleteFrame": "선택한 프레임을 삭제할 수 없습니다.",
+        "startBackendUpdate": "백엔드 업데이트를 시작할 수 없습니다.",
+        "downloadFailed": "다운로드가 상태 {status}로 실패했습니다.",
+        "downloadFile": "선택한 파일을 다운로드할 수 없습니다.",
+        "refreshStatus": "백엔드 상태를 새로고침할 수 없습니다."
+      }
+    },
+    "targetScheduler": {
+      "title": "타깃 스케줄러",
+      "subtitle": "타깃 가시성, 제약 조건, 시퀀스 삽입을 위한 모바일 우선 계획.",
+      "common": {
+        "add": "추가",
+        "edit": "편집",
+        "copy": "복사",
+        "copySuffix": "복사",
+        "remove": "제거",
+        "close": "닫기",
+        "cancel": "취소",
+        "ra": "RA",
+        "dec": "DEC",
+        "deg": "deg",
+        "seconds": "s",
+        "minutes": "min",
+        "meters": "m"
+      },
+      "actions": {
+        "addTarget": "대상 추가",
+        "addFromFavorites": "즐겨찾기에서 추가",
+        "addScheduleToSequence": "시퀀스에 일정 추가",
+        "applying": "적용 중...",
+        "computing": "계산 중...",
+        "recomputeSchedule": "일정 재계산",
+        "clearAll": "모두 지우기"
+      },
+      "labels": {
+        "sessionStart": "세션 시작",
+        "sessionEnd": "세션 종료",
+        "samplingStepMinutes": "샘플링 간격(분)",
+        "samplingStepInfo": "계산 간격을 분 단위로 정합니다. 값이 작을수록 정밀도가 높아지지만 더 많은 타임라인 지점을 평가합니다.",
+        "maxChunkMinutes": "최대 청크(분)",
+        "maxChunkInfo": "스케줄러가 다른 대상으로 전환하기 전, 대상당 연속으로 예약되는 최대 블록을 제한합니다.",
+        "siteLat": "위도",
+        "siteLon": "경도",
+        "siteAlt": "고도",
+        "scheduled": "예약됨"
+      },
+      "sessionModes": {
+        "time": "시각",
+        "twilightEndNautical": "상용박명 종료(항해)",
+        "twilightEndAstronomical": "상용박명 종료(천문)",
+        "sunSet": "일몰",
+        "moonSet": "월몰",
+        "twilightStartNautical": "박명 시작(항해)",
+        "twilightStartAstronomical": "박명 시작(천문)",
+        "sunRise": "일출",
+        "moonRise": "월출"
+      },
+      "warnings": {
+        "sequenceVersionRequired": "시퀀스 삽입에는 TNS 플러그인 1.2.8.0+ (또는 PINS 모드)가 필요합니다."
+      },
+      "unscheduled": {
+        "title": "예약되지 않은 나머지",
+        "allScheduled": "요청한 모든 노출 시간이 이번 세션에 들어갑니다.",
+        "remaining": ": {minutes}분 남음"
+      },
+      "favorites": {
+        "importTitle": "즐겨찾기에서 가져오기",
+        "available": "사용 가능한 즐겨찾기 {count}개",
+        "addAll": "모두 추가",
+        "noneFound": "즐겨찾기가 없습니다.",
+        "unnamed": "이름 없는 즐겨찾기"
+      },
+      "constraints": {
+        "title": "제약 조건",
+        "showAdvanced": "고급 보기",
+        "hideAdvanced": "고급 숨기기",
+        "targetEnabled": "대상 사용",
+        "minAltitude": "최소 고도",
+        "maxAltitude": "최대 고도",
+        "minMoonSeparation": "최소 달 이격",
+        "minMoonSeparationInfo": "예약하려면 대상과 달 사이에 필요한 최소 각거리입니다.",
+        "maxMoonAltitude": "최대 달 고도",
+        "maxMoonAltitudeHint": "0° 이하로 설정하면 달이 지평선 아래에 있을 때만 예약합니다.",
+        "timeWindowStart": "시간 창 시작",
+        "timeWindowEnd": "시간 창 종료",
+        "timeWindowHint": "시간 창을 비워두면 전체 세션 범위에서 예약할 수 있습니다."
+      },
+      "timeline": {
+        "title": "세션 타임라인",
+        "range": "{start} ~ {end}",
+        "invalidSessionRange": "일정을 미리 보려면 유효한 세션 범위를 설정하세요.",
+        "noSegments": "아직 일정 구간이 없습니다. 대상 제약 조건과 관측지 좌표를 확인하세요.",
+        "minutesShort": "{value}분",
+        "segmentTitle": "{name}: {start} - {end}",
+        "idle": "대기",
+        "idleSegmentTitle": "대기: {start} - {end}"
+      },
+      "targetList": {
+        "title": "대상",
+        "total": "총 {count}개",
+        "empty": "아직 대상이 없습니다. 직접 추가하거나 즐겨찾기에서 가져오세요.",
+        "dragToReorder": "드래그하여 순서 변경"
+      },
+      "targetCard": {
+        "priorityShort": "P{value}",
+        "exposures": "노출 {count}회",
+        "favoriteLinked": "즐겨찾기 연결됨",
+        "scheduledVsRequested": "{scheduled} / {requested}분"
+      },
+      "editor": {
+        "newTarget": "새 대상",
+        "editTarget": "대상 편집",
+        "name": "이름",
+        "namePlaceholder": "M31 - 안드로메다",
+        "priority": "우선순위",
+        "raLabel": "RA (deg 또는 HH:MM:SS)",
+        "raPlaceholder": "00:42:44",
+        "decLabel": "DEC (deg 또는 +/-DD:MM:SS)",
+        "decPlaceholder": "+41:16:07",
+        "rotation": "회전",
+        "linkedToFavorite": "즐겨찾기에 연결됨",
+        "exposurePlan": "노출 계획",
+        "addExposure": "노출 추가",
+        "addAtLeastOneExposure": "노출 항목을 하나 이상 추가하세요.",
+        "exposureRow": "노출 {index}",
+        "filter": "필터",
+        "imageType": "이미지 종류",
+        "duration": "노출 시간",
+        "gain": "게인",
+        "count": "횟수",
+        "offset": "오프셋",
+        "binning": "비닝",
+        "saveTarget": "대상 저장",
+        "presets": {
+          "singleL": "Single L",
+          "lrgb": "LRGB",
+          "sho": "SHO"
+        },
+        "imageTypes": {
+          "light": "LIGHT",
+          "dark": "DARK",
+          "flat": "FLAT",
+          "bias": "BIAS"
+        }
+      },
+      "toast": {
+        "title": "Target Scheduler",
+        "noTargetsToApply": "적용할 대상이 없습니다.",
+        "addedTargetsToSequence": "시퀀스에 대상 {count}개를 추가했습니다."
+      },
+      "defaults": {
+        "newTargetName": "새 대상",
+        "favoriteTargetName": "즐겨찾기 대상",
+        "targetName": "대상"
+      },
+      "errors": {
+        "invalidRaFormat": "RA 형식이 올바르지 않습니다.",
+        "invalidDecFormat": "DEC 형식이 올바르지 않습니다.",
+        "targetNameRequired": "대상 이름이 필요합니다.",
+        "invalidSessionRange": "유효하지 않은 세션 범위",
+        "missingSiteCoordinates": "관측지 위도/경도가 없습니다",
+        "computeFailed": "일정 계산에 실패했습니다",
+        "couldNotAddSequenceItem": "시퀀스 항목을 추가할 수 없습니다",
+        "failedToAddSequenceTarget": "{name}의 시퀀스 대상 추가에 실패했습니다",
+        "failedToResolveTargetContainer": "{name}에 대해 새로 생성된 대상 컨테이너를 확인하지 못했습니다",
+        "noActiveSequenceLoaded": "활성 시퀀스가 로드되지 않았습니다.",
+        "noImagingContainerFound": "활성 시퀀스에서 촬영 컨테이너를 찾을 수 없습니다.",
+        "noValidTargetsForExport": "내보낼 유효한 대상이 없습니다.",
+        "failedToApplySchedule": "시퀀스에 일정을 적용하지 못했습니다."
+      }
+    },
+    "filterOffset": {
+      "title": "필터 오프셋 계산기",
+      "subtitle": "각 필터휠 필터의 포커스 오프셋을 계산하고 저장합니다",
+      "iterations": "반복 횟수",
+      "selectFilters": "필터 선택",
+      "noFilters": "프로필에 사용 가능한 필터가 없습니다",
+      "calculate": "계산",
+      "position": "위치",
+      "filter": "필터",
+      "offset": "오프셋",
+      "minTwoFilters": "필터를 최소 2개 선택해야 합니다",
+      "start": "계산 시작",
+      "stop": "정지",
+      "loop": "루프",
+      "filterProgress": "필터",
+      "runningFilter": "현재 필터",
+      "currentOffsets": "현재 오프셋",
+      "newOffsets": "새 오프셋",
+      "useRelativeOffsets": "상대 오프셋 사용",
+      "currentAutoFocusFilter": "현재 오토포커스 필터",
+      "newAutoFocusFilter": "새 오토포커스 필터",
+      "none": "없음",
+      "accept": "적용",
+      "abort": "중단",
+      "errorLabel": "오류",
+      "notConnected": "{device}이(가) 연결되지 않았습니다",
+      "deviceCamera": "카메라",
+      "deviceFocuser": "포커서",
+      "deviceFilterWheel": "필터휠"
+    },
+    "phd2logviewer": {
+      "title": "PHD2 로그 뷰어",
+      "subtitle": "PHD2 가이드 로그를 선택하여 가이딩 성능과 통계를 확인하세요.",
+      "loading": "로딩 중…",
+      "selectLog": "— 로그 선택 —",
+      "noLogs": "로그를 찾을 수 없습니다",
+      "refresh": "로그 목록 새로고침",
+      "clear": "지우기",
+      "session": "세션:",
+      "excludeDither": "디더 정착 자동 제외",
+      "rawRa": "원본 RA(보정 안 됨)",
+      "emptyState": "위의 드롭다운에서 PHD2 가이드 로그를 선택하세요.",
+      "tabs": {
+        "guide": "가이드 그래프",
+        "calibration": "캘리브레이션"
+      },
+      "legend": {
+        "ra": "RA",
+        "raRaw": "RA (원본)",
+        "dec": "Dec",
+        "dither": "디더"
+      },
+      "info": {
+        "started": "세션 시작",
+        "ended": "종료",
+        "duration": "지속 시간",
+        "camera": "카메라",
+        "mount": "마운트",
+        "focalLength": "초점 거리",
+        "pixelScale": "픽셀 스케일",
+        "profile": "프로필",
+        "totalFrames": "전체 프레임"
+      },
+      "statistics": "통계",
+      "stats": {
+        "totalRms": "전체 RMS",
+        "raRms": "RA RMS",
+        "decRms": "Dec RMS",
+        "peakRa": "RA 최대",
+        "peakDec": "Dec 최대",
+        "frames": "프레임",
+        "combined": "합산",
+        "rightAscension": "적경",
+        "declination": "적위",
+        "maxError": "최대 오차",
+        "of": "/ {total}"
+      },
+      "fft": {
+        "title": "RA 주파수 분석",
+        "subtitle": "RA 가이딩의 주기 오차 고조파를 식별합니다.",
+        "dominantPeriod": "주요 주기"
+      },
+      "cal": {
+        "axis": "축",
+        "angle": "각도 (°)",
+        "rate": "속도 (px/s)",
+        "parity": "패리티",
+        "steps": "스텝",
+        "dist": "거리 (px)",
+        "backlash": "백래시",
+        "over": "기간",
+        "noSummary": "요약 데이터 없음 (캘리브레이션이 중단되었을 수 있음)",
+        "noData": "이 세션에 대한 캘리브레이션 데이터가 없습니다."
+      },
+      "settings": {
+        "title": "로그 디렉터리",
+        "placeholder": "경로가 설정되지 않음",
+        "notConfigured": "PHD2 로그 디렉터리를 설정하세요",
+        "saveError": "경로를 저장하지 못했습니다"
+      }
+    },
+    "supernovae": {
+      "title": "초신성",
+      "source": "출처: Rochester Astronomy 활성 SN 목록",
+      "updated": "{d} 업데이트됨",
+      "download": "다운로드",
+      "downloading": "다운로드 중…",
+      "noData": "로드된 데이터가 없습니다. 다운로드를 클릭하여 현재 활성 초신성 목록을 가져오세요.",
+      "filterMag": "최대 등급",
+      "filterType": "유형",
+      "filterTypePlaceholder": "예: Ia",
+      "filterYear": "연도",
+      "filterConstellation": "별자리",
+      "filterAll": "전체",
+      "filterNewOnly": "신규만",
+      "filterVisibleOnly": "오늘 밤 관측 가능",
+      "visibleHint": "NINA 프로필의 관측자 위치 기준",
+      "visibleNoLocation": "관측자 위치 없음 — NINA 프로필에서 위치를 설정하세요",
+      "sortBy": "정렬 기준",
+      "sortLatestMag": "최신 등급 (밝은 순)",
+      "sortFirstObserved": "발견 날짜 (최신순)",
+      "sortLastObserved": "마지막 관측 (최신순)",
+      "showing": "{total}개 중 {n}개 표시",
+      "newCount": "신규 {n}개",
+      "colName": "이름",
+      "colType": "유형",
+      "colLatestMag": "최신 등급",
+      "colMaxMag": "최대 등급",
+      "colDiscovered": "발견일",
+      "colLastObs": "마지막 관측",
+      "colConstellation": "별자리",
+      "colHost": "모은하",
+      "colRA": "RA",
+      "colDec": "Dec",
+      "frame": "프레임",
+      "frameTitle": "프레이밍 어시스턴트로 보내기",
+      "fav": "즐겨찾기",
+      "favTitle": "즐겨찾기에 추가",
+      "favAdded": "{name}을(를) 즐겨찾기에 추가함",
+      "favError": "즐겨찾기 추가 실패",
+      "visCircumpolar": "주극성 — 항상 지평선 위",
+      "visVisible": "오늘 밤 관측 가능",
+      "visHidden": "오늘 밤 지평선 아래",
+      "page": "{n} / {total}"
+    },
+    "vncRemote": {
+      "debugModeWarning": "디버그 모드가 활성화되어 있어 VNC 연결을 사용할 수 없습니다. 설정에서 디버그 모드를 끄세요."
+    }
+  },
+  "pinsDevices": {
+    "title": "PINS 장치",
+    "powerBox": "PINS.PowerBox",
+    "meteoStation": "PINS.MeteoStation",
+    "configurationTab": "구성",
+    "generalTab": "일반",
+    "wifiTab": "WiFi",
+    "powerPortsTab": "전원 포트",
+    "dewPortsTab": "이슬방지 포트",
+    "adjustablePowerTab": "조정 가능 전원",
+    "weatherTab": "날씨",
+    "usbPortsTab": "USB 포트",
+    "settings": {
+      "title": "설정",
+      "temperature": "온도",
+      "humidity": "습도",
+      "dewPoint": "이슬점",
+      "placeholders": {
+        "networkName": "네트워크 이름",
+        "password": "비밀번호",
+        "passwordHint": "비밀번호 힌트"
+      },
+      "validation": {
+        "passwordRequired": "비밀번호를 입력하세요"
+      }
+    },
+    "ports": {
+      "disableOnStartup": "시작 시 비활성화",
+      "enableOnStartup": "시작 시 활성화",
+      "alwaysEnabled": "항상 활성화",
+      "status": "상태",
+      "current": "전류",
+      "currentVoltage": "현재 전압",
+      "currentPower": "현재 전력",
+      "outputVoltage": "출력 전압",
+      "powerLevel": "전력 레벨",
+      "defaultVoltage": "기본 전압"
+    },
+    "dew": {
+      "status": "상태",
+      "autoMode": "자동 모드",
+      "disableAutoMode": "자동 모드 끄기",
+      "enableAutoMode": "자동 모드 켜기",
+      "probeTemperature": "프로브 온도",
+      "current": "전류",
+      "maxCurrent": "최대 전류",
+      "currentPower": "현재 전력",
+      "autoThreshold": "자동 임계값",
+      "autoThresholdDisplay": "자동 임계값",
+      "autoThresholdDescription": "온도가 이슬점에 가까워지면 이슬방지 히터를 자동으로 가열",
+      "powerLevel": "전력 레벨"
+    },
+    "power": {
+      "buckConverter": "벅 컨버터",
+      "pwmOutput": "PWM 출력"
+    },
+    "general": {
+      "rail12v": "12V 라인",
+      "rail5v": "5V 라인",
+      "averageAmps": "평균 전류(A)",
+      "ampsPerHour": "시간당 전류(Ah)",
+      "wattsPerHour": "시간당 전력(Wh)"
+    },
+    "weather": {
+      "luxUnit": "Lux"
+    },
+    "errors": {
+      "failedRenamePort": "포트 이름 변경 실패",
+      "failedTogglePort": "포트 전환 실패",
+      "failedToggleBootState": "부팅 상태 전환 실패",
+      "failedToggleAutoMode": "자동 모드 전환 실패",
+      "failedSetPowerLevel": "전력 레벨 설정 실패"
+    }
+  },
+  "dialogs": {
+    "plateSolving": {
+      "time": "시간",
+      "status": "상태",
+      "error": "오차 거리",
+      "rotation": "회전"
+    }
+  },
+  "loading": "로딩 중",
+  "observationPlaner": {
+    "title": "관측 플래너",
+    "subtitle": "오늘 밤 미리보기 + 고도 지도가 포함된 즐겨찾기 (위치 기반)",
+    "sections": {
+      "tonightPicks": "오늘 밤 추천",
+      "topForWindow": "선택한 시간대의 추천 대상",
+      "preview": "미리보기",
+      "framing": "프레이밍"
+    },
+    "filters": {
+      "title": "필터",
+      "search": "검색",
+      "search_placeholder": "M42, 안드로메다, NGC...",
+      "timeWindow": "시간대",
+      "startLocal": "시작 (현지)",
+      "endLocal": "종료 (현지)",
+      "moon": "달",
+      "objectType": "대상 유형",
+      "azSector": "하늘 방향 (방위각 구역)",
+      "onlyAboveHorizon": "고도 >0°만",
+      "limit": "제한"
+    },
+    "sort": {
+      "title": "정렬",
+      "nameAZ": "이름 A→Z",
+      "maxAltDesc": "최대 고도 ↓",
+      "bestTimeAsc": "최적 시간 ↑",
+      "bestTime": "최적 시간",
+      "maxAltWindow": "최대 고도 (구간)",
+      "visible": "관측 가능?"
+    },
+    "location": {
+      "title": "위치",
+      "get": "위치 가져오기",
+      "notAvailable": "사용 가능한 위치 없음",
+      "hintNoLocation": "참고: 위치가 없으면 고도/방향 필터와 차트를 계산할 수 없습니다."
+    },
+    "performance": {
+      "title": "표시 / 성능",
+      "lazyPreviews": "미리보기 지연 로드",
+      "redraw": "다시 그리기"
+    },
+    "buttons": {
+      "refresh": "새로고침",
+      "reload": "다시 불러오기",
+      "slew": "슬루",
+      "center": "센터링",
+      "slewNoCenter": "슬루 (센터링 없음)",
+      "slewCenter": "슬루 + 센터링",
+      "slewCenterPlatesolve": "슬루 + 센터링 (플레이트 솔브)",
+      "sendToSequencer": "시퀀서로 보내기",
+      "openFraming": "프레이밍 어시스턴트 열기",
+      "seqShort": "시퀀스"
+    },
+    "preview": {
+      "noImage": "이미지 없음",
+      "unavailable": "미리보기를 사용할 수 없음",
+      "info": "미리보기 정보",
+      "reload": "미리보기 다시 불러오기"
+    },
+    "cache": {
+      "useNinaCache": "대상 이미지에 NINA 캐시 사용",
+      "hint": "TNS WebAPI를 통해 DSS/대상 사진을 불러옵니다. 캐시 토글이 useCache를 제어합니다.",
+      "hintShort": "useCache를 targetpic에 전달"
+    },
+    "chart": {
+      "altitudeVsTime": "고도 대 시간",
+      "sampleMin": "샘플 (분)",
+      "directionAz": "방향 (방위각)",
+      "separation": "이격 —"
+    },
+    "sectors": {
+      "N_NE": "북 → 북동 (315°–45°)",
+      "NE_E": "북동 → 동 (45°–90°)",
+      "E_SE": "동 → 남동 (90°–135°)",
+      "SE_S": "남동 → 남 (135°–180°)",
+      "S_SW": "남 → 남서 (180°–225°)",
+      "SW_W": "남서 → 서 (225°–270°)",
+      "W_NW": "서 → 북서 (270°–315°)",
+      "NW_N": "북서 → 북 (315°–360°)",
+      "all": "전체"
+    },
+    "common": {
+      "yes": "예",
+      "no": "아니오",
+      "loading": "불러오는 중…",
+      "all": "전체"
+    },
+    "tooltips": {
+      "favorite": "즐겨찾기",
+      "refreshFavorites": "즐겨찾기 새로고침 및 재계산",
+      "filterNoBelowHorizon": "maxAlt <= 0°인 대상 필터링",
+      "filterAzSector": "bestAzDeg(관측 구간 내 최고 고도에서의 방위각)로 필터링",
+      "gpsUpdate": "GPS 위치 업데이트",
+      "openFramingFmt": "프레이밍 열기 · {ra} / {dec} · MaxAlt {maxAlt}°",
+      "tonightScoreFmt": "오늘 밤 점수: {score} · MaxAlt {maxAlt}° · {hours}시간",
+      "redrawChart": "차트 다시 그리기",
+      "lazyVisibleOnly": "보이는 카드만 불러오기",
+      "useCacheHint": "targetpic에 useCache 전달",
+      "previewReload": "미리보기 새로고침"
+    },
+    "empty": {
+      "noFavorites": "즐겨찾기가 없습니다."
+    },
+    "status": {
+      "sendingToSequencer": "시퀀서로 대상 전송 중…",
+      "sequencerTargetSet": "시퀀서 대상 설정됨"
+    },
+    "errors": {
+      "noSequenceAvailable": "사용 가능한 시퀀스가 없습니다. 먼저 시퀀스를 불러오세요",
+      "sequencerFailed": "시퀀서 실패"
+    }
+  },
+  "nightsummary": {
+    "title": "야간 요약",
+    "notAvailable": "야간 요약 플러그인이 감지되지 않았습니다. 이 페이지를 사용하려면 Night Summary NINA 플러그인을 설치하세요.",
+    "tnsPluginToOld": "이 기능을 사용하기에는 Touch N Stars 플러그인이 너무 오래되었습니다. 버전 1.2.8.0 이상으로 업데이트하세요.",
+    "tabSettings": "설정",
+    "tabSessions": "세션",
+    "settings": {
+      "reportContent": "보고서 내용",
+      "detailLevel": "상세 수준",
+      "detailSnapshot": "스냅샷",
+      "detailStandard": "표준",
+      "detailFull": "전체",
+      "showTsProgressBars": "TS 진행률 표시줄 표시",
+      "showNextNightPreview": "오늘 밤 미리보기 표시",
+      "showOverheadBreakdown": "천정 분석 표시",
+      "showSkyThumbnails": "하늘 썸네일 표시",
+      "showLiveStackImages": "라이브스택 이미지 표시",
+      "showAltitudeChart": "고도 차트 표시",
+      "showMoonCurve": "달 곡선 표시",
+      "showMinAltitude": "최저 고도 표시",
+      "showStarCountCV": "별 개수 CV 표시",
+      "showPerTargetIQ": "대상별 이미지 품질 표시",
+      "showMetricChart": "지표 차트 표시",
+      "showChartAfMarkers": "오토포커스 마커 표시",
+      "showChartFlipMarkers": "자오선 반전(meridian flip) 마커 표시",
+      "showChartRoofMarkers": "지붕 이벤트 마커 표시",
+      "chartXAxis": "X축",
+      "chartPrimary": "주요 지표",
+      "chartSecondary": "보조 지표",
+      "showSessionHistory": "세션 기록 표시",
+      "expandSectionsDefault": "기본적으로 섹션 펼치기",
+      "lightModeReport": "라이트 모드 보고서",
+      "filterClassifications": "분류 필터",
+      "filterClassificationsHint": "NINA 프로필의 필터입니다. 자동은 첫 글자 매칭을 사용합니다(L,R,G,B = 광대역; H,S,O = 협대역).",
+      "filterAuto": "자동",
+      "filterBroadband": "광대역",
+      "filterNarrowband": "협대역",
+      "filterExclude": "제외",
+      "equipmentProfile": "장비 프로필",
+      "showEquipmentProfile": "보고서에 장비 섹션 표시",
+      "equipmentHint": "각 장치의 표시 여부를 전환하고 자동 감지된 이름을 재정의합니다.",
+      "equipmentOverridePlaceholder": "이름 재정의 (선택 사항)",
+      "fileNaming": "보고서 파일 이름 지정",
+      "filePattern": "파일 이름 패턴",
+      "filePatternHint": "모든 전송 채널에 적용됩니다. 로컬 저장 시 하위 디렉터리를 만들려면 \\를 사용하세요.",
+      "saveReportLocally": "보고서 로컬 저장",
+      "savePath": "저장 경로",
+      "savePathPlaceholder": "기본 위치를 사용하려면 비워 두세요",
+      "emailTitle": "이메일 보고서 설정",
+      "emailEnabled": "이메일 보고서 사용",
+      "emailOtherProvider": "다른 제공업체",
+      "emailSender": "보내는 사람 이메일",
+      "emailPassword": "앱 비밀번호",
+      "emailRecipient": "받는 사람 이메일 주소",
+      "smtpServer": "SMTP 서버",
+      "smtpPort": "포트",
+      "smtpSsl": "TLS/SSL 사용",
+      "testEmail": "테스트 이메일 보내기",
+      "pushoverTitle": "Pushover 알림",
+      "pushoverEnabled": "Pushover 사용",
+      "pushoverAppToken": "앱 토큰",
+      "pushoverUserKey": "사용자 키",
+      "testPushover": "테스트 알림 보내기",
+      "discordTitle": "Discord 알림",
+      "discordEnabled": "Discord 사용",
+      "discordWebhook": "웹훅 URL",
+      "testDiscord": "테스트 메시지 보내기",
+      "localDashboardTitle": "로컬 대시보드",
+      "localDashboardEnabled": "로컬 웹 서버 사용",
+      "localDashboardPort": "포트",
+      "localDashboardHint": "네트워크의 모든 브라우저에서 접근할 수 있는 로컬 웹 서버에서 세션 기록을 제공합니다. 원격 접속에는 VPN을 사용하세요.",
+      "showChartTargetChips": "대상 칩 줄 표시",
+      "showChartFilterChips": "필터 칩 줄 표시"
+    },
+    "sessions": {
+      "placeholder": "세션 선택…",
+      "loading": "세션 불러오는 중…",
+      "noSessions": "선택된 세션이 없습니다. 드롭다운에서 세션을 선택하세요.",
+      "resend": "보고서 다시 보내기",
+      "delete": "삭제",
+      "deleteTitle": "세션 삭제",
+      "deleteConfirm": "이 세션을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+    },
+    "stats": {
+      "totalImages": "전체 이미지",
+      "accepted": "승인됨",
+      "totalTime": "총 시간",
+      "targets": "대상",
+      "avgHfr": "평균 HFR",
+      "byTarget": "대상별",
+      "target": "대상",
+      "images": "이미지",
+      "exposure": "노출"
+    }
+  },
+  "indi": {
+    "config": {
+      "connectionMode": "연결 모드",
+      "serial": "시리얼",
+      "network": "네트워크",
+      "devicePort": "장치 포트",
+      "baudRate": "보드레이트",
+      "autoDetect": "자동 검색",
+      "ipAddress": "IP 주소",
+      "tcpPort": "TCP 포트",
+      "selectPort": "-- 포트 선택 --"
+    }
+  },
+  "nav": {
+    "equipment": "장비",
+    "camera": "카메라",
+    "autofocus": "포커스",
+    "mount": "마운트",
+    "dome": "돔",
+    "flatDevice": "플랫",
+    "switch": "스위치",
+    "filterWheel": "필터",
+    "rotator": "로테이터",
+    "guider": "가이더",
+    "sequence": "시퀀스",
+    "monitoring": "모니터",
+    "flatWizard": "플랫",
+    "framing": "프레이밍",
+    "skyView": "Stellarium",
+    "settings": "설정",
+    "about": "정보"
+  }
+}


### PR DESCRIPTION
- Add src/locales/ko.json: full translation of all 3,383 strings from en.json src/locales/ko.json 신규 추가: en.json 기준 3,383개 문자열 전체 번역
- Register Korean in src/i18n.js (import, languageToBackendCode ko-KR, availableLanguages "한국어", messages) src/i18n.js에 한국어 등록 (import, languageToBackendCode ko-KR, availableLanguages "한국어", messages)
- Keep common astrophotography/NINA terms (guiding, plate solve, dithering, sequence, etc.) 천체촬영/NINA 용어는 통용 표기 유지 (가이딩, 플레이트 솔브, 디더링, 시퀀스 등)
- Preserve {placeholders} and HTML tags; passes i18n:check (0 empty values, 0 placeholder mismatches) {placeholder}·HTML 태그 보존, i18n:check 통과 (빈 값/플레이스홀더 불일치 0)