### PR TITLE
fix(livestack): move zoomable image controls above the status bar so …

### DIFF
--- a/src/assets/tailwind.css
+++ b/src/assets/tailwind.css
@@ -104,6 +104,14 @@
     min-height: 100vh;
     min-height: calc(100vh - env(safe-area-inset-top) - env(safe-area-inset-bottom));
   }
+
+  /* Bottom anchor for floating page elements above the StatusBar, including an
+     open status panel. Class variant of the inline style already used in
+     SequencePage.vue, controlSequence.vue and CaptureButton.vue — needed where
+     only a class name can be passed (e.g. ZoomableImage's controlsClass). */
+  .bottom-above-statusbar {
+    bottom: calc(var(--above-statusbar) + var(--status-panel-height));
+  }
 }
 
 .glow-green {

--- a/src/plugins/livestack/views/LiveStack.vue
+++ b/src/plugins/livestack/views/LiveStack.vue
@@ -62,11 +62,10 @@
         <ZoomableImage
           :imageData="getStretchSettings().stretchedImageData || livestackStore.currentImageUrl"
           :loading="isLoading || isHistogramProcessing"
-          :showControls="true"
           :showDownload="true"
           :showFullscreen="false"
           :showHistogram="true"
-          controlsClass="top-2 right-2 portrait:top-24 portrait:left-20 landscape:left-40"
+          controlsClass="right-2 bottom-above-statusbar left-2 landscape:left-(--nav-offset)"
           :initialZoom="currentZoomLevel"
           height="100vh"
           :altText="imageAltText"


### PR DESCRIPTION
…the control bar can't cover them