### PR TITLE
Add PINS system localization setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [App6.1.4-beta2] - unreleased
+### Added
+- PINS setup and settings: Configure the rig's system locale, Wi-Fi country, timezone and keyboard layout. The setup assistant reads the current Pi values and places this step before Wi-Fi; the same live settings remain available under General Settings on every client
+
 ### Fixed
 - Webcam: Layout and settings dialog on iOS, and snapshots that stayed "Disconnected" in the app
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [App6.1.4-beta2] - unreleased
 ### Added
-- PINS setup and settings: Configure the rig's system locale, Wi-Fi country, timezone and keyboard layout. The setup assistant reads the current Pi values and places this step before Wi-Fi; the same live settings remain available under General Settings on every client
+- PINS setup and settings: Configure the rig's system locale, Wi-Fi country, timezone and keyboard layout. The setup assistant reads the current Pi values and places this step before Wi-Fi; the same live settings remain available under General Settings on every client, with searchable lists of the values supported by the Pi
 
 ### Fixed
 - Webcam: Layout and settings dialog on iOS, and snapshots that stayed "Disconnected" in the app

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,7 +103,10 @@ Cameras have **no** `SettingsSerialConnection` fallback — only `SettingsAlpaca
 It opens before setup is complete and is ordered ahead of the tutorial and What's New.
 The common flow covers Welcome → Language → Information → Instance (native only) →
 Mount → Location → Telescope → Camera → Focuser → Filter wheel → Done. PINS adds
-Wi-Fi, Updates, INDI slew speed and Guiding. It is restartable from settings and the PINS page.
+System Localization, Wi-Fi, Updates, INDI slew speed and Guiding. Localization is
+deliberately before Wi-Fi so the regulatory country, timezone, locale and remote
+keyboard layout are correct before networking is configured. It is restartable
+from settings and the PINS page.
 
 - **Extension point:** add one entry to the computed `steps` list in `SetupWizard.vue` plus
   one `v-else-if` branch. Nothing else in the wizard shell is step-count aware. Step IDs,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,8 +6,8 @@ Guidance for AI agents working in this repository.
 
 - [docs/AGENT_GUIDELINES.md](docs/AGENT_GUIDELINES.md) — the project's static agent harness:
   operating principles, product priorities, safety rules. It takes precedence over this file.
-- [HighLevelDesign.md](HighLevelDesign.md) — architecture, the three runtime modes
-  (NINA/WPF, PINS/headless, mock), transports.
+- [HighLevelDesign.md](HighLevelDesign.md) — architecture, the two backend runtime
+  modes (NINA/WPF and PINS/headless), transports, and test-fixture boundary.
 - [CONTRIBUTING.md](CONTRIBUTING.md) — contribution rules, i18n requirements.
 - [src/plugins/plugins.md](src/plugins/plugins.md) — plugin authoring.
 
@@ -59,7 +59,7 @@ Everything is written with `apiService.profileChangeValue('<Section>-<Key>', val
 ## Equipment: device mapping
 
 Every device follows the same three-step driver change (implemented generically in
-`src/components/pinsWizard/IndiDriverSelect.vue`):
+`src/components/setupWizard/IndiDriverSelect.vue`):
 
 ```
 profileChangeValue('<X>Settings-IndiDriver', name)
@@ -97,15 +97,17 @@ Device quirks: filter wheel slot count (`SettingsFilterWheelSlotNum.vue`), Switc
 Cameras have **no** `SettingsSerialConnection` fallback — only `SettingsAlpacaDirect` when
 `Category === 'ASCOM Alpaca'`, otherwise the `components.alpacaDirect.cameraNoSettings` note.
 
-## PINS setup wizard
+## Setup wizard
 
-`src/components/pinsWizard/` — a full-screen overlay guiding PINS users through
-Welcome → Wi-Fi → Updates → Mount → Slew speed → Location → Telescope → Camera → Done.
-Auto-opens from `App.vue` when `store.isPINS && setupCompleted && !pinsWizard.completed`,
-queued behind the tutorial and ahead of What's New. Restartable from settings and the PINS page.
+`src/components/setupWizard/` contains the cancellable first-run and equipment wizard.
+It opens before setup is complete and is ordered ahead of the tutorial and What's New.
+The common flow covers Welcome → Language → Information → Instance (native only) →
+Mount → Location → Telescope → Camera → Focuser → Filter wheel → Done. PINS adds
+Wi-Fi, Updates, INDI slew speed and Guiding. It is restartable from settings and the PINS page.
 
-- **Extension point:** add one entry to the `steps` array in `PinsSetupWizard.vue` plus one
-  `v-else-if` branch. Nothing else is step-count aware.
+- **Extension point:** add one entry to the computed `steps` list in `SetupWizard.vue` plus
+  one `v-else-if` branch. Nothing else in the wizard shell is step-count aware. Step IDs,
+  rather than indexes, are persisted because PINS-only steps can appear after connection.
 - **Telescope sits before camera on purpose** — the camera step's image-scale readout needs
   `TelescopeSettings.FocalLength`.
 - **The camera reverses the order** of every other device step: native device list first, INDI
@@ -119,7 +121,8 @@ queued behind the tutorial and ahead of What's New. Restartable from settings an
   from inside the wizard teleport to `body` and must be raised to `z-[75]`, otherwise they open
   invisibly behind it. `LocationSyncModal` sits at `z-[76]` because it blocks the mount connect.
 - The wizard hides itself while `pinsStore.shouldShowUpgradeOverlay` is true and persists
-  `settingsStore.pinsWizard.currentStep` — a PINS upgrade restarts services and reloads the app.
+  `settingsStore.setupWizard.currentStepId` — a PINS upgrade restarts services and can
+  temporarily interrupt the app connection.
 
 ## Location handling
 

--- a/HighLevelDesign.md
+++ b/HighLevelDesign.md
@@ -2,11 +2,13 @@
 
 ## 1. Purpose and Scope
 
-Touch-N-Stars is a Vue 3 + Capacitor client for remotely operating NINA-based astrophotography setups from phone and tablet devices. The app is designed as a control plane UI and does not replace NINA processing logic. It supports three runtime modes:
+Touch-N-Stars is a Vue 3 + Capacitor client for remotely operating NINA-based astrophotography setups from phone and tablet devices. The app is designed as a control plane UI and does not replace NINA processing logic. It supports two backend runtime modes:
 
 1. Normal NINA/WPF backend mode.
 2. PINS/headless mode with additional daemon APIs and SignalR channels.
-3. Local mock mode for UI and workflow testing without a backend.
+
+Automated tests use local contract fakes and browser fixtures, but the application
+does not currently expose a selectable mock runtime mode.
 
 This document describes the architecture as implemented in the current codebase.
 
@@ -39,17 +41,19 @@ flowchart LR
 ### 3.1 Frontend Core
 
 - Framework: Vue 3.5 (Composition API).
-- Router: Vue Router 5 with setup guard and nav visibility guard.
+- Router: Vue Router 5 with lazy core routes and a nav-visibility redirect. First-run
+  setup is a cancellable overlay and does not gate routing.
 - State: Pinia 3 with persisted state plugin.
 - Styling: Tailwind CSS + component-local styles.
-- i18n: vue-i18n with 12 shipped locales.
+- i18n: vue-i18n with 14 shipped locales.
 - Native shell: Capacitor 8 for Android and iOS.
 
 ### 3.2 High-Level Layering
 
 1. Presentation: `src/views` and `src/components`.
 2. Domain state: `src/store` and plugin-local stores under `src/plugins/*/store`.
-3. Integration services: `src/services` (REST, SignalR, WebSockets, updater, mock).
+3. Integration services: `src/services` (REST, SignalR, WebSockets, updater, and
+   rig discovery/recovery).
 4. Utilities and infrastructure: `src/utils`, scripts, static assets in `public`.
 
 ## 4. Startup and Lifecycle
@@ -61,17 +65,20 @@ flowchart LR
 1. Create app, Pinia, router, i18n, and head manager.
 2. Register global tooltip directive.
 3. Set global error handler and console capture.
-4. Initialize plugin store with app/router references.
-5. If mock mode is disabled, discover and initialize enabled plugins.
-6. Mount app.
-7. Notify Capacitor updater that app is ready.
-8. Initialize time sync (best-effort).
+4. Initialize i18n from persisted settings.
+5. Initialize the plugin store with app/router references, refresh bundled plugin
+   metadata, and initialize enabled plugins.
+6. Mount the app and synchronize Android system-bar colors.
+7. Initialize Android Wi-Fi binding, rig-shared settings synchronization, and the
+   PINS rig connection supervisor.
+8. Register native foreground recovery, notify the Capacitor updater that the app
+   is ready, and initialize time sync (best-effort).
 
 ### 4.2 Runtime Lifecycle
 
 `src/App.vue` orchestrates app lifecycle:
 
-- Connection splash and setup gating.
+- Connection splash and the cancellable setup-wizard overlay.
 - Background/foreground pause/resume handling (web + Capacitor events).
 - Update checks and update modal flow.
 - Dialog/messagebox signaling mode switching for PINS vs non-PINS.
@@ -117,7 +124,8 @@ flowchart LR
 ### 6.2 Persistence Strategy
 
 - Pinia persisted state is used for settings and plugin state.
-- Additional direct localStorage flags are used for setup/tutorial completion and mock mode toggles.
+- Additional direct localStorage values are used for setup/tutorial completion,
+  wizard progress, network transitions, and selected migration/feature flags.
 - On instance switch or backend loss, `apiStore.clearAllStates()` performs a broad cleanup across stores and disconnects transports.
 
 ## 7. Plugin Architecture
@@ -225,7 +233,7 @@ contracts are maintained in
 
 ### 12.1 App Ready and Backend Connect
 
-1. Boot app + initialize plugins (unless mock).
+1. Boot app, initialize i18n, refresh plugin metadata, and initialize enabled plugins.
 2. Run `fetchAllInfos` to validate backend stack and versions.
 3. Connect sockets/hubs based on mode.
 4. Begin periodic fetch loops and feature-specific background tasks.
@@ -234,8 +242,10 @@ contracts are maintained in
 
 1. User selects instance in settings.
 2. `settingsStore` updates active connection.
-3. `apiStore.clearAllStates()` resets transport/store state.
-4. Connect sequence restarts against the new backend.
+3. After initial setup, the app reloads while preserving the current route; onboarding
+   can explicitly use the in-place `apiStore.switchBackend()` path.
+4. The in-place path invalidates old requests, clears instance-scoped state and
+   transports, then restarts the handshake and poller against the new backend.
 
 ### 12.3 Native Update Flow
 
@@ -249,7 +259,8 @@ contracts are maintained in
 ### 13.1 Strengths
 
 - Clear separation between UI, stores, and service adapters.
-- Mode-aware behavior (standard, PINS, mock) is explicit.
+- Mode-aware behavior for standard NINA and PINS is explicit; contract fakes keep
+  transport tests independent of live hardware.
 - Plugin ecosystem is integrated into startup and navigation.
 - Strong recovery patterns for reconnecting sockets/hubs.
 

--- a/HighLevelDesign.md
+++ b/HighLevelDesign.md
@@ -157,6 +157,11 @@ flowchart LR
 - Enables additional PINS services and overlays.
 - Uses SignalR for dialogs/message boxes.
 - Includes time mismatch warning/sync flow against PINS system API.
+- After PINS detection, the setup wizard exposes host localization before Wi-Fi;
+  General Settings exposes the same controls later. Both read the current locale,
+  Wi-Fi country, timezone, and keyboard layout from pinsdaemon instead of
+  persisting device-local copies, so web, Android, and iOS clients see one shared
+  system state.
 
 ## 9. Feature Domain Map
 

--- a/README.md
+++ b/README.md
@@ -26,13 +26,15 @@ The app is actively maintained and continuously improved, but it is no longer in
 
 ### 🏁 **Purpose of the WebApp**
 
-The application aims to make controlling and adjusting already configured profiles easier - directly through a tablet or smartphone. This makes handling more mobile and convenient, especially when setting up equipment and starting imaging sessions.
+The application makes controlling and configuring NINA- or PINS-based astrophotography rigs easier directly from a tablet or smartphone. This makes field setup, equipment configuration, and imaging-session control more mobile and convenient.
 
 ### 🧩 **Important Notes**
 
-- This web app **requires a fully configured and running installation of NINA**.
-- It requires the **Advanced API** plugin in the latest version.
-  The API port must be set to 1888 and V2 must be enabled.
+- Standard Windows operation requires a running NINA installation with the latest
+  **Touch-N-Stars** and **Advanced API** plugins. PINS/headless rigs are supported
+  as a separate runtime mode.
+- Advanced API V2 must be enabled. Its port is discovered dynamically through the
+  Touch-N-Stars plugin and does not need to be fixed to `1888`.
 - For Three Point Polar Alignment, version 2.2.2.0 or newer is required.
 - It is intended as a complement to the desktop software and provides mobile support for basic functions.
 - The author assumes no liability

--- a/docs/AGENT_GUIDELINES.md
+++ b/docs/AGENT_GUIDELINES.md
@@ -44,10 +44,11 @@ Touch-N-Stars currently includes:
 
 - Vue 3.5 Composition API frontend, Vite build, Vue Router 5, Pinia 3, persisted state, Tailwind CSS, vue-i18n, and Capacitor 8 Android/iOS shell.
 - A mobile-first UI for controlling and monitoring N.I.N.A. workflows from browsers, tablets, phones, and embedded displays.
-- Three runtime modes:
+- Two backend runtime modes:
   - Standard N.I.N.A. mode using the Touch-N-Stars plugin server and N.I.N.A. Advanced API V2.
   - PINS/headless mode with additional daemon APIs, SignalR hubs, and Raspberry Pi/Linux-oriented behavior.
-  - Local mock mode for UI development, workflow demos, and selected tests without a backend.
+- Local contract fakes and browser fixtures for selected automated tests. There is
+  no selectable mock runtime mode in the current application.
 - Multiple communication paths:
   - Touch-N-Stars plugin server REST under `/api/*`.
   - Advanced API V2 REST under `/v2/api/*`.
@@ -347,7 +348,7 @@ Required rules:
 - Default tests must not move real equipment, start real sequences, run long exposures, change Wi-Fi, install packages, restart services, upload firmware, or mutate a live session.
 - Live smoke tests require simulator-backed N.I.N.A. or a dedicated lab PINS host, explicit user intent, and carefully gated commands.
 - Prefer contract mocks for backend integration tests.
-- Mock mode is not proof of real hardware correctness.
+- Contract mocks and browser fixtures are not proof of real hardware correctness.
 - UI must make dangerous operations explicit and understandable to field users.
 - Never hide safety warnings or invalid equipment state messages for cleaner UI.
 
@@ -362,7 +363,8 @@ Required rules:
 - Use plugin metadata `id`, `data-plugin-id`, stable `data-testid`, ARIA roles, or semantic selectors for tests and UI hooks.
 - Regenerate the plugin registry when plugin metadata or plugin entry points change.
 - Avoid duplicate routes, stale routes, and duplicate nav items.
-- Respect mock mode behavior, where plugin loading may intentionally be skipped.
+- Keep plugin-loading tests isolated with explicit fakes; production startup
+  refreshes bundled metadata and initializes enabled plugins.
 - Keep plugin-local state isolated unless a shared contract is explicitly required.
 
 ## UI, Mobile, And Accessibility Rules

--- a/docs/AGENT_TASK_TEMPLATE.md
+++ b/docs/AGENT_TASK_TEMPLATE.md
@@ -29,10 +29,12 @@ Use Background/Delegated only for narrow, reproducible tasks with explicit accep
 Current project context:
 - Touch-N-Stars is a mobile-first Vue 3 + Capacitor control interface for N.I.N.A.-based astrophotography sessions.
 - It is a frontend control plane and orchestration layer; it does not replace N.I.N.A. sequencing, device control, imaging, guiding, plate solving, profile logic, or processing.
-- Runtime modes include standard N.I.N.A., PINS/headless, and local mock mode.
+- Backend runtime modes are standard N.I.N.A. and PINS/headless. Automated tests
+  may use explicit contract fakes and browser fixtures; there is no selectable
+  mock runtime mode in the current app.
 - Standard N.I.N.A. mode talks to the Touch-N-Stars plugin server `/api/*` and N.I.N.A. Advanced API V2 `/v2/api/*` plus WebSocket channels.
 - PINS/headless mode can add SignalR hubs and pinsdaemon system APIs, usually on port `8000`.
-- Mock mode is for UI development, demos, and selected tests only; it is not proof of real N.I.N.A., PINS, SignalR, WebSocket, pinsdaemon, or hardware behavior.
+- Contract fakes and browser fixtures are for selected tests only; they are not proof of real N.I.N.A., PINS, SignalR, WebSocket, pinsdaemon, or hardware behavior.
 - The app is hardware-adjacent and system-adjacent; correctness and safety matter more than broad refactors.
 
 Context packet:
@@ -228,7 +230,8 @@ Add these constraints:
 - Add/update i18n entries for all user-facing strings.
 - Do not rely on translated text as the primary test selector.
 - Prefer stable `data-testid`, ARIA roles, and semantic selectors.
-- Verify standard N.I.N.A., PINS, and mock mode impact if the flow is shared.
+- Verify standard N.I.N.A. and PINS impact when the flow is shared, and keep
+  contract-fake coverage aligned with the production interfaces.
 ```
 
 Suggested validation:
@@ -245,7 +248,8 @@ Acceptance criteria examples:
 ```text
 1. The UI flow works on narrow phone and tablet widths.
 2. All user-facing text uses i18n keys.
-3. Existing setup/navigation behavior still works in mock mode.
+3. Existing setup/navigation behavior remains covered by browser fixtures without
+   implying a selectable mock runtime.
 4. The change does not hide equipment state or safety warnings.
 ```
 
@@ -347,7 +351,7 @@ Add these constraints:
 - Use stable plugin IDs and metadata.
 - Regenerate plugin registry when plugin metadata or entry points change.
 - Avoid duplicate routes, stale routes, and duplicate nav entries.
-- Respect mock mode behavior where plugin loading may be skipped.
+- Keep plugin-loading tests isolated with explicit fakes; production startup refreshes metadata and initializes enabled plugins.
 ```
 
 Suggested validation:
@@ -458,7 +462,7 @@ Add these constraints:
 
 ```text
 - Prefer contract mocks for N.I.N.A., WebSocket, SignalR, PINS, and pinsdaemon behavior.
-- Do not use UI mock mode as proof of real backend behavior.
+- Do not use contract fakes or browser fixtures as proof of real backend behavior.
 - Do not touch live equipment or mutate system services in default tests.
 - Include success, invalid-state, auth/error, disconnect/reconnect, and stale-event cases when relevant.
 ```

--- a/docs/Features.md
+++ b/docs/Features.md
@@ -35,7 +35,7 @@ Touch-N-Stars is a mobile control client for NINA (Nighttime Imaging 'N' Astrono
 *   **Weather Monitoring**: Integration for monitoring weather conditions.
 *   **Built-in Tutorials**: Interactive tutorials to guide users through features and setup.
 *   **Favorite Targets**: Manage and quickly access your favorite astronomical targets.
-*   **Setup Wizard**: A cancellable first-run and equipment wizard covering language, rig connection, mount, location, telescope, camera, focuser, and filter wheel. PINS first reads and configures the host locale, Wi-Fi country, timezone, and keyboard layout, then adds Wi-Fi, updates, INDI slew-rate, guiding, and third-party INDI-driver installation steps. The live regional settings can also be changed later under General Settings.
+*   **Setup Wizard**: A cancellable first-run and equipment wizard covering language, rig connection, mount, location, telescope, camera, focuser, and filter wheel. PINS first reads and configures the host locale, Wi-Fi country, timezone, and keyboard layout from searchable host-supported lists, then adds Wi-Fi, updates, INDI slew-rate, guiding, and third-party INDI-driver installation steps. The live regional settings can also be changed later under General Settings.
 
 ## Prerequisites
 

--- a/docs/Features.md
+++ b/docs/Features.md
@@ -1,10 +1,10 @@
 # Touch-N-Stars: A Comprehensive Overview of Features
 
-Touch-N-Stars is a powerful WebApp designed for mobile control of NINA (Nighttime Imaging 'N' Astronomy) software, offering a robust set of features for astro-enthusiasts to manage their equipment and imaging sessions remotely. The application is built with a focus on mobile operability, user-friendly design, and practicality, complementing the desktop NINA software with essential mobile support.
+Touch-N-Stars is a mobile control client for NINA (Nighttime Imaging 'N' Astronomy) and PINS/headless astrophotography rigs. It offers tools for remotely configuring equipment and managing imaging sessions from browsers, tablets, and phones.
 
 ## Core Functionality & Integration
 
-*   **Mobile Control of NINA**: Seamlessly control and adjust pre-configured NINA profiles directly from a tablet or smartphone.
+*   **Mobile Rig Control**: Control and configure NINA or PINS profiles directly from a tablet or smartphone.
 *   **Celestia Atlas Integration**: Offline sky visualization and catalogue search with target selection, framing handoff, mount/FOV overlays, horizon and landscape support, independent brightness limits, and persisted deep-sky type/source marker filters.
 *   **Comprehensive Equipment Management**: Manage various astronomical equipment, including:
     *   **Camera Control**: Detailed control over camera settings and operations.
@@ -35,9 +35,9 @@ Touch-N-Stars is a powerful WebApp designed for mobile control of NINA (Nighttim
 *   **Weather Monitoring**: Integration for monitoring weather conditions.
 *   **Built-in Tutorials**: Interactive tutorials to guide users through features and setup.
 *   **Favorite Targets**: Manage and quickly access your favorite astronomical targets.
-*   **Setup Procedures**: Guided procedures for initial equipment setup.
+*   **Setup Wizard**: A cancellable first-run and equipment wizard covering language, rig connection, mount, location, telescope, camera, focuser, and filter wheel. PINS adds Wi-Fi, updates, INDI slew-rate, guiding, and third-party INDI-driver installation steps.
 
 ## Prerequisites
 
-*   Requires a fully configured and running NINA installation with the latest version of the Touch-N-Star
-*   s plugin.
+*   Standard Windows mode requires a running NINA installation with current Touch-N-Stars and Advanced API plugins; Advanced API V2 must be enabled and its port is discovered dynamically.
+*   PINS/headless mode uses the PINS backend plus Pinsdaemon for system-management features.

--- a/docs/Features.md
+++ b/docs/Features.md
@@ -35,7 +35,7 @@ Touch-N-Stars is a mobile control client for NINA (Nighttime Imaging 'N' Astrono
 *   **Weather Monitoring**: Integration for monitoring weather conditions.
 *   **Built-in Tutorials**: Interactive tutorials to guide users through features and setup.
 *   **Favorite Targets**: Manage and quickly access your favorite astronomical targets.
-*   **Setup Wizard**: A cancellable first-run and equipment wizard covering language, rig connection, mount, location, telescope, camera, focuser, and filter wheel. PINS adds Wi-Fi, updates, INDI slew-rate, guiding, and third-party INDI-driver installation steps.
+*   **Setup Wizard**: A cancellable first-run and equipment wizard covering language, rig connection, mount, location, telescope, camera, focuser, and filter wheel. PINS first reads and configures the host locale, Wi-Fi country, timezone, and keyboard layout, then adds Wi-Fi, updates, INDI slew-rate, guiding, and third-party INDI-driver installation steps. The live regional settings can also be changed later under General Settings.
 
 ## Prerequisites
 

--- a/src/components/settings/SettingsGeneralTab.vue
+++ b/src/components/settings/SettingsGeneralTab.vue
@@ -113,6 +113,9 @@
     <!-- Time Synchronisation -->
     <TimeSyncSettings v-if="store.isPINS" />
 
+    <!-- Raspberry Pi system locale, regulatory domain, timezone and keyboard -->
+    <PinsLocalizationSettings v-if="store.isPINS" />
+
     <!-- Connection Settings -->
     <div
       class="p-2 sm:p-4 flex flex-col gap-2 sm:gap-3 bg-gray-800/50 rounded-lg border border-gray-700/50"
@@ -343,6 +346,7 @@ import SetLogLevel from '@/components/settings/general/SetLogLevel.vue';
 import NumberInputPicker from '@/components/helpers/NumberInputPicker.vue';
 import LocationSettingsPins from '@/components/settings/general/LocationSettingsPins.vue';
 import TimeSyncSettings from '@/components/settings/general/TimeSyncSettings.vue';
+import PinsLocalizationSettings from '@/components/settings/general/PinsLocalizationSettings.vue';
 import SetHorizonFilePath from '@/components/settings/general/SetHorizonFilePath.vue';
 import { useI18n } from 'vue-i18n';
 

--- a/src/components/settings/general/PinsLocalizationSettings.vue
+++ b/src/components/settings/general/PinsLocalizationSettings.vue
@@ -27,15 +27,18 @@
             {{ t('components.settings.localization.systemLocale') }}
           </span>
           <input
-            v-model.trim="form.locale"
-            :list="`${listPrefix}-locales`"
+            v-model.trim="filters.locale"
+            type="search"
             class="tns-input"
             autocomplete="off"
             :disabled="saving"
+            :placeholder="t('components.settings.localization.searchPlaceholder')"
           />
-          <datalist :id="`${listPrefix}-locales`">
-            <option v-for="value in options.locales" :key="value" :value="value" />
-          </datalist>
+          <select v-model="form.locale" class="tns-select" :disabled="saving">
+            <option v-for="value in localeChoices" :key="value" :value="value">
+              {{ value }}
+            </option>
+          </select>
         </label>
 
         <label class="flex flex-col gap-1">
@@ -58,15 +61,18 @@
             {{ t('components.settings.localization.timezone') }}
           </span>
           <input
-            v-model.trim="form.timezone"
-            :list="`${listPrefix}-timezones`"
+            v-model.trim="filters.timezone"
+            type="search"
             class="tns-input"
             autocomplete="off"
             :disabled="saving"
+            :placeholder="t('components.settings.localization.searchPlaceholder')"
           />
-          <datalist :id="`${listPrefix}-timezones`">
-            <option v-for="value in options.timezones" :key="value" :value="value" />
-          </datalist>
+          <select v-model="form.timezone" class="tns-select" :disabled="saving">
+            <option v-for="value in timezoneChoices" :key="value" :value="value">
+              {{ value }}
+            </option>
+          </select>
         </label>
 
         <label class="flex flex-col gap-1">
@@ -74,15 +80,18 @@
             {{ t('components.settings.localization.keyboardLayout') }}
           </span>
           <input
-            v-model.trim="form.keyboardLayout"
-            :list="`${listPrefix}-keyboards`"
+            v-model.trim="filters.keyboardLayout"
+            type="search"
             class="tns-input"
             autocomplete="off"
             :disabled="saving"
+            :placeholder="t('components.settings.localization.searchPlaceholder')"
           />
-          <datalist :id="`${listPrefix}-keyboards`">
-            <option v-for="value in options.keyboardLayouts" :key="value" :value="value" />
-          </datalist>
+          <select v-model="form.keyboardLayout" class="tns-select" :disabled="saving">
+            <option v-for="value in keyboardChoices" :key="value" :value="value">
+              {{ value }}
+            </option>
+          </select>
         </label>
       </div>
 
@@ -110,7 +119,7 @@
 </template>
 
 <script setup>
-import { computed, onMounted, reactive, ref, useId } from 'vue';
+import { computed, onMounted, reactive, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import apiPinsService from '@/services/apiPinsService';
 import { apiStore } from '@/store/store';
@@ -125,7 +134,6 @@ defineProps({
 
 const { t } = useI18n();
 const store = apiStore();
-const listPrefix = `pins-localization-${useId().replaceAll(':', '')}`;
 const loading = ref(false);
 const saving = ref(false);
 const saved = ref(false);
@@ -143,6 +151,26 @@ const form = reactive({
   timezone: '',
   keyboardLayout: '',
 });
+const filters = reactive({
+  locale: '',
+  timezone: '',
+  keyboardLayout: '',
+});
+
+function filterOptions(values, query, selected) {
+  const needle = query.trim().toLocaleLowerCase();
+  if (!needle) return values;
+  const matches = values.filter((value) => value.toLocaleLowerCase().includes(needle));
+  return selected && !matches.includes(selected) ? [selected, ...matches] : matches;
+}
+
+const localeChoices = computed(() => filterOptions(options.locales, filters.locale, form.locale));
+const timezoneChoices = computed(() =>
+  filterOptions(options.timezones, filters.timezone, form.timezone)
+);
+const keyboardChoices = computed(() =>
+  filterOptions(options.keyboardLayouts, filters.keyboardLayout, form.keyboardLayout)
+);
 
 const isComplete = computed(() => Object.values(form).every((value) => String(value).trim()));
 const isDirty = computed(

--- a/src/components/settings/general/PinsLocalizationSettings.vue
+++ b/src/components/settings/general/PinsLocalizationSettings.vue
@@ -1,0 +1,234 @@
+<template>
+  <section
+    v-if="store.isPINS"
+    :class="
+      embedded
+        ? 'flex flex-col gap-4'
+        : 'p-2 sm:p-4 flex flex-col gap-3 bg-gray-800/50 rounded-lg border border-gray-700/50'
+    "
+  >
+    <div v-if="!embedded">
+      <h3 class="font-bold text-base text-cyan-400">
+        {{ t('components.settings.localization.title') }}
+      </h3>
+      <p class="text-sm text-content-muted mt-1">
+        {{ t('components.settings.localization.description') }}
+      </p>
+    </div>
+
+    <p v-if="loading" class="text-sm text-content-muted">
+      {{ t('components.settings.localization.loading') }}
+    </p>
+
+    <template v-else>
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <label class="flex flex-col gap-1">
+          <span class="text-xs font-semibold uppercase text-content-muted">
+            {{ t('components.settings.localization.systemLocale') }}
+          </span>
+          <input
+            v-model.trim="form.locale"
+            :list="`${listPrefix}-locales`"
+            class="tns-input"
+            autocomplete="off"
+            :disabled="saving"
+          />
+          <datalist :id="`${listPrefix}-locales`">
+            <option v-for="value in options.locales" :key="value" :value="value" />
+          </datalist>
+        </label>
+
+        <label class="flex flex-col gap-1">
+          <span class="text-xs font-semibold uppercase text-content-muted">
+            {{ t('components.settings.localization.wifiCountry') }}
+          </span>
+          <select v-model="form.wifiCountry" class="tns-select" :disabled="saving">
+            <option
+              v-for="country in options.wifiCountries"
+              :key="country.code"
+              :value="country.code"
+            >
+              {{ country.name }} ({{ country.code }})
+            </option>
+          </select>
+        </label>
+
+        <label class="flex flex-col gap-1">
+          <span class="text-xs font-semibold uppercase text-content-muted">
+            {{ t('components.settings.localization.timezone') }}
+          </span>
+          <input
+            v-model.trim="form.timezone"
+            :list="`${listPrefix}-timezones`"
+            class="tns-input"
+            autocomplete="off"
+            :disabled="saving"
+          />
+          <datalist :id="`${listPrefix}-timezones`">
+            <option v-for="value in options.timezones" :key="value" :value="value" />
+          </datalist>
+        </label>
+
+        <label class="flex flex-col gap-1">
+          <span class="text-xs font-semibold uppercase text-content-muted">
+            {{ t('components.settings.localization.keyboardLayout') }}
+          </span>
+          <input
+            v-model.trim="form.keyboardLayout"
+            :list="`${listPrefix}-keyboards`"
+            class="tns-input"
+            autocomplete="off"
+            :disabled="saving"
+          />
+          <datalist :id="`${listPrefix}-keyboards`">
+            <option v-for="value in options.keyboardLayouts" :key="value" :value="value" />
+          </datalist>
+        </label>
+      </div>
+
+      <div class="flex flex-wrap items-center gap-2">
+        <button class="tns-btn-primary" :disabled="saving || !isComplete || !isDirty" @click="save">
+          {{
+            saving
+              ? t('components.settings.localization.saving')
+              : t('components.settings.localization.save')
+          }}
+        </button>
+        <button class="tns-btn-secondary" :disabled="saving" @click="load">
+          {{ t('components.settings.localization.refresh') }}
+        </button>
+        <span v-if="saved" class="text-sm text-status-ok">
+          {{ t('components.settings.localization.saved') }}
+        </span>
+      </div>
+    </template>
+
+    <p v-if="errorMessage" class="text-sm text-status-danger break-words">
+      {{ errorMessage }}
+    </p>
+  </section>
+</template>
+
+<script setup>
+import { computed, onMounted, reactive, ref, useId } from 'vue';
+import { useI18n } from 'vue-i18n';
+import apiPinsService from '@/services/apiPinsService';
+import { apiStore } from '@/store/store';
+import {
+  parseJobIdFromResponse,
+  pollJobUntilFinished,
+} from '@/plugins/pins/composables/pinsJobPolling';
+
+defineProps({
+  embedded: { type: Boolean, default: false },
+});
+
+const { t } = useI18n();
+const store = apiStore();
+const listPrefix = `pins-localization-${useId().replaceAll(':', '')}`;
+const loading = ref(false);
+const saving = ref(false);
+const saved = ref(false);
+const errorMessage = ref('');
+const current = ref(null);
+const options = reactive({
+  locales: [],
+  wifiCountries: [],
+  timezones: [],
+  keyboardLayouts: [],
+});
+const form = reactive({
+  locale: '',
+  wifiCountry: '',
+  timezone: '',
+  keyboardLayout: '',
+});
+
+const isComplete = computed(() => Object.values(form).every((value) => String(value).trim()));
+const isDirty = computed(
+  () =>
+    current.value &&
+    Object.keys(form).some((key) => String(form[key]) !== String(current.value[key] || ''))
+);
+
+function messageFrom(error) {
+  return error?.response?.data?.detail || error?.message || String(error);
+}
+
+function setCurrent(status) {
+  current.value = status;
+  for (const key of Object.keys(form)) form[key] = status?.[key] || '';
+}
+
+function includeCurrentOptions() {
+  for (const [key, optionKey] of [
+    ['locale', 'locales'],
+    ['timezone', 'timezones'],
+    ['keyboardLayout', 'keyboardLayouts'],
+  ]) {
+    const value = form[key];
+    if (value && !options[optionKey].includes(value)) options[optionKey].unshift(value);
+  }
+  if (
+    form.wifiCountry &&
+    !options.wifiCountries.some((country) => country.code === form.wifiCountry)
+  ) {
+    options.wifiCountries.unshift({ code: form.wifiCountry, name: form.wifiCountry });
+  }
+}
+
+async function load() {
+  if (!store.isPINS || loading.value) return;
+  loading.value = true;
+  saved.value = false;
+  errorMessage.value = '';
+  try {
+    const [status, available] = await Promise.all([
+      apiPinsService.getPinsSystemLocalization(),
+      apiPinsService.getPinsSystemLocalizationOptions(),
+    ]);
+    options.locales = available?.locales || [];
+    options.wifiCountries = available?.wifiCountries || [];
+    options.timezones = available?.timezones || [];
+    options.keyboardLayouts = available?.keyboardLayouts || [];
+    setCurrent(status || {});
+    includeCurrentOptions();
+  } catch (error) {
+    console.error('[PinsLocalization] Load failed:', error);
+    errorMessage.value = t('components.settings.localization.loadError', {
+      message: messageFrom(error),
+    });
+  } finally {
+    loading.value = false;
+  }
+}
+
+async function save() {
+  if (!store.isPINS || saving.value || !isComplete.value || !isDirty.value) return;
+  saving.value = true;
+  saved.value = false;
+  errorMessage.value = '';
+  try {
+    const response = await apiPinsService.updatePinsSystemLocalization({ ...form });
+    const jobId = parseJobIdFromResponse(response);
+    if (!jobId) throw new Error(t('components.settings.localization.missingJob'));
+    const result = await pollJobUntilFinished(jobId);
+    if (!result.success) {
+      throw new Error(
+        result.result?.error || result.result?.stderr || result.result?.status || 'failed'
+      );
+    }
+    await load();
+    saved.value = true;
+  } catch (error) {
+    console.error('[PinsLocalization] Save failed:', error);
+    errorMessage.value = t('components.settings.localization.saveError', {
+      message: messageFrom(error),
+    });
+  } finally {
+    saving.value = false;
+  }
+}
+
+onMounted(load);
+</script>

--- a/src/components/settings/general/PinsLocalizationSettings.vue
+++ b/src/components/settings/general/PinsLocalizationSettings.vue
@@ -88,8 +88,8 @@
             :placeholder="t('components.settings.localization.searchPlaceholder')"
           />
           <select v-model="form.keyboardLayout" class="tns-select" :disabled="saving">
-            <option v-for="value in keyboardChoices" :key="value" :value="value">
-              {{ value }}
+            <option v-for="layout in keyboardChoices" :key="layout.code" :value="layout.code">
+              {{ layout.name }} ({{ layout.code }})
             </option>
           </select>
         </label>
@@ -144,6 +144,7 @@ const options = reactive({
   wifiCountries: [],
   timezones: [],
   keyboardLayouts: [],
+  keyboardLayoutOptions: [],
 });
 const form = reactive({
   locale: '',
@@ -169,8 +170,20 @@ const timezoneChoices = computed(() =>
   filterOptions(options.timezones, filters.timezone, form.timezone)
 );
 const keyboardChoices = computed(() =>
-  filterOptions(options.keyboardLayouts, filters.keyboardLayout, form.keyboardLayout)
+  filterKeyboardOptions(options.keyboardLayoutOptions, filters.keyboardLayout, form.keyboardLayout)
 );
+
+function filterKeyboardOptions(values, query, selected) {
+  const needle = query.trim().toLocaleLowerCase();
+  if (!needle) return values;
+  const matches = values.filter((layout) =>
+    `${layout.code} ${layout.name}`.toLocaleLowerCase().includes(needle)
+  );
+  const current = values.find((layout) => layout.code === selected);
+  return current && !matches.some((layout) => layout.code === selected)
+    ? [current, ...matches]
+    : matches;
+}
 
 const isComplete = computed(() => Object.values(form).every((value) => String(value).trim()));
 const isDirty = computed(
@@ -203,6 +216,15 @@ function includeCurrentOptions() {
   ) {
     options.wifiCountries.unshift({ code: form.wifiCountry, name: form.wifiCountry });
   }
+  if (
+    form.keyboardLayout &&
+    !options.keyboardLayoutOptions.some((layout) => layout.code === form.keyboardLayout)
+  ) {
+    options.keyboardLayoutOptions.unshift({
+      code: form.keyboardLayout,
+      name: form.keyboardLayout,
+    });
+  }
 }
 
 async function load() {
@@ -219,6 +241,10 @@ async function load() {
     options.wifiCountries = available?.wifiCountries || [];
     options.timezones = available?.timezones || [];
     options.keyboardLayouts = available?.keyboardLayouts || [];
+    options.keyboardLayoutOptions =
+      available?.keyboardLayoutOptions?.length > 0
+        ? available.keyboardLayoutOptions
+        : options.keyboardLayouts.map((code) => ({ code, name: code }));
     setCurrent(status || {});
     includeCurrentOptions();
   } catch (error) {

--- a/src/components/settings/general/PinsLocalizationSettings.vue
+++ b/src/components/settings/general/PinsLocalizationSettings.vue
@@ -96,7 +96,11 @@
       </div>
 
       <div class="flex flex-wrap items-center gap-2">
-        <button class="tns-btn-primary" :disabled="saving || !isComplete || !isDirty" @click="save">
+        <button
+          class="tns-btn-primary"
+          :disabled="saving || confirming || !isComplete || !isDirty"
+          @click="save"
+        >
           {{
             saving
               ? t('components.settings.localization.saving')
@@ -123,6 +127,7 @@ import { computed, onMounted, reactive, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import apiPinsService from '@/services/apiPinsService';
 import { apiStore } from '@/store/store';
+import { useToastStore } from '@/store/toastStore';
 import {
   parseJobIdFromResponse,
   pollJobUntilFinished,
@@ -134,8 +139,10 @@ defineProps({
 
 const { t } = useI18n();
 const store = apiStore();
+const toastStore = useToastStore();
 const loading = ref(false);
 const saving = ref(false);
+const confirming = ref(false);
 const saved = ref(false);
 const errorMessage = ref('');
 const current = ref(null);
@@ -190,6 +197,9 @@ const isDirty = computed(
   () =>
     current.value &&
     Object.keys(form).some((key) => String(form[key]) !== String(current.value[key] || ''))
+);
+const isWifiCountryDirty = computed(
+  () => current.value && String(form.wifiCountry) !== String(current.value.wifiCountry || '')
 );
 
 function messageFrom(error) {
@@ -258,7 +268,25 @@ async function load() {
 }
 
 async function save() {
-  if (!store.isPINS || saving.value || !isComplete.value || !isDirty.value) return;
+  if (!store.isPINS || saving.value || confirming.value || !isComplete.value || !isDirty.value)
+    return;
+
+  if (isWifiCountryDirty.value) {
+    confirming.value = true;
+    let confirmed = false;
+    try {
+      confirmed = await toastStore.showConfirmation(
+        t('components.settings.localization.wifiCountryConfirmTitle'),
+        t('components.settings.localization.wifiCountryConfirmMessage'),
+        t('common.confirm'),
+        t('common.cancel')
+      );
+    } finally {
+      confirming.value = false;
+    }
+    if (!confirmed) return;
+  }
+
   saving.value = true;
   saved.value = false;
   errorMessage.value = '';
@@ -266,7 +294,7 @@ async function save() {
     const response = await apiPinsService.updatePinsSystemLocalization({ ...form });
     const jobId = parseJobIdFromResponse(response);
     if (!jobId) throw new Error(t('components.settings.localization.missingJob'));
-    const result = await pollJobUntilFinished(jobId);
+    const result = await pollJobUntilFinished(jobId, { maxConsecutiveErrors: 5 });
     if (!result.success) {
       throw new Error(
         result.result?.error || result.result?.stderr || result.result?.status || 'failed'

--- a/src/components/setupWizard/SetupWizard.vue
+++ b/src/components/setupWizard/SetupWizard.vue
@@ -77,6 +77,8 @@
 
               <WizardInstanceStep v-else-if="currentStep.id === 'instance'" />
 
+              <WizardLocalizationStep v-else-if="currentStep.id === 'localization'" />
+
               <WizardWifiStep v-else-if="currentStep.id === 'wifi'" />
 
               <WizardUpdatesStep v-else-if="currentStep.id === 'updates'" />
@@ -154,6 +156,7 @@ import { usePinsStore } from '@/plugins/pins/store/pinsStore';
 import WizardLanguageStep from './steps/WizardLanguageStep.vue';
 import WizardInfoStep from './steps/WizardInfoStep.vue';
 import WizardInstanceStep from './steps/WizardInstanceStep.vue';
+import WizardLocalizationStep from './steps/WizardLocalizationStep.vue';
 import WizardWifiStep from './steps/WizardWifiStep.vue';
 import WizardUpdatesStep from './steps/WizardUpdatesStep.vue';
 import WizardMountStep from './steps/WizardMountStep.vue';
@@ -184,7 +187,7 @@ function step(id) {
  * connection. Adding a device step means one entry here plus one v-else-if
  * branch above; nothing else in the shell is step-aware.
  *
- * Only four steps are genuinely PINS-only. Mount, camera, focuser and filter
+ * Five steps are genuinely PINS-only. Mount, camera, focuser and filter
  * wheel connect through the NINA Advanced API and work on any backend - they
  * hide their own INDI blocks instead of disappearing entirely.
  */
@@ -193,8 +196,9 @@ const steps = computed(() => [
   step('language'),
   step('info'),
   ...(isMobile ? [step('instance')] : []),
-  // Wi-Fi and updates talk to the PINS daemon on port 8000.
-  ...(store.isPINS ? [step('wifi'), step('updates')] : []),
+  // Set the rig's regional defaults before Wi-Fi regulatory settings are used.
+  // These steps talk to the PINS daemon on port 8000.
+  ...(store.isPINS ? [step('localization'), step('wifi'), step('updates')] : []),
   // Mount before location: the location sync needs a connected mount.
   step('mount'),
   // IndiMaxSlewRateDps is an INDI driver limit and meaningless without it.

--- a/src/components/setupWizard/__tests__/localizationBoundary.test.js
+++ b/src/components/setupWizard/__tests__/localizationBoundary.test.js
@@ -29,4 +29,5 @@ test('large host option sets use searchable explicit selects instead of datalist
   assert.match(localizationSource, /v-model="form\.timezone"/);
   assert.match(localizationSource, /v-model="form\.keyboardLayout"/);
   assert.match(localizationSource, /type="search"/);
+  assert.match(localizationSource, /`\$\{layout\.code\} \$\{layout\.name\}`/);
 });

--- a/src/components/setupWizard/__tests__/localizationBoundary.test.js
+++ b/src/components/setupWizard/__tests__/localizationBoundary.test.js
@@ -1,0 +1,20 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const wizardSource = readFileSync(new URL('../SetupWizard.vue', import.meta.url), 'utf8');
+const settingsSource = readFileSync(
+  new URL('../../settings/SettingsGeneralTab.vue', import.meta.url),
+  'utf8'
+);
+
+test('PINS localization is ordered before Wi-Fi in the setup assistant', () => {
+  assert.match(
+    wizardSource,
+    /store\.isPINS\s*\?\s*\[step\('localization'\), step\('wifi'\), step\('updates'\)\]/
+  );
+});
+
+test('system localization settings remain inside the PINS capability boundary', () => {
+  assert.match(settingsSource, /<PinsLocalizationSettings v-if="store\.isPINS" \/>/);
+});

--- a/src/components/setupWizard/__tests__/localizationBoundary.test.js
+++ b/src/components/setupWizard/__tests__/localizationBoundary.test.js
@@ -7,6 +7,10 @@ const settingsSource = readFileSync(
   new URL('../../settings/SettingsGeneralTab.vue', import.meta.url),
   'utf8'
 );
+const localizationSource = readFileSync(
+  new URL('../../settings/general/PinsLocalizationSettings.vue', import.meta.url),
+  'utf8'
+);
 
 test('PINS localization is ordered before Wi-Fi in the setup assistant', () => {
   assert.match(
@@ -17,4 +21,12 @@ test('PINS localization is ordered before Wi-Fi in the setup assistant', () => {
 
 test('system localization settings remain inside the PINS capability boundary', () => {
   assert.match(settingsSource, /<PinsLocalizationSettings v-if="store\.isPINS" \/>/);
+});
+
+test('large host option sets use searchable explicit selects instead of datalists', () => {
+  assert.doesNotMatch(localizationSource, /<datalist/);
+  assert.match(localizationSource, /v-model="form\.locale"/);
+  assert.match(localizationSource, /v-model="form\.timezone"/);
+  assert.match(localizationSource, /v-model="form\.keyboardLayout"/);
+  assert.match(localizationSource, /type="search"/);
 });

--- a/src/components/setupWizard/steps/WizardLocalizationStep.vue
+++ b/src/components/setupWizard/steps/WizardLocalizationStep.vue
@@ -1,0 +1,20 @@
+<template>
+  <div class="flex flex-col gap-4">
+    <div>
+      <h2 class="text-xl font-semibold text-content">
+        {{ t('components.setupWizard.localization.title') }}
+      </h2>
+      <p class="text-sm text-content-muted mt-1">
+        {{ t('components.setupWizard.localization.description') }}
+      </p>
+    </div>
+    <PinsLocalizationSettings embedded />
+  </div>
+</template>
+
+<script setup>
+import { useI18n } from 'vue-i18n';
+import PinsLocalizationSettings from '@/components/settings/general/PinsLocalizationSettings.vue';
+
+const { t } = useI18n();
+</script>

--- a/src/locales/ca.json
+++ b/src/locales/ca.json
@@ -692,6 +692,8 @@
         "description": "These are the current settings on the PINS device, not this app. Changes apply to every phone, tablet and browser that connects to it.",
         "systemLocale": "Locale",
         "wifiCountry": "Wi-Fi country",
+        "wifiCountryConfirmTitle": "Voleu aplicar el canvi de país de la Wi-Fi?",
+        "wifiCountryConfirmMessage": "Canviar el país de la Wi-Fi pot interrompre breument la connexió amb aquest dispositiu PINS. Voleu aplicar els canvis?",
         "timezone": "Time zone",
         "keyboardLayout": "Keyboard layout",
         "loading": "Reading the current system settings...",

--- a/src/locales/ca.json
+++ b/src/locales/ca.json
@@ -249,7 +249,8 @@
         "focuser": "Focuser",
         "filterWheel": "Filter wheel",
         "guider": "Guiding",
-        "done": "Done"
+        "done": "Done",
+        "localization": "Regional settings"
       },
       "driver": {
         "loading": "Loading drivers…",
@@ -433,7 +434,11 @@
         "moreDevicesHint": "Flat panel, weather and the remaining devices are configured on their own pages.",
         "noConnectionHint": "No connection to a rig yet. You can add one under Settings → Connection at any time."
       },
-      "cancel": "Cancel setup"
+      "cancel": "Cancel setup",
+      "localization": {
+        "title": "Set the rig regional settings",
+        "description": "Set these values before Wi-Fi so hotspot location, time and remote keyboard input match where the rig is used."
+      }
     },
     "fileBrowser": {
       "title": "Navega",
@@ -681,6 +686,22 @@
       "mount": {
         "titel": "Configuració de la muntura",
         "max_slew_rate": "Velocitat màxima de desplaçament (°/s)"
+      },
+      "localization": {
+        "title": "System regional settings",
+        "description": "These are the current settings on the PINS device, not this app. Changes apply to every phone, tablet and browser that connects to it.",
+        "systemLocale": "Locale",
+        "wifiCountry": "Wi-Fi country",
+        "timezone": "Time zone",
+        "keyboardLayout": "Keyboard layout",
+        "loading": "Reading the current system settings...",
+        "loadError": "Could not read the system settings: {message}",
+        "save": "Apply changes",
+        "saving": "Applying...",
+        "saved": "System settings updated.",
+        "saveError": "Could not update the system settings: {message}",
+        "missingJob": "The PINS daemon did not return an operation ID.",
+        "refresh": "Reload current values"
       }
     },
     "alpacaDirect": {
@@ -4234,7 +4255,7 @@
       },
       "messages": {
         "noSessionsDeleted": "No s'ha eliminat cap sessió.",
-        "deletedSessions": "S'han eliminat {count} sessió(s), s'ha alliberat {freed}, ús restant del connector {remaining}.",
+        "deletedSessions": "S'han eliminat {count} sessió{suffix}, s'ha alliberat {freed}, ús restant del connector {remaining}.",
         "deletedArtifact": "Artefacte eliminat i s'ha alliberat {freed}.",
         "deletedFrame": "Fotograma eliminat i s'ha alliberat {freed}.",
         "backendUpdateStarted": "Actualització del backend iniciada. PINS es reiniciarà quan l'instal·lació hagi acabat."

--- a/src/locales/ca.json
+++ b/src/locales/ca.json
@@ -436,8 +436,8 @@
       },
       "cancel": "Cancel setup",
       "localization": {
-        "title": "Set the rig regional settings",
-        "description": "Set these values before Wi-Fi so hotspot location, time and remote keyboard input match where the rig is used."
+        "title": "Configura els paràmetres regionals de l'equip",
+        "description": "Configura aquests valors abans de la Wi-Fi perquè la ubicació del punt d'accés, l'hora i l'entrada del teclat remot coincideixin amb el lloc on s'utilitza l'equip."
       }
     },
     "fileBrowser": {
@@ -688,23 +688,23 @@
         "max_slew_rate": "Velocitat màxima de desplaçament (°/s)"
       },
       "localization": {
-        "title": "System regional settings",
-        "description": "These are the current settings on the PINS device, not this app. Changes apply to every phone, tablet and browser that connects to it.",
-        "systemLocale": "Locale",
-        "wifiCountry": "Wi-Fi country",
+        "title": "Paràmetres regionals del sistema",
+        "description": "Aquests són els paràmetres actuals del dispositiu PINS, no d'aquesta aplicació. Els canvis s'apliquen a tots els telèfons, tauletes i navegadors que s'hi connectin.",
+        "systemLocale": "Configuració regional",
+        "wifiCountry": "País de la Wi-Fi",
         "wifiCountryConfirmTitle": "Voleu aplicar el canvi de país de la Wi-Fi?",
         "wifiCountryConfirmMessage": "Canviar el país de la Wi-Fi pot interrompre breument la connexió amb aquest dispositiu PINS. Voleu aplicar els canvis?",
-        "timezone": "Time zone",
-        "keyboardLayout": "Keyboard layout",
-        "loading": "Reading the current system settings...",
-        "loadError": "Could not read the system settings: {message}",
-        "save": "Apply changes",
-        "saving": "Applying...",
-        "saved": "System settings updated.",
-        "saveError": "Could not update the system settings: {message}",
-        "missingJob": "The PINS daemon did not return an operation ID.",
-        "refresh": "Reload current values",
-        "searchPlaceholder": "Filter available options..."
+        "timezone": "Zona horària",
+        "keyboardLayout": "Distribució del teclat",
+        "loading": "S'estan llegint els paràmetres actuals del sistema...",
+        "loadError": "No s'han pogut llegir els paràmetres del sistema: {message}",
+        "save": "Aplica els canvis",
+        "saving": "S'estan aplicant...",
+        "saved": "S'han actualitzat els paràmetres del sistema.",
+        "saveError": "No s'han pogut actualitzar els paràmetres del sistema: {message}",
+        "missingJob": "El dimoni PINS no ha retornat cap ID d'operació.",
+        "refresh": "Torna a carregar els valors actuals",
+        "searchPlaceholder": "Filtra les opcions disponibles..."
       }
     },
     "alpacaDirect": {

--- a/src/locales/ca.json
+++ b/src/locales/ca.json
@@ -701,7 +701,8 @@
         "saved": "System settings updated.",
         "saveError": "Could not update the system settings: {message}",
         "missingJob": "The PINS daemon did not return an operation ID.",
-        "refresh": "Reload current values"
+        "refresh": "Reload current values",
+        "searchPlaceholder": "Filter available options..."
       }
     },
     "alpacaDirect": {

--- a/src/locales/cn.json
+++ b/src/locales/cn.json
@@ -660,7 +660,8 @@
         "saved": "System settings updated.",
         "saveError": "Could not update the system settings: {message}",
         "missingJob": "The PINS daemon did not return an operation ID.",
-        "refresh": "Reload current values"
+        "refresh": "Reload current values",
+        "searchPlaceholder": "Filter available options..."
       }
     },
     "alpacaDirect": {

--- a/src/locales/cn.json
+++ b/src/locales/cn.json
@@ -208,7 +208,8 @@
         "focuser": "Focuser",
         "filterWheel": "Filter wheel",
         "guider": "Guiding",
-        "done": "Done"
+        "done": "Done",
+        "localization": "Regional settings"
       },
       "driver": {
         "loading": "Loading drivers…",
@@ -392,7 +393,11 @@
         "moreDevicesHint": "Flat panel, weather and the remaining devices are configured on their own pages.",
         "noConnectionHint": "No connection to a rig yet. You can add one under Settings → Connection at any time."
       },
-      "cancel": "Cancel setup"
+      "cancel": "Cancel setup",
+      "localization": {
+        "title": "Set the rig regional settings",
+        "description": "Set these values before Wi-Fi so hotspot location, time and remote keyboard input match where the rig is used."
+      }
     },
     "fileBrowser": {
       "title": "Browse",
@@ -640,6 +645,22 @@
         "clearTitle": "清除地平线文件路径",
         "confirmTitle": "清除地平线文件路径",
         "confirmMessage": "确定要清除地平线文件路径吗？"
+      },
+      "localization": {
+        "title": "System regional settings",
+        "description": "These are the current settings on the PINS device, not this app. Changes apply to every phone, tablet and browser that connects to it.",
+        "systemLocale": "Locale",
+        "wifiCountry": "Wi-Fi country",
+        "timezone": "Time zone",
+        "keyboardLayout": "Keyboard layout",
+        "loading": "Reading the current system settings...",
+        "loadError": "Could not read the system settings: {message}",
+        "save": "Apply changes",
+        "saving": "Applying...",
+        "saved": "System settings updated.",
+        "saveError": "Could not update the system settings: {message}",
+        "missingJob": "The PINS daemon did not return an operation ID.",
+        "refresh": "Reload current values"
       }
     },
     "alpacaDirect": {

--- a/src/locales/cn.json
+++ b/src/locales/cn.json
@@ -395,8 +395,8 @@
       },
       "cancel": "Cancel setup",
       "localization": {
-        "title": "Set the rig regional settings",
-        "description": "Set these values before Wi-Fi so hotspot location, time and remote keyboard input match where the rig is used."
+        "title": "设置设备的区域设置",
+        "description": "请在设置 Wi-Fi 前配置这些值，以便热点位置、时间和远程键盘输入与设备使用地点一致。"
       }
     },
     "fileBrowser": {
@@ -647,23 +647,23 @@
         "confirmMessage": "确定要清除地平线文件路径吗？"
       },
       "localization": {
-        "title": "System regional settings",
-        "description": "These are the current settings on the PINS device, not this app. Changes apply to every phone, tablet and browser that connects to it.",
-        "systemLocale": "Locale",
-        "wifiCountry": "Wi-Fi country",
+        "title": "系统区域设置",
+        "description": "这些是 PINS 设备当前的设置，而不是此应用的设置。更改会应用于连接到该设备的所有手机、平板电脑和浏览器。",
+        "systemLocale": "区域设置",
+        "wifiCountry": "Wi-Fi 国家或地区",
         "wifiCountryConfirmTitle": "应用 Wi-Fi 国家或地区更改？",
         "wifiCountryConfirmMessage": "更改 Wi-Fi 国家或地区可能会短暂中断与此 PINS 设备的连接。是否应用更改？",
-        "timezone": "Time zone",
-        "keyboardLayout": "Keyboard layout",
-        "loading": "Reading the current system settings...",
-        "loadError": "Could not read the system settings: {message}",
-        "save": "Apply changes",
-        "saving": "Applying...",
-        "saved": "System settings updated.",
-        "saveError": "Could not update the system settings: {message}",
-        "missingJob": "The PINS daemon did not return an operation ID.",
-        "refresh": "Reload current values",
-        "searchPlaceholder": "Filter available options..."
+        "timezone": "时区",
+        "keyboardLayout": "键盘布局",
+        "loading": "正在读取当前系统设置...",
+        "loadError": "无法读取系统设置：{message}",
+        "save": "应用更改",
+        "saving": "正在应用...",
+        "saved": "系统设置已更新。",
+        "saveError": "无法更新系统设置：{message}",
+        "missingJob": "PINS 守护程序未返回操作 ID。",
+        "refresh": "重新加载当前值",
+        "searchPlaceholder": "筛选可用选项..."
       }
     },
     "alpacaDirect": {

--- a/src/locales/cn.json
+++ b/src/locales/cn.json
@@ -651,6 +651,8 @@
         "description": "These are the current settings on the PINS device, not this app. Changes apply to every phone, tablet and browser that connects to it.",
         "systemLocale": "Locale",
         "wifiCountry": "Wi-Fi country",
+        "wifiCountryConfirmTitle": "应用 Wi-Fi 国家或地区更改？",
+        "wifiCountryConfirmMessage": "更改 Wi-Fi 国家或地区可能会短暂中断与此 PINS 设备的连接。是否应用更改？",
         "timezone": "Time zone",
         "keyboardLayout": "Keyboard layout",
         "loading": "Reading the current system settings...",

--- a/src/locales/cz.json
+++ b/src/locales/cz.json
@@ -660,7 +660,8 @@
         "saved": "System settings updated.",
         "saveError": "Could not update the system settings: {message}",
         "missingJob": "The PINS daemon did not return an operation ID.",
-        "refresh": "Reload current values"
+        "refresh": "Reload current values",
+        "searchPlaceholder": "Filter available options..."
       }
     },
     "alpacaDirect": {

--- a/src/locales/cz.json
+++ b/src/locales/cz.json
@@ -208,7 +208,8 @@
         "focuser": "Focuser",
         "filterWheel": "Filter wheel",
         "guider": "Guiding",
-        "done": "Done"
+        "done": "Done",
+        "localization": "Regional settings"
       },
       "driver": {
         "loading": "Loading drivers…",
@@ -392,7 +393,11 @@
         "moreDevicesHint": "Flat panel, weather and the remaining devices are configured on their own pages.",
         "noConnectionHint": "No connection to a rig yet. You can add one under Settings → Connection at any time."
       },
-      "cancel": "Cancel setup"
+      "cancel": "Cancel setup",
+      "localization": {
+        "title": "Set the rig regional settings",
+        "description": "Set these values before Wi-Fi so hotspot location, time and remote keyboard input match where the rig is used."
+      }
     },
     "fileBrowser": {
       "title": "Browse",
@@ -640,6 +645,22 @@
         "clearTitle": "Vymazat cestu souboru horizontu",
         "confirmTitle": "Vymazat cestu souboru horizontu",
         "confirmMessage": "Opravdu chcete vymazat cestu souboru horizontu?"
+      },
+      "localization": {
+        "title": "System regional settings",
+        "description": "These are the current settings on the PINS device, not this app. Changes apply to every phone, tablet and browser that connects to it.",
+        "systemLocale": "Locale",
+        "wifiCountry": "Wi-Fi country",
+        "timezone": "Time zone",
+        "keyboardLayout": "Keyboard layout",
+        "loading": "Reading the current system settings...",
+        "loadError": "Could not read the system settings: {message}",
+        "save": "Apply changes",
+        "saving": "Applying...",
+        "saved": "System settings updated.",
+        "saveError": "Could not update the system settings: {message}",
+        "missingJob": "The PINS daemon did not return an operation ID.",
+        "refresh": "Reload current values"
       }
     },
     "alpacaDirect": {

--- a/src/locales/cz.json
+++ b/src/locales/cz.json
@@ -651,6 +651,8 @@
         "description": "These are the current settings on the PINS device, not this app. Changes apply to every phone, tablet and browser that connects to it.",
         "systemLocale": "Locale",
         "wifiCountry": "Wi-Fi country",
+        "wifiCountryConfirmTitle": "Použít změnu země Wi-Fi?",
+        "wifiCountryConfirmMessage": "Změna země Wi-Fi může krátce přerušit připojení k tomuto zařízení PINS. Použít změny?",
         "timezone": "Time zone",
         "keyboardLayout": "Keyboard layout",
         "loading": "Reading the current system settings...",

--- a/src/locales/cz.json
+++ b/src/locales/cz.json
@@ -395,8 +395,8 @@
       },
       "cancel": "Cancel setup",
       "localization": {
-        "title": "Set the rig regional settings",
-        "description": "Set these values before Wi-Fi so hotspot location, time and remote keyboard input match where the rig is used."
+        "title": "Nastavit místní nastavení sestavy",
+        "description": "Nastavte tyto hodnoty před Wi-Fi, aby umístění hotspotu, čas a vzdálené zadávání z klávesnice odpovídaly místu použití sestavy."
       }
     },
     "fileBrowser": {
@@ -647,23 +647,23 @@
         "confirmMessage": "Opravdu chcete vymazat cestu souboru horizontu?"
       },
       "localization": {
-        "title": "System regional settings",
-        "description": "These are the current settings on the PINS device, not this app. Changes apply to every phone, tablet and browser that connects to it.",
-        "systemLocale": "Locale",
-        "wifiCountry": "Wi-Fi country",
+        "title": "Místní nastavení systému",
+        "description": "Toto jsou aktuální nastavení zařízení PINS, nikoli této aplikace. Změny platí pro každý telefon, tablet a prohlížeč, který se k němu připojí.",
+        "systemLocale": "Národní prostředí",
+        "wifiCountry": "Země Wi-Fi",
         "wifiCountryConfirmTitle": "Použít změnu země Wi-Fi?",
         "wifiCountryConfirmMessage": "Změna země Wi-Fi může krátce přerušit připojení k tomuto zařízení PINS. Použít změny?",
-        "timezone": "Time zone",
-        "keyboardLayout": "Keyboard layout",
-        "loading": "Reading the current system settings...",
-        "loadError": "Could not read the system settings: {message}",
-        "save": "Apply changes",
-        "saving": "Applying...",
-        "saved": "System settings updated.",
-        "saveError": "Could not update the system settings: {message}",
-        "missingJob": "The PINS daemon did not return an operation ID.",
-        "refresh": "Reload current values",
-        "searchPlaceholder": "Filter available options..."
+        "timezone": "Časové pásmo",
+        "keyboardLayout": "Rozložení klávesnice",
+        "loading": "Načítají se aktuální systémová nastavení...",
+        "loadError": "Systémová nastavení se nepodařilo načíst: {message}",
+        "save": "Použít změny",
+        "saving": "Používání změn...",
+        "saved": "Systémová nastavení byla aktualizována.",
+        "saveError": "Systémová nastavení se nepodařilo aktualizovat: {message}",
+        "missingJob": "Démon PINS nevrátil ID operace.",
+        "refresh": "Znovu načíst aktuální hodnoty",
+        "searchPlaceholder": "Filtrovat dostupné možnosti..."
       }
     },
     "alpacaDirect": {

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -692,6 +692,8 @@
         "description": "Dies sind die aktuellen Einstellungen des PINS-Geräts, nicht dieser App. Änderungen gelten für alle verbundenen Geräte.",
         "systemLocale": "Gebietsschema",
         "wifiCountry": "WLAN-Land",
+        "wifiCountryConfirmTitle": "Änderung des WLAN-Landes anwenden?",
+        "wifiCountryConfirmMessage": "Das Ändern des WLAN-Landes kann die Verbindung zu diesem PINS-Gerät kurz unterbrechen. Änderungen anwenden?",
         "timezone": "Zeitzone",
         "keyboardLayout": "Tastaturbelegung",
         "loading": "Aktuelle Systemeinstellungen werden gelesen...",

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -701,7 +701,8 @@
         "saved": "Systemeinstellungen wurden aktualisiert.",
         "saveError": "Systemeinstellungen konnten nicht aktualisiert werden: {message}",
         "missingJob": "Der PINS-Daemon hat keine Vorgangs-ID zurückgegeben.",
-        "refresh": "Aktuelle Werte neu laden"
+        "refresh": "Aktuelle Werte neu laden",
+        "searchPlaceholder": "Verfügbare Optionen filtern..."
       }
     },
     "alpacaDirect": {

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -249,7 +249,8 @@
         "focuser": "Fokussierer",
         "filterWheel": "Filterrad",
         "guider": "Guiding",
-        "done": "Fertig"
+        "done": "Fertig",
+        "localization": "Regionale Einstellungen"
       },
       "driver": {
         "loading": "Treiber werden geladen…",
@@ -433,7 +434,11 @@
         "moreDevicesHint": "Flatfield-Panel, Wetter und die übrigen Geräte richtest du auf ihren eigenen Seiten ein.",
         "noConnectionHint": "Noch keine Verbindung zu einem Rig. Du kannst sie jederzeit unter Einstellungen → Verbindung nachtragen."
       },
-      "cancel": "Einrichtung abbrechen"
+      "cancel": "Einrichtung abbrechen",
+      "localization": {
+        "title": "Regionale Einstellungen des Systems",
+        "description": "Lege diese Werte vor dem WLAN fest, damit Hotspot-Standort, Uhrzeit und Remote-Tastatur zum Einsatzort passen."
+      }
     },
     "fileBrowser": {
       "title": "Durchsuchen",
@@ -681,6 +686,22 @@
         "loadError": "Zeitinformationen konnten nicht geladen werden.",
         "syncError": "Die Zeitsynchronisierung ist fehlgeschlagen. \nÜberprüfen Sie die Verbindung zum PINS-Gerät.",
         "syncSuccess": "Zeit erfolgreich synchronisiert."
+      },
+      "localization": {
+        "title": "Regionale Systemeinstellungen",
+        "description": "Dies sind die aktuellen Einstellungen des PINS-Geräts, nicht dieser App. Änderungen gelten für alle verbundenen Geräte.",
+        "systemLocale": "Gebietsschema",
+        "wifiCountry": "WLAN-Land",
+        "timezone": "Zeitzone",
+        "keyboardLayout": "Tastaturbelegung",
+        "loading": "Aktuelle Systemeinstellungen werden gelesen...",
+        "loadError": "Systemeinstellungen konnten nicht gelesen werden: {message}",
+        "save": "Änderungen anwenden",
+        "saving": "Wird angewendet...",
+        "saved": "Systemeinstellungen wurden aktualisiert.",
+        "saveError": "Systemeinstellungen konnten nicht aktualisiert werden: {message}",
+        "missingJob": "Der PINS-Daemon hat keine Vorgangs-ID zurückgegeben.",
+        "refresh": "Aktuelle Werte neu laden"
       }
     },
     "alpacaDirect": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -249,7 +249,8 @@
         "focuser": "Focuser",
         "filterWheel": "Filter wheel",
         "guider": "Guiding",
-        "done": "Done"
+        "done": "Done",
+        "localization": "Regional settings"
       },
       "driver": {
         "loading": "Loading drivers…",
@@ -433,7 +434,11 @@
         "moreDevicesHint": "Flat panel, weather and the remaining devices are configured on their own pages.",
         "noConnectionHint": "No connection to a rig yet. You can add one under Settings → Connection at any time."
       },
-      "cancel": "Cancel setup"
+      "cancel": "Cancel setup",
+      "localization": {
+        "title": "Set the rig regional settings",
+        "description": "Set these values before Wi-Fi so hotspot location, time and remote keyboard input match where the rig is used."
+      }
     },
     "fileBrowser": {
       "title": "Browse",
@@ -681,6 +686,22 @@
       "mount": {
         "titel": "Mount settings",
         "max_slew_rate": "Max slew rate (°/s)"
+      },
+      "localization": {
+        "title": "System regional settings",
+        "description": "These are the current settings on the PINS device, not this app. Changes apply to every phone, tablet and browser that connects to it.",
+        "systemLocale": "Locale",
+        "wifiCountry": "Wi-Fi country",
+        "timezone": "Time zone",
+        "keyboardLayout": "Keyboard layout",
+        "loading": "Reading the current system settings...",
+        "loadError": "Could not read the system settings: {message}",
+        "save": "Apply changes",
+        "saving": "Applying...",
+        "saved": "System settings updated.",
+        "saveError": "Could not update the system settings: {message}",
+        "missingJob": "The PINS daemon did not return an operation ID.",
+        "refresh": "Reload current values"
       }
     },
     "alpacaDirect": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -692,6 +692,8 @@
         "description": "These are the current settings on the PINS device, not this app. Changes apply to every phone, tablet and browser that connects to it.",
         "systemLocale": "Locale",
         "wifiCountry": "Wi-Fi country",
+        "wifiCountryConfirmTitle": "Apply Wi-Fi country change?",
+        "wifiCountryConfirmMessage": "Changing the Wi-Fi country may briefly interrupt the connection to this PINS device. Apply the changes?",
         "timezone": "Time zone",
         "keyboardLayout": "Keyboard layout",
         "loading": "Reading the current system settings...",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -701,7 +701,8 @@
         "saved": "System settings updated.",
         "saveError": "Could not update the system settings: {message}",
         "missingJob": "The PINS daemon did not return an operation ID.",
-        "refresh": "Reload current values"
+        "refresh": "Reload current values",
+        "searchPlaceholder": "Filter available options..."
       }
     },
     "alpacaDirect": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -660,7 +660,8 @@
         "saved": "System settings updated.",
         "saveError": "Could not update the system settings: {message}",
         "missingJob": "The PINS daemon did not return an operation ID.",
-        "refresh": "Reload current values"
+        "refresh": "Reload current values",
+        "searchPlaceholder": "Filter available options..."
       }
     },
     "alpacaDirect": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -651,6 +651,8 @@
         "description": "These are the current settings on the PINS device, not this app. Changes apply to every phone, tablet and browser that connects to it.",
         "systemLocale": "Locale",
         "wifiCountry": "Wi-Fi country",
+        "wifiCountryConfirmTitle": "¿Aplicar el cambio de país Wi-Fi?",
+        "wifiCountryConfirmMessage": "Cambiar el país Wi-Fi puede interrumpir brevemente la conexión con este dispositivo PINS. ¿Aplicar los cambios?",
         "timezone": "Time zone",
         "keyboardLayout": "Keyboard layout",
         "loading": "Reading the current system settings...",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -395,8 +395,8 @@
       },
       "cancel": "Cancel setup",
       "localization": {
-        "title": "Set the rig regional settings",
-        "description": "Set these values before Wi-Fi so hotspot location, time and remote keyboard input match where the rig is used."
+        "title": "Configurar los ajustes regionales del equipo",
+        "description": "Configura estos valores antes del Wi-Fi para que la ubicación del punto de acceso, la hora y la entrada del teclado remoto coincidan con el lugar donde se utiliza el equipo."
       }
     },
     "fileBrowser": {
@@ -647,23 +647,23 @@
         "confirmMessage": "¿Desea borrar la ruta del archivo de horizonte?"
       },
       "localization": {
-        "title": "System regional settings",
-        "description": "These are the current settings on the PINS device, not this app. Changes apply to every phone, tablet and browser that connects to it.",
-        "systemLocale": "Locale",
-        "wifiCountry": "Wi-Fi country",
+        "title": "Ajustes regionales del sistema",
+        "description": "Estos son los ajustes actuales del dispositivo PINS, no los de esta aplicación. Los cambios se aplican a todos los teléfonos, tabletas y navegadores que se conecten a él.",
+        "systemLocale": "Configuración regional",
+        "wifiCountry": "País Wi-Fi",
         "wifiCountryConfirmTitle": "¿Aplicar el cambio de país Wi-Fi?",
         "wifiCountryConfirmMessage": "Cambiar el país Wi-Fi puede interrumpir brevemente la conexión con este dispositivo PINS. ¿Aplicar los cambios?",
-        "timezone": "Time zone",
-        "keyboardLayout": "Keyboard layout",
-        "loading": "Reading the current system settings...",
-        "loadError": "Could not read the system settings: {message}",
-        "save": "Apply changes",
-        "saving": "Applying...",
-        "saved": "System settings updated.",
-        "saveError": "Could not update the system settings: {message}",
-        "missingJob": "The PINS daemon did not return an operation ID.",
-        "refresh": "Reload current values",
-        "searchPlaceholder": "Filter available options..."
+        "timezone": "Zona horaria",
+        "keyboardLayout": "Distribución del teclado",
+        "loading": "Leyendo los ajustes actuales del sistema...",
+        "loadError": "No se pudieron leer los ajustes del sistema: {message}",
+        "save": "Aplicar cambios",
+        "saving": "Aplicando...",
+        "saved": "Ajustes del sistema actualizados.",
+        "saveError": "No se pudieron actualizar los ajustes del sistema: {message}",
+        "missingJob": "El servicio PINS no devolvió un ID de operación.",
+        "refresh": "Volver a cargar los valores actuales",
+        "searchPlaceholder": "Filtrar las opciones disponibles..."
       }
     },
     "alpacaDirect": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -208,7 +208,8 @@
         "focuser": "Focuser",
         "filterWheel": "Filter wheel",
         "guider": "Guiding",
-        "done": "Done"
+        "done": "Done",
+        "localization": "Regional settings"
       },
       "driver": {
         "loading": "Loading drivers…",
@@ -392,7 +393,11 @@
         "moreDevicesHint": "Flat panel, weather and the remaining devices are configured on their own pages.",
         "noConnectionHint": "No connection to a rig yet. You can add one under Settings → Connection at any time."
       },
-      "cancel": "Cancel setup"
+      "cancel": "Cancel setup",
+      "localization": {
+        "title": "Set the rig regional settings",
+        "description": "Set these values before Wi-Fi so hotspot location, time and remote keyboard input match where the rig is used."
+      }
     },
     "fileBrowser": {
       "title": "Browse",
@@ -640,6 +645,22 @@
         "clearTitle": "Borrar ruta del archivo de horizonte",
         "confirmTitle": "Borrar ruta del archivo de horizonte",
         "confirmMessage": "¿Desea borrar la ruta del archivo de horizonte?"
+      },
+      "localization": {
+        "title": "System regional settings",
+        "description": "These are the current settings on the PINS device, not this app. Changes apply to every phone, tablet and browser that connects to it.",
+        "systemLocale": "Locale",
+        "wifiCountry": "Wi-Fi country",
+        "timezone": "Time zone",
+        "keyboardLayout": "Keyboard layout",
+        "loading": "Reading the current system settings...",
+        "loadError": "Could not read the system settings: {message}",
+        "save": "Apply changes",
+        "saving": "Applying...",
+        "saved": "System settings updated.",
+        "saveError": "Could not update the system settings: {message}",
+        "missingJob": "The PINS daemon did not return an operation ID.",
+        "refresh": "Reload current values"
       }
     },
     "alpacaDirect": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -660,7 +660,8 @@
         "saved": "System settings updated.",
         "saveError": "Could not update the system settings: {message}",
         "missingJob": "The PINS daemon did not return an operation ID.",
-        "refresh": "Reload current values"
+        "refresh": "Reload current values",
+        "searchPlaceholder": "Filter available options..."
       }
     },
     "alpacaDirect": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -651,6 +651,8 @@
         "description": "These are the current settings on the PINS device, not this app. Changes apply to every phone, tablet and browser that connects to it.",
         "systemLocale": "Locale",
         "wifiCountry": "Wi-Fi country",
+        "wifiCountryConfirmTitle": "Appliquer le changement de pays Wi-Fi ?",
+        "wifiCountryConfirmMessage": "Changer le pays Wi-Fi peut interrompre brièvement la connexion à cet appareil PINS. Appliquer les modifications ?",
         "timezone": "Time zone",
         "keyboardLayout": "Keyboard layout",
         "loading": "Reading the current system settings...",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -208,7 +208,8 @@
         "focuser": "Focuser",
         "filterWheel": "Filter wheel",
         "guider": "Guiding",
-        "done": "Done"
+        "done": "Done",
+        "localization": "Regional settings"
       },
       "driver": {
         "loading": "Loading drivers…",
@@ -392,7 +393,11 @@
         "moreDevicesHint": "Flat panel, weather and the remaining devices are configured on their own pages.",
         "noConnectionHint": "No connection to a rig yet. You can add one under Settings → Connection at any time."
       },
-      "cancel": "Cancel setup"
+      "cancel": "Cancel setup",
+      "localization": {
+        "title": "Set the rig regional settings",
+        "description": "Set these values before Wi-Fi so hotspot location, time and remote keyboard input match where the rig is used."
+      }
     },
     "fileBrowser": {
       "title": "Browse",
@@ -640,6 +645,22 @@
         "clearTitle": "Effacer le chemin du fichier d'horizon",
         "confirmTitle": "Effacer le chemin du fichier d'horizon",
         "confirmMessage": "Voulez-vous vraiment effacer le chemin du fichier d'horizon ?"
+      },
+      "localization": {
+        "title": "System regional settings",
+        "description": "These are the current settings on the PINS device, not this app. Changes apply to every phone, tablet and browser that connects to it.",
+        "systemLocale": "Locale",
+        "wifiCountry": "Wi-Fi country",
+        "timezone": "Time zone",
+        "keyboardLayout": "Keyboard layout",
+        "loading": "Reading the current system settings...",
+        "loadError": "Could not read the system settings: {message}",
+        "save": "Apply changes",
+        "saving": "Applying...",
+        "saved": "System settings updated.",
+        "saveError": "Could not update the system settings: {message}",
+        "missingJob": "The PINS daemon did not return an operation ID.",
+        "refresh": "Reload current values"
       }
     },
     "alpacaDirect": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -395,8 +395,8 @@
       },
       "cancel": "Cancel setup",
       "localization": {
-        "title": "Set the rig regional settings",
-        "description": "Set these values before Wi-Fi so hotspot location, time and remote keyboard input match where the rig is used."
+        "title": "Configurer les paramètres régionaux de l'équipement",
+        "description": "Configurez ces valeurs avant le Wi-Fi afin que l'emplacement du point d'accès, l'heure et la saisie au clavier distant correspondent au lieu d'utilisation de l'équipement."
       }
     },
     "fileBrowser": {
@@ -647,23 +647,23 @@
         "confirmMessage": "Voulez-vous vraiment effacer le chemin du fichier d'horizon ?"
       },
       "localization": {
-        "title": "System regional settings",
-        "description": "These are the current settings on the PINS device, not this app. Changes apply to every phone, tablet and browser that connects to it.",
-        "systemLocale": "Locale",
-        "wifiCountry": "Wi-Fi country",
+        "title": "Paramètres régionaux du système",
+        "description": "Il s'agit des paramètres actuels de l'appareil PINS, et non de cette application. Les modifications s'appliquent à tous les téléphones, tablettes et navigateurs qui s'y connectent.",
+        "systemLocale": "Paramètres régionaux",
+        "wifiCountry": "Pays Wi-Fi",
         "wifiCountryConfirmTitle": "Appliquer le changement de pays Wi-Fi ?",
         "wifiCountryConfirmMessage": "Changer le pays Wi-Fi peut interrompre brièvement la connexion à cet appareil PINS. Appliquer les modifications ?",
-        "timezone": "Time zone",
-        "keyboardLayout": "Keyboard layout",
-        "loading": "Reading the current system settings...",
-        "loadError": "Could not read the system settings: {message}",
-        "save": "Apply changes",
-        "saving": "Applying...",
-        "saved": "System settings updated.",
-        "saveError": "Could not update the system settings: {message}",
-        "missingJob": "The PINS daemon did not return an operation ID.",
-        "refresh": "Reload current values",
-        "searchPlaceholder": "Filter available options..."
+        "timezone": "Fuseau horaire",
+        "keyboardLayout": "Disposition du clavier",
+        "loading": "Lecture des paramètres actuels du système...",
+        "loadError": "Impossible de lire les paramètres du système : {message}",
+        "save": "Appliquer les modifications",
+        "saving": "Application en cours...",
+        "saved": "Paramètres du système mis à jour.",
+        "saveError": "Impossible de mettre à jour les paramètres du système : {message}",
+        "missingJob": "Le service PINS n'a renvoyé aucun identifiant d'opération.",
+        "refresh": "Recharger les valeurs actuelles",
+        "searchPlaceholder": "Filtrer les options disponibles..."
       }
     },
     "alpacaDirect": {

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -660,7 +660,8 @@
         "saved": "System settings updated.",
         "saveError": "Could not update the system settings: {message}",
         "missingJob": "The PINS daemon did not return an operation ID.",
-        "refresh": "Reload current values"
+        "refresh": "Reload current values",
+        "searchPlaceholder": "Filter available options..."
       }
     },
     "alpacaDirect": {

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -395,8 +395,8 @@
       },
       "cancel": "Cancel setup",
       "localization": {
-        "title": "Set the rig regional settings",
-        "description": "Set these values before Wi-Fi so hotspot location, time and remote keyboard input match where the rig is used."
+        "title": "Configura le impostazioni regionali dell'attrezzatura",
+        "description": "Configura questi valori prima del Wi-Fi affinché la posizione dell'hotspot, l'ora e l'input della tastiera remota corrispondano al luogo in cui viene utilizzata l'attrezzatura."
       }
     },
     "fileBrowser": {
@@ -647,23 +647,23 @@
         "confirmMessage": "Sei sicuro di voler cancellare il percorso del file orizzonte?"
       },
       "localization": {
-        "title": "System regional settings",
-        "description": "These are the current settings on the PINS device, not this app. Changes apply to every phone, tablet and browser that connects to it.",
-        "systemLocale": "Locale",
-        "wifiCountry": "Wi-Fi country",
+        "title": "Impostazioni regionali del sistema",
+        "description": "Queste sono le impostazioni correnti del dispositivo PINS, non dell'app. Le modifiche si applicano a tutti i telefoni, tablet e browser che si connettono al dispositivo.",
+        "systemLocale": "Impostazioni locali",
+        "wifiCountry": "Paese Wi-Fi",
         "wifiCountryConfirmTitle": "Applicare la modifica del paese Wi-Fi?",
         "wifiCountryConfirmMessage": "La modifica del paese Wi-Fi può interrompere brevemente la connessione a questo dispositivo PINS. Applicare le modifiche?",
-        "timezone": "Time zone",
-        "keyboardLayout": "Keyboard layout",
-        "loading": "Reading the current system settings...",
-        "loadError": "Could not read the system settings: {message}",
-        "save": "Apply changes",
-        "saving": "Applying...",
-        "saved": "System settings updated.",
-        "saveError": "Could not update the system settings: {message}",
-        "missingJob": "The PINS daemon did not return an operation ID.",
-        "refresh": "Reload current values",
-        "searchPlaceholder": "Filter available options..."
+        "timezone": "Fuso orario",
+        "keyboardLayout": "Layout della tastiera",
+        "loading": "Lettura delle impostazioni correnti del sistema...",
+        "loadError": "Impossibile leggere le impostazioni del sistema: {message}",
+        "save": "Applica modifiche",
+        "saving": "Applicazione in corso...",
+        "saved": "Impostazioni del sistema aggiornate.",
+        "saveError": "Impossibile aggiornare le impostazioni del sistema: {message}",
+        "missingJob": "Il servizio PINS non ha restituito un ID operazione.",
+        "refresh": "Ricarica i valori correnti",
+        "searchPlaceholder": "Filtra le opzioni disponibili..."
       }
     },
     "alpacaDirect": {

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -651,6 +651,8 @@
         "description": "These are the current settings on the PINS device, not this app. Changes apply to every phone, tablet and browser that connects to it.",
         "systemLocale": "Locale",
         "wifiCountry": "Wi-Fi country",
+        "wifiCountryConfirmTitle": "Applicare la modifica del paese Wi-Fi?",
+        "wifiCountryConfirmMessage": "La modifica del paese Wi-Fi può interrompere brevemente la connessione a questo dispositivo PINS. Applicare le modifiche?",
         "timezone": "Time zone",
         "keyboardLayout": "Keyboard layout",
         "loading": "Reading the current system settings...",

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -208,7 +208,8 @@
         "focuser": "Focuser",
         "filterWheel": "Filter wheel",
         "guider": "Guiding",
-        "done": "Done"
+        "done": "Done",
+        "localization": "Regional settings"
       },
       "driver": {
         "loading": "Loading drivers…",
@@ -392,7 +393,11 @@
         "moreDevicesHint": "Flat panel, weather and the remaining devices are configured on their own pages.",
         "noConnectionHint": "No connection to a rig yet. You can add one under Settings → Connection at any time."
       },
-      "cancel": "Cancel setup"
+      "cancel": "Cancel setup",
+      "localization": {
+        "title": "Set the rig regional settings",
+        "description": "Set these values before Wi-Fi so hotspot location, time and remote keyboard input match where the rig is used."
+      }
     },
     "fileBrowser": {
       "title": "Browse",
@@ -640,6 +645,22 @@
         "clearTitle": "Cancella percorso file orizzonte",
         "confirmTitle": "Cancella percorso file orizzonte",
         "confirmMessage": "Sei sicuro di voler cancellare il percorso del file orizzonte?"
+      },
+      "localization": {
+        "title": "System regional settings",
+        "description": "These are the current settings on the PINS device, not this app. Changes apply to every phone, tablet and browser that connects to it.",
+        "systemLocale": "Locale",
+        "wifiCountry": "Wi-Fi country",
+        "timezone": "Time zone",
+        "keyboardLayout": "Keyboard layout",
+        "loading": "Reading the current system settings...",
+        "loadError": "Could not read the system settings: {message}",
+        "save": "Apply changes",
+        "saving": "Applying...",
+        "saved": "System settings updated.",
+        "saveError": "Could not update the system settings: {message}",
+        "missingJob": "The PINS daemon did not return an operation ID.",
+        "refresh": "Reload current values"
       }
     },
     "alpacaDirect": {

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -404,8 +404,8 @@
       },
       "cancel": "Cancel setup",
       "localization": {
-        "title": "Set the rig regional settings",
-        "description": "Set these values before Wi-Fi so hotspot location, time and remote keyboard input match where the rig is used."
+        "title": "機材の地域設定を行う",
+        "description": "ホットスポットの場所、時刻、リモートキーボード入力を機材の使用場所に合わせるため、Wi-Fi より先にこれらの値を設定してください。"
       }
     },
     "fileBrowser": {
@@ -656,23 +656,23 @@
         "max_slew_rate": "最大スルーレート (°/s)"
       },
       "localization": {
-        "title": "System regional settings",
-        "description": "These are the current settings on the PINS device, not this app. Changes apply to every phone, tablet and browser that connects to it.",
-        "systemLocale": "Locale",
-        "wifiCountry": "Wi-Fi country",
+        "title": "システムの地域設定",
+        "description": "これはこのアプリではなく、PINS デバイスの現在の設定です。変更は、このデバイスに接続するすべてのスマートフォン、タブレット、ブラウザーに適用されます。",
+        "systemLocale": "ロケール",
+        "wifiCountry": "Wi-Fi の国設定",
         "wifiCountryConfirmTitle": "Wi-Fi の国設定を変更しますか？",
         "wifiCountryConfirmMessage": "Wi-Fi の国設定を変更すると、この PINS デバイスとの接続が一時的に切断される場合があります。変更を適用しますか？",
-        "timezone": "Time zone",
-        "keyboardLayout": "Keyboard layout",
-        "loading": "Reading the current system settings...",
-        "loadError": "Could not read the system settings: {message}",
-        "save": "Apply changes",
-        "saving": "Applying...",
-        "saved": "System settings updated.",
-        "saveError": "Could not update the system settings: {message}",
-        "missingJob": "The PINS daemon did not return an operation ID.",
-        "refresh": "Reload current values",
-        "searchPlaceholder": "Filter available options..."
+        "timezone": "タイムゾーン",
+        "keyboardLayout": "キーボード配列",
+        "loading": "現在のシステム設定を読み込んでいます...",
+        "loadError": "システム設定を読み込めませんでした: {message}",
+        "save": "変更を適用",
+        "saving": "適用中...",
+        "saved": "システム設定を更新しました。",
+        "saveError": "システム設定を更新できませんでした: {message}",
+        "missingJob": "PINS デーモンが操作 ID を返しませんでした。",
+        "refresh": "現在の値を再読み込み",
+        "searchPlaceholder": "利用可能なオプションを絞り込む..."
       }
     },
     "alpacaDirect": {

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -669,7 +669,8 @@
         "saved": "System settings updated.",
         "saveError": "Could not update the system settings: {message}",
         "missingJob": "The PINS daemon did not return an operation ID.",
-        "refresh": "Reload current values"
+        "refresh": "Reload current values",
+        "searchPlaceholder": "Filter available options..."
       }
     },
     "alpacaDirect": {

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -660,6 +660,8 @@
         "description": "These are the current settings on the PINS device, not this app. Changes apply to every phone, tablet and browser that connects to it.",
         "systemLocale": "Locale",
         "wifiCountry": "Wi-Fi country",
+        "wifiCountryConfirmTitle": "Wi-Fi の国設定を変更しますか？",
+        "wifiCountryConfirmMessage": "Wi-Fi の国設定を変更すると、この PINS デバイスとの接続が一時的に切断される場合があります。変更を適用しますか？",
         "timezone": "Time zone",
         "keyboardLayout": "Keyboard layout",
         "loading": "Reading the current system settings...",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -217,7 +217,8 @@
         "focuser": "Focuser",
         "filterWheel": "Filter wheel",
         "guider": "Guiding",
-        "done": "Done"
+        "done": "Done",
+        "localization": "Regional settings"
       },
       "driver": {
         "loading": "Loading drivers…",
@@ -401,7 +402,11 @@
         "moreDevicesHint": "Flat panel, weather and the remaining devices are configured on their own pages.",
         "noConnectionHint": "No connection to a rig yet. You can add one under Settings → Connection at any time."
       },
-      "cancel": "Cancel setup"
+      "cancel": "Cancel setup",
+      "localization": {
+        "title": "Set the rig regional settings",
+        "description": "Set these values before Wi-Fi so hotspot location, time and remote keyboard input match where the rig is used."
+      }
     },
     "fileBrowser": {
       "title": "参照",
@@ -649,6 +654,22 @@
       "mount": {
         "titel": "赤道儀設定",
         "max_slew_rate": "最大スルーレート (°/s)"
+      },
+      "localization": {
+        "title": "System regional settings",
+        "description": "These are the current settings on the PINS device, not this app. Changes apply to every phone, tablet and browser that connects to it.",
+        "systemLocale": "Locale",
+        "wifiCountry": "Wi-Fi country",
+        "timezone": "Time zone",
+        "keyboardLayout": "Keyboard layout",
+        "loading": "Reading the current system settings...",
+        "loadError": "Could not read the system settings: {message}",
+        "save": "Apply changes",
+        "saving": "Applying...",
+        "saved": "System settings updated.",
+        "saveError": "Could not update the system settings: {message}",
+        "missingJob": "The PINS daemon did not return an operation ID.",
+        "refresh": "Reload current values"
       }
     },
     "alpacaDirect": {

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -692,6 +692,8 @@
         "description": "These are the current settings on the PINS device, not this app. Changes apply to every phone, tablet and browser that connects to it.",
         "systemLocale": "Locale",
         "wifiCountry": "Wi-Fi country",
+        "wifiCountryConfirmTitle": "Wi-Fi 국가 변경을 적용하시겠습니까?",
+        "wifiCountryConfirmMessage": "Wi-Fi 국가를 변경하면 이 PINS 장치와의 연결이 잠시 중단될 수 있습니다. 변경 사항을 적용하시겠습니까?",
         "timezone": "Time zone",
         "keyboardLayout": "Keyboard layout",
         "loading": "Reading the current system settings...",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -249,7 +249,8 @@
         "focuser": "Focuser",
         "filterWheel": "Filter wheel",
         "guider": "Guiding",
-        "done": "Done"
+        "done": "Done",
+        "localization": "Regional settings"
       },
       "driver": {
         "loading": "Loading drivers…",
@@ -433,7 +434,11 @@
         "moreDevicesHint": "Flat panel, weather and the remaining devices are configured on their own pages.",
         "noConnectionHint": "No connection to a rig yet. You can add one under Settings → Connection at any time."
       },
-      "cancel": "Cancel setup"
+      "cancel": "Cancel setup",
+      "localization": {
+        "title": "Set the rig regional settings",
+        "description": "Set these values before Wi-Fi so hotspot location, time and remote keyboard input match where the rig is used."
+      }
     },
     "fileBrowser": {
       "title": "찾아보기",
@@ -681,6 +686,22 @@
       "mount": {
         "titel": "마운트 설정",
         "max_slew_rate": "최대 슬루 속도 (°/s)"
+      },
+      "localization": {
+        "title": "System regional settings",
+        "description": "These are the current settings on the PINS device, not this app. Changes apply to every phone, tablet and browser that connects to it.",
+        "systemLocale": "Locale",
+        "wifiCountry": "Wi-Fi country",
+        "timezone": "Time zone",
+        "keyboardLayout": "Keyboard layout",
+        "loading": "Reading the current system settings...",
+        "loadError": "Could not read the system settings: {message}",
+        "save": "Apply changes",
+        "saving": "Applying...",
+        "saved": "System settings updated.",
+        "saveError": "Could not update the system settings: {message}",
+        "missingJob": "The PINS daemon did not return an operation ID.",
+        "refresh": "Reload current values"
       }
     },
     "alpacaDirect": {

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -701,7 +701,8 @@
         "saved": "System settings updated.",
         "saveError": "Could not update the system settings: {message}",
         "missingJob": "The PINS daemon did not return an operation ID.",
-        "refresh": "Reload current values"
+        "refresh": "Reload current values",
+        "searchPlaceholder": "Filter available options..."
       }
     },
     "alpacaDirect": {

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -436,8 +436,8 @@
       },
       "cancel": "Cancel setup",
       "localization": {
-        "title": "Set the rig regional settings",
-        "description": "Set these values before Wi-Fi so hotspot location, time and remote keyboard input match where the rig is used."
+        "title": "장비의 지역 설정 구성",
+        "description": "핫스팟 위치, 시간 및 원격 키보드 입력이 장비 사용 위치와 일치하도록 Wi-Fi보다 먼저 이 값을 설정하세요."
       }
     },
     "fileBrowser": {
@@ -688,23 +688,23 @@
         "max_slew_rate": "최대 슬루 속도 (°/s)"
       },
       "localization": {
-        "title": "System regional settings",
-        "description": "These are the current settings on the PINS device, not this app. Changes apply to every phone, tablet and browser that connects to it.",
-        "systemLocale": "Locale",
-        "wifiCountry": "Wi-Fi country",
+        "title": "시스템 지역 설정",
+        "description": "이 설정은 앱이 아닌 PINS 장치의 현재 설정입니다. 변경 사항은 이 장치에 연결되는 모든 휴대폰, 태블릿 및 브라우저에 적용됩니다.",
+        "systemLocale": "로캘",
+        "wifiCountry": "Wi-Fi 국가",
         "wifiCountryConfirmTitle": "Wi-Fi 국가 변경을 적용하시겠습니까?",
         "wifiCountryConfirmMessage": "Wi-Fi 국가를 변경하면 이 PINS 장치와의 연결이 잠시 중단될 수 있습니다. 변경 사항을 적용하시겠습니까?",
-        "timezone": "Time zone",
-        "keyboardLayout": "Keyboard layout",
-        "loading": "Reading the current system settings...",
-        "loadError": "Could not read the system settings: {message}",
-        "save": "Apply changes",
-        "saving": "Applying...",
-        "saved": "System settings updated.",
-        "saveError": "Could not update the system settings: {message}",
-        "missingJob": "The PINS daemon did not return an operation ID.",
-        "refresh": "Reload current values",
-        "searchPlaceholder": "Filter available options..."
+        "timezone": "시간대",
+        "keyboardLayout": "키보드 배열",
+        "loading": "현재 시스템 설정을 불러오는 중...",
+        "loadError": "시스템 설정을 불러올 수 없습니다: {message}",
+        "save": "변경 사항 적용",
+        "saving": "적용 중...",
+        "saved": "시스템 설정이 업데이트되었습니다.",
+        "saveError": "시스템 설정을 업데이트할 수 없습니다: {message}",
+        "missingJob": "PINS 데몬이 작업 ID를 반환하지 않았습니다.",
+        "refresh": "현재 값 다시 불러오기",
+        "searchPlaceholder": "사용 가능한 옵션 필터링..."
       }
     },
     "alpacaDirect": {

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -660,7 +660,8 @@
         "saved": "System settings updated.",
         "saveError": "Could not update the system settings: {message}",
         "missingJob": "The PINS daemon did not return an operation ID.",
-        "refresh": "Reload current values"
+        "refresh": "Reload current values",
+        "searchPlaceholder": "Filter available options..."
       }
     },
     "alpacaDirect": {

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -208,7 +208,8 @@
         "focuser": "Focuser",
         "filterWheel": "Filter wheel",
         "guider": "Guiding",
-        "done": "Done"
+        "done": "Done",
+        "localization": "Regional settings"
       },
       "driver": {
         "loading": "Loading drivers…",
@@ -392,7 +393,11 @@
         "moreDevicesHint": "Flat panel, weather and the remaining devices are configured on their own pages.",
         "noConnectionHint": "No connection to a rig yet. You can add one under Settings → Connection at any time."
       },
-      "cancel": "Cancel setup"
+      "cancel": "Cancel setup",
+      "localization": {
+        "title": "Set the rig regional settings",
+        "description": "Set these values before Wi-Fi so hotspot location, time and remote keyboard input match where the rig is used."
+      }
     },
     "fileBrowser": {
       "title": "Browse",
@@ -640,6 +645,22 @@
         "clearTitle": "Horizonbestandspad wissen",
         "confirmTitle": "Horizonbestandspad wissen",
         "confirmMessage": "Weet u zeker dat u het horizonbestandspad wilt wissen?"
+      },
+      "localization": {
+        "title": "System regional settings",
+        "description": "These are the current settings on the PINS device, not this app. Changes apply to every phone, tablet and browser that connects to it.",
+        "systemLocale": "Locale",
+        "wifiCountry": "Wi-Fi country",
+        "timezone": "Time zone",
+        "keyboardLayout": "Keyboard layout",
+        "loading": "Reading the current system settings...",
+        "loadError": "Could not read the system settings: {message}",
+        "save": "Apply changes",
+        "saving": "Applying...",
+        "saved": "System settings updated.",
+        "saveError": "Could not update the system settings: {message}",
+        "missingJob": "The PINS daemon did not return an operation ID.",
+        "refresh": "Reload current values"
       }
     },
     "alpacaDirect": {

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -651,6 +651,8 @@
         "description": "These are the current settings on the PINS device, not this app. Changes apply to every phone, tablet and browser that connects to it.",
         "systemLocale": "Locale",
         "wifiCountry": "Wi-Fi country",
+        "wifiCountryConfirmTitle": "Wijziging van Wi-Fi-land toepassen?",
+        "wifiCountryConfirmMessage": "Het wijzigen van het Wi-Fi-land kan de verbinding met dit PINS-apparaat kort onderbreken. Wijzigingen toepassen?",
         "timezone": "Time zone",
         "keyboardLayout": "Keyboard layout",
         "loading": "Reading the current system settings...",

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -395,8 +395,8 @@
       },
       "cancel": "Cancel setup",
       "localization": {
-        "title": "Set the rig regional settings",
-        "description": "Set these values before Wi-Fi so hotspot location, time and remote keyboard input match where the rig is used."
+        "title": "Regionale instellingen van de opstelling configureren",
+        "description": "Stel deze waarden vóór Wi-Fi in, zodat de hotspotlocatie, tijd en externe toetsenbordinvoer overeenkomen met de locatie waar de opstelling wordt gebruikt."
       }
     },
     "fileBrowser": {
@@ -647,23 +647,23 @@
         "confirmMessage": "Weet u zeker dat u het horizonbestandspad wilt wissen?"
       },
       "localization": {
-        "title": "System regional settings",
-        "description": "These are the current settings on the PINS device, not this app. Changes apply to every phone, tablet and browser that connects to it.",
-        "systemLocale": "Locale",
-        "wifiCountry": "Wi-Fi country",
+        "title": "Regionale systeeminstellingen",
+        "description": "Dit zijn de huidige instellingen van het PINS-apparaat, niet van deze app. Wijzigingen gelden voor elke telefoon, tablet en browser die ermee verbinding maakt.",
+        "systemLocale": "Landinstelling",
+        "wifiCountry": "Wi-Fi-land",
         "wifiCountryConfirmTitle": "Wijziging van Wi-Fi-land toepassen?",
         "wifiCountryConfirmMessage": "Het wijzigen van het Wi-Fi-land kan de verbinding met dit PINS-apparaat kort onderbreken. Wijzigingen toepassen?",
-        "timezone": "Time zone",
-        "keyboardLayout": "Keyboard layout",
-        "loading": "Reading the current system settings...",
-        "loadError": "Could not read the system settings: {message}",
-        "save": "Apply changes",
-        "saving": "Applying...",
-        "saved": "System settings updated.",
-        "saveError": "Could not update the system settings: {message}",
-        "missingJob": "The PINS daemon did not return an operation ID.",
-        "refresh": "Reload current values",
-        "searchPlaceholder": "Filter available options..."
+        "timezone": "Tijdzone",
+        "keyboardLayout": "Toetsenbordindeling",
+        "loading": "Huidige systeeminstellingen worden gelezen...",
+        "loadError": "De systeeminstellingen konden niet worden gelezen: {message}",
+        "save": "Wijzigingen toepassen",
+        "saving": "Bezig met toepassen...",
+        "saved": "Systeeminstellingen bijgewerkt.",
+        "saveError": "De systeeminstellingen konden niet worden bijgewerkt: {message}",
+        "missingJob": "De PINS-daemon heeft geen bewerkings-ID teruggegeven.",
+        "refresh": "Huidige waarden opnieuw laden",
+        "searchPlaceholder": "Beschikbare opties filteren..."
       }
     },
     "alpacaDirect": {

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -660,7 +660,8 @@
         "saved": "System settings updated.",
         "saveError": "Could not update the system settings: {message}",
         "missingJob": "The PINS daemon did not return an operation ID.",
-        "refresh": "Reload current values"
+        "refresh": "Reload current values",
+        "searchPlaceholder": "Filter available options..."
       }
     },
     "alpacaDirect": {

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -651,6 +651,8 @@
         "description": "These are the current settings on the PINS device, not this app. Changes apply to every phone, tablet and browser that connects to it.",
         "systemLocale": "Locale",
         "wifiCountry": "Wi-Fi country",
+        "wifiCountryConfirmTitle": "Zastosować zmianę kraju Wi-Fi?",
+        "wifiCountryConfirmMessage": "Zmiana kraju Wi-Fi może na krótko przerwać połączenie z tym urządzeniem PINS. Zastosować zmiany?",
         "timezone": "Time zone",
         "keyboardLayout": "Keyboard layout",
         "loading": "Reading the current system settings...",

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -395,8 +395,8 @@
       },
       "cancel": "Cancel setup",
       "localization": {
-        "title": "Set the rig regional settings",
-        "description": "Set these values before Wi-Fi so hotspot location, time and remote keyboard input match where the rig is used."
+        "title": "Skonfiguruj ustawienia regionalne zestawu",
+        "description": "Ustaw te wartości przed konfiguracją Wi-Fi, aby lokalizacja hotspotu, czas i zdalny układ klawiatury odpowiadały miejscu używania zestawu."
       }
     },
     "fileBrowser": {
@@ -647,23 +647,23 @@
         "confirmMessage": "Czy na pewno chcesz wyczyścić ścieżkę pliku horyzontu?"
       },
       "localization": {
-        "title": "System regional settings",
-        "description": "These are the current settings on the PINS device, not this app. Changes apply to every phone, tablet and browser that connects to it.",
-        "systemLocale": "Locale",
-        "wifiCountry": "Wi-Fi country",
+        "title": "Ustawienia regionalne systemu",
+        "description": "Są to bieżące ustawienia urządzenia PINS, a nie tej aplikacji. Zmiany dotyczą każdego telefonu, tabletu i przeglądarki, które łączą się z urządzeniem.",
+        "systemLocale": "Ustawienia regionalne",
+        "wifiCountry": "Kraj Wi-Fi",
         "wifiCountryConfirmTitle": "Zastosować zmianę kraju Wi-Fi?",
         "wifiCountryConfirmMessage": "Zmiana kraju Wi-Fi może na krótko przerwać połączenie z tym urządzeniem PINS. Zastosować zmiany?",
-        "timezone": "Time zone",
-        "keyboardLayout": "Keyboard layout",
-        "loading": "Reading the current system settings...",
-        "loadError": "Could not read the system settings: {message}",
-        "save": "Apply changes",
-        "saving": "Applying...",
-        "saved": "System settings updated.",
-        "saveError": "Could not update the system settings: {message}",
-        "missingJob": "The PINS daemon did not return an operation ID.",
-        "refresh": "Reload current values",
-        "searchPlaceholder": "Filter available options..."
+        "timezone": "Strefa czasowa",
+        "keyboardLayout": "Układ klawiatury",
+        "loading": "Odczytywanie bieżących ustawień systemu...",
+        "loadError": "Nie udało się odczytać ustawień systemu: {message}",
+        "save": "Zastosuj zmiany",
+        "saving": "Stosowanie zmian...",
+        "saved": "Ustawienia systemu zostały zaktualizowane.",
+        "saveError": "Nie udało się zaktualizować ustawień systemu: {message}",
+        "missingJob": "Demon PINS nie zwrócił identyfikatora operacji.",
+        "refresh": "Wczytaj ponownie bieżące wartości",
+        "searchPlaceholder": "Filtruj dostępne opcje..."
       }
     },
     "alpacaDirect": {

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -208,7 +208,8 @@
         "focuser": "Focuser",
         "filterWheel": "Filter wheel",
         "guider": "Guiding",
-        "done": "Done"
+        "done": "Done",
+        "localization": "Regional settings"
       },
       "driver": {
         "loading": "Loading drivers…",
@@ -392,7 +393,11 @@
         "moreDevicesHint": "Flat panel, weather and the remaining devices are configured on their own pages.",
         "noConnectionHint": "No connection to a rig yet. You can add one under Settings → Connection at any time."
       },
-      "cancel": "Cancel setup"
+      "cancel": "Cancel setup",
+      "localization": {
+        "title": "Set the rig regional settings",
+        "description": "Set these values before Wi-Fi so hotspot location, time and remote keyboard input match where the rig is used."
+      }
     },
     "fileBrowser": {
       "title": "Browse",
@@ -640,6 +645,22 @@
         "clearTitle": "Wyczyść ścieżkę pliku horyzontu",
         "confirmTitle": "Wyczyść ścieżkę pliku horyzontu",
         "confirmMessage": "Czy na pewno chcesz wyczyścić ścieżkę pliku horyzontu?"
+      },
+      "localization": {
+        "title": "System regional settings",
+        "description": "These are the current settings on the PINS device, not this app. Changes apply to every phone, tablet and browser that connects to it.",
+        "systemLocale": "Locale",
+        "wifiCountry": "Wi-Fi country",
+        "timezone": "Time zone",
+        "keyboardLayout": "Keyboard layout",
+        "loading": "Reading the current system settings...",
+        "loadError": "Could not read the system settings: {message}",
+        "save": "Apply changes",
+        "saving": "Applying...",
+        "saved": "System settings updated.",
+        "saveError": "Could not update the system settings: {message}",
+        "missingJob": "The PINS daemon did not return an operation ID.",
+        "refresh": "Reload current values"
       }
     },
     "alpacaDirect": {

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -660,7 +660,8 @@
         "saved": "System settings updated.",
         "saveError": "Could not update the system settings: {message}",
         "missingJob": "The PINS daemon did not return an operation ID.",
-        "refresh": "Reload current values"
+        "refresh": "Reload current values",
+        "searchPlaceholder": "Filter available options..."
       }
     },
     "alpacaDirect": {

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -208,7 +208,8 @@
         "focuser": "Focuser",
         "filterWheel": "Filter wheel",
         "guider": "Guiding",
-        "done": "Done"
+        "done": "Done",
+        "localization": "Regional settings"
       },
       "driver": {
         "loading": "Loading drivers…",
@@ -392,7 +393,11 @@
         "moreDevicesHint": "Flat panel, weather and the remaining devices are configured on their own pages.",
         "noConnectionHint": "No connection to a rig yet. You can add one under Settings → Connection at any time."
       },
-      "cancel": "Cancel setup"
+      "cancel": "Cancel setup",
+      "localization": {
+        "title": "Set the rig regional settings",
+        "description": "Set these values before Wi-Fi so hotspot location, time and remote keyboard input match where the rig is used."
+      }
     },
     "fileBrowser": {
       "title": "Browse",
@@ -640,6 +645,22 @@
         "clearTitle": "Limpar caminho do ficheiro de horizonte",
         "confirmTitle": "Limpar caminho do ficheiro de horizonte",
         "confirmMessage": "Tem a certeza que deseja limpar o caminho do ficheiro de horizonte?"
+      },
+      "localization": {
+        "title": "System regional settings",
+        "description": "These are the current settings on the PINS device, not this app. Changes apply to every phone, tablet and browser that connects to it.",
+        "systemLocale": "Locale",
+        "wifiCountry": "Wi-Fi country",
+        "timezone": "Time zone",
+        "keyboardLayout": "Keyboard layout",
+        "loading": "Reading the current system settings...",
+        "loadError": "Could not read the system settings: {message}",
+        "save": "Apply changes",
+        "saving": "Applying...",
+        "saved": "System settings updated.",
+        "saveError": "Could not update the system settings: {message}",
+        "missingJob": "The PINS daemon did not return an operation ID.",
+        "refresh": "Reload current values"
       }
     },
     "alpacaDirect": {

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -651,6 +651,8 @@
         "description": "These are the current settings on the PINS device, not this app. Changes apply to every phone, tablet and browser that connects to it.",
         "systemLocale": "Locale",
         "wifiCountry": "Wi-Fi country",
+        "wifiCountryConfirmTitle": "Aplicar a alteração do país Wi-Fi?",
+        "wifiCountryConfirmMessage": "Alterar o país Wi-Fi pode interromper brevemente a ligação a este dispositivo PINS. Aplicar as alterações?",
         "timezone": "Time zone",
         "keyboardLayout": "Keyboard layout",
         "loading": "Reading the current system settings...",

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -395,8 +395,8 @@
       },
       "cancel": "Cancel setup",
       "localization": {
-        "title": "Set the rig regional settings",
-        "description": "Set these values before Wi-Fi so hotspot location, time and remote keyboard input match where the rig is used."
+        "title": "Configurar as definições regionais do equipamento",
+        "description": "Configure estes valores antes do Wi-Fi para que a localização do ponto de acesso, a hora e a entrada do teclado remoto correspondam ao local onde o equipamento é utilizado."
       }
     },
     "fileBrowser": {
@@ -647,23 +647,23 @@
         "confirmMessage": "Tem a certeza que deseja limpar o caminho do ficheiro de horizonte?"
       },
       "localization": {
-        "title": "System regional settings",
-        "description": "These are the current settings on the PINS device, not this app. Changes apply to every phone, tablet and browser that connects to it.",
-        "systemLocale": "Locale",
-        "wifiCountry": "Wi-Fi country",
+        "title": "Definições regionais do sistema",
+        "description": "Estas são as definições atuais do dispositivo PINS, não desta aplicação. As alterações aplicam-se a todos os telemóveis, tablets e navegadores que se liguem ao dispositivo.",
+        "systemLocale": "Configuração regional",
+        "wifiCountry": "País do Wi-Fi",
         "wifiCountryConfirmTitle": "Aplicar a alteração do país Wi-Fi?",
         "wifiCountryConfirmMessage": "Alterar o país Wi-Fi pode interromper brevemente a ligação a este dispositivo PINS. Aplicar as alterações?",
-        "timezone": "Time zone",
-        "keyboardLayout": "Keyboard layout",
-        "loading": "Reading the current system settings...",
-        "loadError": "Could not read the system settings: {message}",
-        "save": "Apply changes",
-        "saving": "Applying...",
-        "saved": "System settings updated.",
-        "saveError": "Could not update the system settings: {message}",
-        "missingJob": "The PINS daemon did not return an operation ID.",
-        "refresh": "Reload current values",
-        "searchPlaceholder": "Filter available options..."
+        "timezone": "Fuso horário",
+        "keyboardLayout": "Disposição do teclado",
+        "loading": "A ler as definições atuais do sistema...",
+        "loadError": "Não foi possível ler as definições do sistema: {message}",
+        "save": "Aplicar alterações",
+        "saving": "A aplicar...",
+        "saved": "Definições do sistema atualizadas.",
+        "saveError": "Não foi possível atualizar as definições do sistema: {message}",
+        "missingJob": "O serviço PINS não devolveu um ID de operação.",
+        "refresh": "Recarregar os valores atuais",
+        "searchPlaceholder": "Filtrar as opções disponíveis..."
       }
     },
     "alpacaDirect": {

--- a/src/locales/uk.json
+++ b/src/locales/uk.json
@@ -395,8 +395,8 @@
       },
       "cancel": "Cancel setup",
       "localization": {
-        "title": "Set the rig regional settings",
-        "description": "Set these values before Wi-Fi so hotspot location, time and remote keyboard input match where the rig is used."
+        "title": "Налаштувати регіональні параметри обладнання",
+        "description": "Установіть ці значення перед налаштуванням Wi-Fi, щоб розташування точки доступу, час і введення з віддаленої клавіатури відповідали місцю використання обладнання."
       }
     },
     "settings": {
@@ -627,23 +627,23 @@
         "max_slew_rate": "Макс. швидкість наведення (°/с)"
       },
       "localization": {
-        "title": "System regional settings",
-        "description": "These are the current settings on the PINS device, not this app. Changes apply to every phone, tablet and browser that connects to it.",
-        "systemLocale": "Locale",
-        "wifiCountry": "Wi-Fi country",
+        "title": "Регіональні параметри системи",
+        "description": "Це поточні параметри пристрою PINS, а не цієї програми. Зміни застосовуються до всіх телефонів, планшетів і браузерів, які підключаються до нього.",
+        "systemLocale": "Локаль",
+        "wifiCountry": "Країна Wi-Fi",
         "wifiCountryConfirmTitle": "Застосувати зміну країни Wi-Fi?",
         "wifiCountryConfirmMessage": "Зміна країни Wi-Fi може ненадовго перервати з’єднання з цим пристроєм PINS. Застосувати зміни?",
-        "timezone": "Time zone",
-        "keyboardLayout": "Keyboard layout",
-        "loading": "Reading the current system settings...",
-        "loadError": "Could not read the system settings: {message}",
-        "save": "Apply changes",
-        "saving": "Applying...",
-        "saved": "System settings updated.",
-        "saveError": "Could not update the system settings: {message}",
-        "missingJob": "The PINS daemon did not return an operation ID.",
-        "refresh": "Reload current values",
-        "searchPlaceholder": "Filter available options..."
+        "timezone": "Часовий пояс",
+        "keyboardLayout": "Розкладка клавіатури",
+        "loading": "Зчитування поточних параметрів системи...",
+        "loadError": "Не вдалося зчитати параметри системи: {message}",
+        "save": "Застосувати зміни",
+        "saving": "Застосування...",
+        "saved": "Параметри системи оновлено.",
+        "saveError": "Не вдалося оновити параметри системи: {message}",
+        "missingJob": "Демон PINS не повернув ідентифікатор операції.",
+        "refresh": "Перезавантажити поточні значення",
+        "searchPlaceholder": "Фільтрувати доступні параметри..."
       }
     },
     "alpacaDirect": {

--- a/src/locales/uk.json
+++ b/src/locales/uk.json
@@ -631,6 +631,8 @@
         "description": "These are the current settings on the PINS device, not this app. Changes apply to every phone, tablet and browser that connects to it.",
         "systemLocale": "Locale",
         "wifiCountry": "Wi-Fi country",
+        "wifiCountryConfirmTitle": "Застосувати зміну країни Wi-Fi?",
+        "wifiCountryConfirmMessage": "Зміна країни Wi-Fi може ненадовго перервати з’єднання з цим пристроєм PINS. Застосувати зміни?",
         "timezone": "Time zone",
         "keyboardLayout": "Keyboard layout",
         "loading": "Reading the current system settings...",

--- a/src/locales/uk.json
+++ b/src/locales/uk.json
@@ -640,7 +640,8 @@
         "saved": "System settings updated.",
         "saveError": "Could not update the system settings: {message}",
         "missingJob": "The PINS daemon did not return an operation ID.",
-        "refresh": "Reload current values"
+        "refresh": "Reload current values",
+        "searchPlaceholder": "Filter available options..."
       }
     },
     "alpacaDirect": {

--- a/src/locales/uk.json
+++ b/src/locales/uk.json
@@ -208,7 +208,8 @@
         "focuser": "Focuser",
         "filterWheel": "Filter wheel",
         "guider": "Guiding",
-        "done": "Done"
+        "done": "Done",
+        "localization": "Regional settings"
       },
       "driver": {
         "loading": "Loading drivers…",
@@ -392,7 +393,11 @@
         "moreDevicesHint": "Flat panel, weather and the remaining devices are configured on their own pages.",
         "noConnectionHint": "No connection to a rig yet. You can add one under Settings → Connection at any time."
       },
-      "cancel": "Cancel setup"
+      "cancel": "Cancel setup",
+      "localization": {
+        "title": "Set the rig regional settings",
+        "description": "Set these values before Wi-Fi so hotspot location, time and remote keyboard input match where the rig is used."
+      }
     },
     "settings": {
       "title": "Налаштування",
@@ -620,6 +625,22 @@
       "mount": {
         "titel": "Налаштування монтування",
         "max_slew_rate": "Макс. швидкість наведення (°/с)"
+      },
+      "localization": {
+        "title": "System regional settings",
+        "description": "These are the current settings on the PINS device, not this app. Changes apply to every phone, tablet and browser that connects to it.",
+        "systemLocale": "Locale",
+        "wifiCountry": "Wi-Fi country",
+        "timezone": "Time zone",
+        "keyboardLayout": "Keyboard layout",
+        "loading": "Reading the current system settings...",
+        "loadError": "Could not read the system settings: {message}",
+        "save": "Apply changes",
+        "saving": "Applying...",
+        "saved": "System settings updated.",
+        "saveError": "Could not update the system settings: {message}",
+        "missingJob": "The PINS daemon did not return an operation ID.",
+        "refresh": "Reload current values"
       }
     },
     "alpacaDirect": {

--- a/src/plugins/pins/composables/__tests__/pinsJobPolling.test.js
+++ b/src/plugins/pins/composables/__tests__/pinsJobPolling.test.js
@@ -1,0 +1,42 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { installBrowserGlobals, freshPinia } from '../../../../test-helpers/browserEnv.js';
+
+installBrowserGlobals();
+freshPinia();
+
+const { default: apiPinsService } = await import('@/services/apiPinsService');
+const { pollJobUntilFinished } = await import('../pinsJobPolling.js');
+
+test('job polling can tolerate configured transient request failures', async (t) => {
+  let attempts = 0;
+  t.mock.method(apiPinsService, 'getPinsDaemonJob', async () => {
+    attempts += 1;
+    if (attempts <= 2) throw new Error('temporary disconnect');
+    return { status: 'completed' };
+  });
+
+  const result = await pollJobUntilFinished('localization-1', {
+    intervalMs: 0,
+    maxAttempts: 3,
+    maxConsecutiveErrors: 2,
+  });
+
+  assert.equal(result.success, true);
+  assert.equal(attempts, 3);
+});
+
+test('job polling still rejects after the configured error tolerance is exceeded', async (t) => {
+  t.mock.method(apiPinsService, 'getPinsDaemonJob', async () => {
+    throw new Error('connection unavailable');
+  });
+
+  await assert.rejects(
+    pollJobUntilFinished('localization-2', {
+      intervalMs: 0,
+      maxAttempts: 3,
+      maxConsecutiveErrors: 1,
+    }),
+    /connection unavailable/
+  );
+});

--- a/src/plugins/pins/composables/pinsJobPolling.js
+++ b/src/plugins/pins/composables/pinsJobPolling.js
@@ -44,18 +44,29 @@ export function isJobFailed(result) {
  * Polls `/jobs/{id}` until the job succeeded, failed, or the attempt budget ran out.
  *
  * @param {string|number} id - job id returned by the daemon
- * @param {{ intervalMs?: number, maxAttempts?: number, onStatusChange?: (status: string) => void }} [options]
+ * @param {{ intervalMs?: number, maxAttempts?: number, maxConsecutiveErrors?: number, onStatusChange?: (status: string) => void }} [options]
  *   onStatusChange fires only when the status string actually changes, so callers
- *   can log transitions without spamming one line per poll.
+ *   can log transitions without spamming one line per poll. maxConsecutiveErrors
+ *   lets operations that may briefly interrupt the network tolerate failed polls.
  * @returns {Promise<{ success: boolean, result: object }>}
  */
 export async function pollJobUntilFinished(
   id,
-  { intervalMs = 2000, maxAttempts = 120, onStatusChange } = {}
+  { intervalMs = 2000, maxAttempts = 120, maxConsecutiveErrors = 0, onStatusChange } = {}
 ) {
   let lastStatus = null;
+  let consecutiveErrors = 0;
   for (let attempt = 0; attempt < maxAttempts; attempt++) {
-    const result = (await apiPinsService.getPinsDaemonJob(id)) || {};
+    let result;
+    try {
+      result = (await apiPinsService.getPinsDaemonJob(id)) || {};
+      consecutiveErrors = 0;
+    } catch (error) {
+      consecutiveErrors += 1;
+      if (consecutiveErrors > maxConsecutiveErrors) throw error;
+      await new Promise((resolve) => setTimeout(resolve, intervalMs));
+      continue;
+    }
     const currentStatus = String(result.status || '').toLowerCase();
 
     if (currentStatus && currentStatus !== lastStatus) {

--- a/src/plugins/plugins.md
+++ b/src/plugins/plugins.md
@@ -25,15 +25,22 @@ plugins/
   "description": "Plugin description",
   "version": "1.0.0",
   "author": "Author Name",
-  "enabled": false,
+  "defaultEnabled": false,
+  "enabled": true,
   "isPins": false
 }
 ```
+
+`enabled` controls whether the bundled plugin is exposed to the plugin store at
+all. `defaultEnabled` is the initial user-facing state; after first load, the
+persisted user choice takes precedence. `isPins` marks plugins whose feature is
+specific to the PINS runtime.
 
 ## Plugin Entry Point (index.js)
 
 ```javascript
 // Import your icon directly in your plugin
+import { markRaw } from 'vue';
 import { YourIconComponent } from '@heroicons/vue/24/outline';
 // Or create/import a custom icon component
 // import MyCustomIcon from './components/MyCustomIcon.vue';
@@ -46,22 +53,21 @@ export default {
   install(app, options) {
     const pluginStore = usePluginStore();
     const router = options.router;
+    const currentPlugin = pluginStore.plugins.find((plugin) => plugin.id === metadata.id);
+    if (!currentPlugin) return;
 
-    // Register routes
+    // pluginPath is assigned by pluginStore so enabled plugins receive stable,
+    // collision-free /pluginN routes for this registry load.
     router.addRoute({
-      path: '/my-plugin',
+      path: currentPlugin.pluginPath,
       component: MyPluginView,
       meta: { requiresSetup: true },
     });
 
-    // Register plugin metadata
-    pluginStore.registerPlugin(metadata);
-
-    // Add navigation item only if plugin is enabled
-    if (metadata.enabled) {
+    if (currentPlugin.enabled) {
       pluginStore.addPluginNavigationItem(metadata.id, {
-        path: '/my-plugin',
-        icon: YourIconComponent, // Each plugin provides its own icon
+        path: currentPlugin.pluginPath,
+        icon: markRaw(YourIconComponent),
         title: metadata.name,
       });
     }
@@ -84,7 +90,7 @@ This interactive command will:
 1. Ask you for the plugin name, description, and author
 2. Generate the necessary folder structure based on your plugin name
 3. Create a properly formatted `plugin.json` file with your metadata
-4. Generate a default `index.js` file with proper routing and registration
+4. Generate a default `index.js` file using the plugin store's assigned route
 5. Create a basic view component showing your plugin name and description
 
 After running the command, your plugin will be ready to customize and extend!
@@ -94,8 +100,8 @@ After running the command, your plugin will be ready to customize and extend!
 Alternatively, you can create a plugin manually:
 
 1. Create a new folder in the plugins directory with your plugin name (e.g., `my-plugin`)
-2. Create a `plugin.json` file with your plugin metadata
-3. Create an `index.js` file as the entry point
+2. Create a `plugin.json` file with the metadata fields described above
+3. Create an `index.js` entry point that uses the store-assigned `pluginPath`
 4. Add your components, views, and stores
 5. The plugin will be automatically discovered and listed in the settings
 
@@ -130,8 +136,8 @@ import MyCustomIcon from './components/MyCustomIcon.vue';
 
 // Then in your plugin install function:
 pluginStore.addPluginNavigationItem(metadata.id, {
-  path: '/my-plugin',
-  icon: SparklesIcon, // or MyCustomIcon
+  path: currentPlugin.pluginPath,
+  icon: markRaw(SparklesIcon), // or markRaw(MyCustomIcon)
   title: metadata.name,
 });
 ```

--- a/src/services/__tests__/apiPinsLocalization.test.js
+++ b/src/services/__tests__/apiPinsLocalization.test.js
@@ -1,0 +1,55 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { installBrowserGlobals, freshPinia } from '../../test-helpers/browserEnv.js';
+
+installBrowserGlobals();
+
+const { default: axios } = await import('axios');
+const { default: apiPinsService } = await import('@/services/apiPinsService');
+const { useSettingsStore } = await import('@/store/settingsStore');
+
+freshPinia();
+const settingsStore = useSettingsStore();
+settingsStore.connection.ip = '10.0.0.25';
+settingsStore.connection.port = 5000;
+
+test('localization reads current system values and available choices from pinsdaemon', async (t) => {
+  const calls = [];
+  t.mock.method(axios, 'get', async (url, config) => {
+    calls.push({ url, config });
+    return { data: {} };
+  });
+
+  await apiPinsService.getPinsSystemLocalization();
+  await apiPinsService.getPinsSystemLocalizationOptions();
+
+  assert.deepEqual(
+    calls.map((call) => call.url),
+    [
+      'http://10.0.0.25:8000/system/localization',
+      'http://10.0.0.25:8000/system/localization/options',
+    ]
+  );
+  assert.match(calls[0].config.headers.Authorization, /^Bearer /);
+});
+
+test('localization updates use the authenticated pinsdaemon endpoint', async (t) => {
+  let call;
+  t.mock.method(axios, 'put', async (url, data, config) => {
+    call = { url, data, config };
+    return { data: { jobId: 'localization-1', status: 'queued' } };
+  });
+  const payload = {
+    locale: 'en_GB.UTF-8',
+    wifiCountry: 'DE',
+    timezone: 'Europe/Berlin',
+    keyboardLayout: 'de',
+  };
+
+  const result = await apiPinsService.updatePinsSystemLocalization(payload);
+
+  assert.equal(call.url, 'http://10.0.0.25:8000/system/localization');
+  assert.deepEqual(call.data, payload);
+  assert.match(call.config.headers.Authorization, /^Bearer /);
+  assert.equal(result.jobId, 'localization-1');
+});

--- a/src/services/apiPinsService.js
+++ b/src/services/apiPinsService.js
@@ -789,6 +789,30 @@ export default {
     });
   },
 
+  getPinsSystemLocalization() {
+    const { PINSDAEMON_URL } = getUrls();
+    return this._pinsDaemonGetRequest('/system/localization', {
+      baseUrl: PINSDAEMON_URL,
+      timeout: 10000,
+    });
+  },
+
+  getPinsSystemLocalizationOptions() {
+    const { PINSDAEMON_URL } = getUrls();
+    return this._pinsDaemonGetRequest('/system/localization/options', {
+      baseUrl: PINSDAEMON_URL,
+      timeout: 15000,
+    });
+  },
+
+  updatePinsSystemLocalization(payload) {
+    const { PINSDAEMON_URL } = getUrls();
+    return this._pinsDaemonPutRequest('/system/localization', payload, {
+      baseUrl: PINSDAEMON_URL,
+      timeout: 15000,
+    });
+  },
+
   getPinsHealthAt(host, { timeout = 2200, signal } = {}) {
     const normalizedHost = String(host || '').trim();
     if (!normalizedHost) {


### PR DESCRIPTION
## What changed

- add a PINS-only System Localization step before Wi-Fi in the setup assistant
- expose the same live host settings under General Settings
- load and update Locale, Wi-Fi Country, Time Zone, and Keyboard Layout through pinsdaemon
- show searchable host-supported option lists on web, Android, and iOS
- search keyboard layouts by both XKB code and human-readable language name, so `en` finds `English (US) (us)` and `English (UK) (gb)`
- add API contract and PINS-boundary tests, locale strings, changelog notes, and aligned project documentation

## Why

PINS hotspot sessions could inherit an incorrect locale, Wi-Fi regulatory country, timezone, or keyboard layout. That could produce wrong Atlas observer/time behavior and mismatched VNC/SSH keyboard input. The settings must come from the rig itself rather than a per-browser or per-mobile-device copy.

The keyboard option source uses XKB codes such as `us` and `gb`; searching only those codes made a query such as `en` appear to have no results. The UI now consumes the host-provided XKB names and searches both code and name.

## Backend dependency

Requires the matching pinsdaemon localization API currently on `Touch-N-Stars/pinsdaemon:main` (through commit `09368ec`).

## Validation

- 162 Touch-N-Stars tests passed
- ESLint passed
- Vue typecheck passed
- i18n validation passed
- production Vite build passed
- deployed and tested against a Raspberry Pi PINS instance
- live Pi returned 327 locales, 249 Wi-Fi countries, 485 timezones, and 99 named keyboard layouts
- authenticated four-field update job passed
- reversible timezone update and restore passed
- served web bundle loaded current system values from pinsdaemon
