### PR TITLE
fix(target-scheduler): support "now" start mode and editable end date without forced +1 day

### DIFF
--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -3651,6 +3651,7 @@
       },
       "sessionModes": {
         "time": "Zeit",
+        "now": "Jetzt",
         "twilightEndNautical": "Nautische Daemmerung Ende",
         "twilightEndAstronomical": "Astronomische Daemmerung Ende",
         "sunSet": "Sonnenuntergang",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -3645,6 +3645,7 @@
       },
       "sessionModes": {
         "time": "Time",
+        "now": "Now",
         "twilightEndNautical": "Twilight end nautical",
         "twilightEndAstronomical": "Twilight end astronomical",
         "sunSet": "Sun set",

--- a/src/plugins/target-scheduler/composables/useTargetScheduler.js
+++ b/src/plugins/target-scheduler/composables/useTargetScheduler.js
@@ -62,16 +62,20 @@ function defaultSessionEnd() {
 }
 
 function toInputDateTimeOrFallback(value, fallbackDate) {
-  const parsed = new Date(value);
+  const parsed = new Date(value || undefined);
   return Number.isNaN(parsed.getTime()) ? toInputDateTime(fallbackDate) : toInputDateTime(parsed);
 }
 
 function resolveInitialSessionInputs(persisted) {
   const fallbackStart = defaultSessionStart();
   const fallbackEnd = defaultSessionEnd();
+  const startInput =
+    persisted?.sessionStartMode === 'now'
+      ? toInputDateTime(new Date())
+      : toInputDateTimeOrFallback(persisted?.sessionStartInput, fallbackStart);
 
   return {
-    sessionStartInput: toInputDateTimeOrFallback(persisted?.sessionStartInput, fallbackStart),
+    sessionStartInput: startInput,
     sessionEndInput: toInputDateTimeOrFallback(persisted?.sessionEndInput, fallbackEnd),
   };
 }
@@ -88,8 +92,9 @@ function getDateOnlyOrToday(value) {
 }
 
 function resolveNightDateFromInput(value, mode, overnightModes) {
-  const nightDate = getDateOnlyOrToday(value);
-  const parsed = new Date(value);
+  const normalizedInput = value || undefined;
+  const nightDate = getDateOnlyOrToday(normalizedInput);
+  const parsed = new Date(normalizedInput);
 
   if (overnightModes.has(mode) && !Number.isNaN(parsed.getTime()) && parsed.getHours() < 12) {
     nightDate.setDate(nightDate.getDate() - 1);

--- a/src/plugins/target-scheduler/composables/useTargetScheduler.js
+++ b/src/plugins/target-scheduler/composables/useTargetScheduler.js
@@ -22,6 +22,7 @@ const ALTITUDE_CONDITION_TYPE = 'NINA.Sequencer.Conditions.AltitudeCondition';
 
 const SESSION_START_MODE_VALUES = Object.freeze([
   'time',
+  'now',
   'twilight_end_nautical',
   'twilight_end_astronomical',
   'sun_set',
@@ -60,45 +61,18 @@ function defaultSessionEnd() {
   return d;
 }
 
-function getHoursMinutesOrFallback(value, fallbackDate) {
+function toInputDateTimeOrFallback(value, fallbackDate) {
   const parsed = new Date(value);
-  if (Number.isNaN(parsed.getTime())) {
-    return {
-      hours: fallbackDate.getHours(),
-      minutes: fallbackDate.getMinutes(),
-    };
-  }
-
-  return {
-    hours: parsed.getHours(),
-    minutes: parsed.getMinutes(),
-  };
-}
-
-function buildTodayAt(hours, minutes) {
-  const d = new Date();
-  d.setHours(hours, minutes, 0, 0);
-  return d;
+  return Number.isNaN(parsed.getTime()) ? toInputDateTime(fallbackDate) : toInputDateTime(parsed);
 }
 
 function resolveInitialSessionInputs(persisted) {
   const fallbackStart = defaultSessionStart();
   const fallbackEnd = defaultSessionEnd();
 
-  const startHm = getHoursMinutesOrFallback(persisted?.sessionStartInput, fallbackStart);
-  const endHm = getHoursMinutesOrFallback(persisted?.sessionEndInput, fallbackEnd);
-
-  const start = buildTodayAt(startHm.hours, startHm.minutes);
-  const end = buildTodayAt(endHm.hours, endHm.minutes);
-
-  // Preserve overnight sessions by moving end to next day when needed.
-  if (end <= start) {
-    end.setDate(end.getDate() + 1);
-  }
-
   return {
-    sessionStartInput: toInputDateTime(start),
-    sessionEndInput: toInputDateTime(end),
+    sessionStartInput: toInputDateTimeOrFallback(persisted?.sessionStartInput, fallbackStart),
+    sessionEndInput: toInputDateTimeOrFallback(persisted?.sessionEndInput, fallbackEnd),
   };
 }
 
@@ -111,6 +85,17 @@ function getDateOnlyOrToday(value) {
   const out = Number.isNaN(parsed.getTime()) ? new Date() : new Date(parsed);
   out.setHours(0, 0, 0, 0);
   return out;
+}
+
+function resolveNightDateFromInput(value, mode, overnightModes) {
+  const nightDate = getDateOnlyOrToday(value);
+  const parsed = new Date(value);
+
+  if (overnightModes.has(mode) && !Number.isNaN(parsed.getTime()) && parsed.getHours() < 12) {
+    nightDate.setDate(nightDate.getDate() - 1);
+  }
+
+  return nightDate;
 }
 
 function buildDateWithInputTime(baseDate, inputValue, fallbackDate) {
@@ -126,7 +111,7 @@ function buildDateWithInputTime(baseDate, inputValue, fallbackDate) {
 function resolveStartDateForMode(mode, events, nightDate, currentInput) {
   const manualStart = buildDateWithInputTime(nightDate, currentInput, defaultSessionStart());
 
-  if (mode === 'time') return manualStart;
+  if (mode === 'time' || mode === 'now') return manualStart;
   if (mode === 'twilight_end_nautical') return events.nauticalDusk || manualStart;
   if (mode === 'twilight_end_astronomical') return events.astronomicalDusk || manualStart;
   if (mode === 'sun_set') return events.sunSet || manualStart;
@@ -136,10 +121,7 @@ function resolveStartDateForMode(mode, events, nightDate, currentInput) {
 }
 
 function resolveEndDateForMode(mode, events, nightDate, currentInput) {
-  const morningDate = new Date(nightDate);
-  morningDate.setDate(morningDate.getDate() + 1);
-
-  const manualEnd = buildDateWithInputTime(morningDate, currentInput, defaultSessionEnd());
+  const manualEnd = buildDateWithInputTime(nightDate, currentInput, defaultSessionEnd());
 
   if (mode === 'time') return manualEnd;
   if (mode === 'twilight_start_nautical') return events.nauticalDawn || manualEnd;
@@ -383,29 +365,38 @@ export function useTargetScheduler() {
       return;
     }
 
-    const nightDate = getDateOnlyOrToday(sessionStartInput.value);
-    const events = computeNightSessionEvents({
-      nightDate,
+    const startNightDate = resolveNightDateFromInput(
+      sessionStartInput.value,
+      sessionStartMode.value,
+      new Set(['twilight_end_nautical', 'twilight_end_astronomical', 'sun_set', 'moon_set'])
+    );
+    const endNightDate = resolveNightDateFromInput(
+      sessionEndInput.value,
+      sessionEndMode.value,
+      new Set(['twilight_start_nautical', 'twilight_start_astronomical', 'sun_rise', 'moon_rise'])
+    );
+
+    const startEvents = computeNightSessionEvents({
+      nightDate: startNightDate,
+      location: location.value,
+    });
+    const endEvents = computeNightSessionEvents({
+      nightDate: endNightDate,
       location: location.value,
     });
 
     const nextStart = resolveStartDateForMode(
       sessionStartMode.value,
-      events,
-      nightDate,
+      startEvents,
+      startNightDate,
       sessionStartInput.value
     );
-    let nextEnd = resolveEndDateForMode(
+    const nextEnd = resolveEndDateForMode(
       sessionEndMode.value,
-      events,
-      nightDate,
+      endEvents,
+      endNightDate,
       sessionEndInput.value
     );
-
-    if (nextEnd <= nextStart) {
-      nextEnd = new Date(nextEnd);
-      nextEnd.setDate(nextEnd.getDate() + 1);
-    }
 
     const nextStartInput = toInputDateTime(nextStart);
     const nextEndInput = toInputDateTime(nextEnd);
@@ -837,6 +828,14 @@ export function useTargetScheduler() {
   }
 
   let recomputeTimer = null;
+  watch(sessionStartMode, (nextMode, prevMode) => {
+    if (nextMode === 'now' && prevMode !== 'now') {
+      isSyncingSessionInputs = true;
+      sessionStartInput.value = toInputDateTime(new Date());
+      isSyncingSessionInputs = false;
+    }
+  });
+
   watch(
     [
       sessionStartMode,
@@ -844,6 +843,7 @@ export function useTargetScheduler() {
       () => location.value.latitude,
       () => location.value.longitude,
       sessionStartInput,
+      sessionEndInput,
     ],
     () => {
       if (isSyncingSessionInputs) return;

--- a/src/plugins/target-scheduler/services/TargetSchedulerService.js
+++ b/src/plugins/target-scheduler/services/TargetSchedulerService.js
@@ -366,6 +366,10 @@ export function computeNightSessionEvents({ nightDate, location }) {
   const eveningStart = new Date(base);
   eveningStart.setHours(12, 0, 0, 0);
 
+  const nextNoon = new Date(base);
+  nextNoon.setDate(nextNoon.getDate() + 1);
+  nextNoon.setHours(12, 0, 0, 0);
+
   const midnight = new Date(base);
   midnight.setDate(midnight.getDate() + 1);
   midnight.setHours(0, 0, 0, 0);
@@ -381,7 +385,7 @@ export function computeNightSessionEvents({ nightDate, location }) {
       thresholdDeg: sunThreshold,
       direction: 'descending',
       start: eveningStart,
-      end: midnight,
+      end: nextNoon,
       location,
     }),
     nauticalDusk: findAltitudeCrossing({
@@ -389,7 +393,7 @@ export function computeNightSessionEvents({ nightDate, location }) {
       thresholdDeg: -12,
       direction: 'descending',
       start: eveningStart,
-      end: midnight,
+      end: nextNoon,
       location,
     }),
     astronomicalDusk: findAltitudeCrossing({
@@ -397,7 +401,7 @@ export function computeNightSessionEvents({ nightDate, location }) {
       thresholdDeg: -18,
       direction: 'descending',
       start: eveningStart,
-      end: midnight,
+      end: nextNoon,
       location,
     }),
     moonSet: findAltitudeCrossing({
@@ -405,7 +409,7 @@ export function computeNightSessionEvents({ nightDate, location }) {
       thresholdDeg: 0,
       direction: 'descending',
       start: eveningStart,
-      end: midnight,
+      end: nextNoon,
       location,
     }),
     sunRise: findAltitudeCrossing({

--- a/src/plugins/target-scheduler/views/TargetSchedulerView.vue
+++ b/src/plugins/target-scheduler/views/TargetSchedulerView.vue
@@ -89,8 +89,6 @@
               <input
                 v-model="sessionEndDate"
                 type="date"
-                :disabled="!isSessionEndTimeMode"
-                :readonly="!isSessionEndTimeMode"
                 class="w-full rounded border border-slate-600 bg-slate-800 px-2 py-1.5 text-slate-100 disabled:opacity-60"
               />
               <input
@@ -374,6 +372,7 @@ const {
 
 const sessionStartModeOptions = computed(() => [
   { value: 'time', label: t('plugins.targetScheduler.sessionModes.time') },
+  { value: 'now', label: t('plugins.targetScheduler.sessionModes.now') },
   {
     value: 'twilight_end_nautical',
     label: t('plugins.targetScheduler.sessionModes.twilightEndNautical'),


### PR DESCRIPTION
## Summary
This PR fixes Target Scheduler session start/end behavior around midnight and adds a quick "Now" start mode.

## What changed
- Added a new `Start Session` mode: `Now`.
  - Selecting `Now` sets the session start input to the current local date/time.
- Fixed start event calculation for post-midnight cases:
  - `Twilight end astronomical` and `Moon set` are now searched in a window that extends past midnight, so those events are found when they occur after 00:00.
- Removed forced `end = start date + 1 day` behavior.
  - Session end no longer auto-increments date when it is <= start.
  - Persisted session start/end date-time values are preserved as full date-times.
- Session end date is now editable even when end mode is not `Time`.
- Mode synchronization now recalculates with separate start/end base dates and reacts to end-date edits.

## Why this resolves the issue
- Reported problem: selecting `Twilight end astronomical` and `Moon set` did not change start time.
  - Cause: event search stopped at midnight.
  - Fix: event search for dusk/moonset now spans into the following morning window.
- Reported problem: session end date should be editable and not auto-forced to start+1.
  - Fix: removed automatic +1-day correction and made end date editable for event modes.
- Requested improvement: add `Now` as a start option.
  - Implemented in scheduler mode list + i18n labels.

## Validation
- Confirmed existing clear action already exists in Target Scheduler UI (`Clear all`), so no duplicate clear button was added.
- Lint: `npx eslint src/plugins/target-scheduler --ext .js,.vue` passed.

## Scope
- Target Scheduler only:
  - `src/plugins/target-scheduler/composables/useTargetScheduler.js`
  - `src/plugins/target-scheduler/services/TargetSchedulerService.js`
  - `src/plugins/target-scheduler/views/TargetSchedulerView.vue`
  - `src/locales/en.json`
  - `src/locales/de.json`
